### PR TITLE
Apply RAG styling to UE and medical expiries

### DIFF
--- a/app.py
+++ b/app.py
@@ -2045,6 +2045,27 @@ def roster_month(ym):
     month_title = datetime(year, month, 1).strftime("%B %Y")
     today = date.today()
 
+    def _expiry_class(expiry: date | None, ut_flag: bool = False) -> str:
+        if ut_flag:
+            return "exp-amber"
+        if not expiry:
+            return ""
+        days_to_expiry = (expiry - today).days
+        if days_to_expiry < 0:
+            return "exp-red"
+        if days_to_expiry <= 90:
+            return "exp-amber"
+        return "exp-green"
+
+    expiry_classes = {}
+    for person in staff:
+        expiry_classes[person.id] = {
+            "medical": _expiry_class(person.medical_expiry),
+            "tower": _expiry_class(person.tower_ue_expiry, person.tower_ut),
+            "radar": _expiry_class(person.radar_ue_expiry, person.radar_ut),
+            "met": _expiry_class(person.met_ue_expiry, person.met_ut),
+        }
+
     # Build row-separator helpers for the template: break between watches
     watch_break_after_ids = []
     prev_watch = None
@@ -2070,6 +2091,7 @@ def roster_month(ym):
         req=req,                     # <<< ensure 'req' exists for template
         requirement=req,             # <<< keep this if any blocks expect 'requirement'
         rag=rag,
+        expiry_classes=expiry_classes,
         fatigue=fatigue,
         watch_break_after_ids=watch_break_after_ids,
         prev_ym=prev_ym, next_ym=next_ym,

--- a/static/styles.css
+++ b/static/styles.css
@@ -268,8 +268,10 @@ tfoot td{background:var(--card); font-weight:bold; color:var(--text)}
 /* ==============================
    Expiry warnings
    ============================== */
-.exp-orange { background:#ff9800; color:#000; font-weight:700; }
+.exp-green { background:#2e7d32; color:#fff; font-weight:700; }
+.exp-amber { background:#f9a825; color:#000; font-weight:700; }
 .exp-red { background:#e53935; color:#fff; font-weight:700; }
+.exp-orange { background:#ff9800; color:#000; font-weight:700; }
 
 /* ==============================
    Metrics heat rules

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -115,17 +115,17 @@
       <tr class="{% if s.id in watch_break_after_ids %}watch-break{% endif %}">
         <td class="left col-name">{{ s.name }}</td>
         <td class="left col-staff">{{ s.staff_no }}</td>
-        <td class="left small col-date">
+        <td class="left small col-date {{ expiry_classes[s.id]['medical'] }}">
           {% if s.medical_expiry %}{{ s.medical_expiry.strftime('%d/%m/%y') }}{% else %}-{% endif %}
         </td>
-        <td class="left small col-date {% if s.tower_ut %}exp-orange{% endif %}">
+        <td class="left small col-date {{ expiry_classes[s.id]['tower'] }}">
           {% if s.tower_ut %}U/T{% elif s.tower_ue_expiry %}{{ s.tower_ue_expiry.strftime('%d/%m/%y') }}{% else %}-{% endif %}
         </td>
-        <td class="left small col-date {% if s.radar_ut %}exp-orange{% endif %}">
+        <td class="left small col-date {{ expiry_classes[s.id]['radar'] }}">
           {% if s.radar_ut %}U/T{% elif s.radar_ue_expiry %}{{ s.radar_ue_expiry.strftime('%d/%m/%y') }}{% else %}-{% endif %}
         </td>
-        <td class="left small col-date {% if s.met_ut %}exp-orange{% endif %}">
-        {% if s.met_ut %}U/T{% elif s.met_ue_expiry %}{{ s.met_ue_expiry.strftime('%d/%m/%y') }}{% else %}-{% endif %}
+        <td class="left small col-date {{ expiry_classes[s.id]['met'] }}">
+          {% if s.met_ut %}U/T{% elif s.met_ue_expiry %}{{ s.met_ue_expiry.strftime('%d/%m/%y') }}{% else %}-{% endif %}
         </td>
         <td class="left small col-watch">
           {% if s.watch %}{{ s.watch.name.replace('Watch ', '') }}{% else %}-{% endif %}


### PR DESCRIPTION
## Summary
- derive expiry status classes for each staff member in the roster view so medical and UE dates share a consistent RAG scheme
- update the roster template to apply the calculated classes and show amber for trainees
- add CSS helpers for green and amber backgrounds so expiries render with traditional RAG colours

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68deb2f27d1c8324a100cd6dfcbb981d