### PR TITLE
Improve roster caching and resize responsiveness

### DIFF
--- a/app.py
+++ b/app.py
@@ -453,7 +453,7 @@ def _load_month_roster_core(y: int, m: int):
 
 
 # IMPORTANT: overwrite any previously memoized wrapper
-_load_month_roster_fast = _load_month_roster_core
+_load_month_roster_fast = _memoize(seconds=300)(_load_month_roster_core)
 
 
 # -------------------- Helpers --------------------

--- a/templates/base.html
+++ b/templates/base.html
@@ -67,8 +67,30 @@
       if (scale < 0.6) scale = 0.6; // keep controls usable
       document.documentElement.style.setProperty('--ui-scale', scale.toFixed(3));
     }
-    window.addEventListener('load', fitRoster);
-    window.addEventListener('resize', fitRoster);
+
+    // Schedule layout work so rapid resize events don't thrash the layout engine
+    let fitScheduled = false;
+    function scheduleFit(){
+      if(fitScheduled) return;
+      fitScheduled = true;
+      window.requestAnimationFrame(() => {
+        fitScheduled = false;
+        fitRoster();
+      });
+    }
+
+    window.addEventListener('load', () => {
+      fitRoster();
+      window.addEventListener('resize', scheduleFit, { passive: true });
+      if (window.ResizeObserver){
+        try {
+          const ro = new ResizeObserver(() => scheduleFit());
+          ro.observe(document.body);
+        } catch (err) {
+          console.warn('ResizeObserver unavailable', err);
+        }
+      }
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- memoize the month roster loader so repeat visits reuse cached query results
- throttle the roster auto-fit script to avoid excessive recalculation and handle layout changes gracefully
- document the implemented changes and further performance/UX opportunities

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68de9be828108324bbfa54bea0b78b00