### PR TITLE
Restore emoji navigation header

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -249,103 +249,79 @@ textarea{min-height:140px; resize:vertical;}
 /* ==============================
    Header & Navigation
    ============================== */
-.site-header{
+.site-header {
+  background:rgba(12,20,35,.7);
+  border-bottom:1px solid rgba(108,129,168,.25);
+  padding:.85rem clamp(1.2rem, 3vw, 2.6rem);
   position:sticky;
   top:0;
   z-index:1000;
-  background:rgba(10,17,30,.72);
-  border-bottom:1px solid rgba(108,129,168,.25);
-  backdrop-filter:blur(20px);
-  padding:.85rem 0;
-  box-shadow:0 18px 40px -32px rgba(7,17,34,.85);
+  box-shadow:0 14px 42px -32px rgba(7,17,34,.9);
+  backdrop-filter:blur(18px);
 }
 
-.nav-container{
+.nav-container {
   display:flex;
   align-items:center;
   justify-content:space-between;
   gap:1.5rem;
+  max-width:1600px;
+  margin:0 auto;
 }
 
-.brand{
-  display:flex;
-  flex-direction:column;
-  gap:.2rem;
-  text-decoration:none;
-  color:#fff;
-}
+.brand{display:flex; flex-direction:column; gap:.1rem;}
 
-.brand-mark{
-  font-size:clamp(1.3rem, 1.1rem + .6vw, 1.8rem);
+.logo {
+  font-size: clamp(1.25rem, 1.1rem + .5vw, 1.7rem);
   font-weight:700;
-  letter-spacing:.1em;
+  margin:0;
+  letter-spacing:.08em;
   text-transform:uppercase;
   color:transparent;
-  background:linear-gradient(115deg, #fff 0%, rgba(194,214,255,.92) 45%, rgba(114,162,255,.88) 100%);
+  background:linear-gradient(120deg, #fff 0%, rgba(178,205,255,.9) 50%, rgba(112,159,255,.85) 100%);
   -webkit-background-clip:text;
   background-clip:text;
-  text-shadow:0 12px 32px rgba(24,44,96,.45);
+  text-shadow:0 10px 30px rgba(29,57,120,.45);
 }
 
-.brand-sub{
+.logo-sub{
   margin:0;
-  font-size:.78rem;
+  font-size:.82rem;
   letter-spacing:.36em;
   text-transform:uppercase;
-  color:rgba(170,188,224,.72);
+  color:rgba(170,188,224,.7);
   font-weight:600;
 }
 
-.nav-toggle{
-  display:none;
-  align-items:center;
-  gap:.35rem;
-  padding:.45rem .85rem;
-  border-radius:var(--radius-sm);
-  background:rgba(18,28,46,.9);
-  border:1px solid rgba(124,152,210,.42);
-  color:#fff;
-  box-shadow:0 16px 28px -24px rgba(32,60,124,.7);
-}
-
-.nav-toggle:hover{
-  background:rgba(36,54,94,.95);
-}
-
-.main-nav{display:flex; align-items:center;}
-
-.nav-list{
+.main-nav {
   display:flex;
   gap:.65rem;
+  flex-wrap:wrap;
   align-items:center;
-  margin:0;
-  padding:0;
-  list-style:none;
+  justify-content:flex-end;
 }
 
-.nav-link{
+.nav-link {
   position:relative;
   display:inline-flex;
   align-items:center;
   gap:.45rem;
-  padding:.55rem 1.1rem;
+  padding:.5rem 1.05rem;
   border-radius:999px;
-  background:rgba(21,30,47,.82);
+  background:rgba(21,30,47,.8);
   color:var(--text);
   font-weight:600;
   border:1px solid transparent;
-  box-shadow:0 18px 32px -28px rgba(51,102,204,.82);
+  box-shadow:0 16px 30px -28px rgba(51,102,204,.85);
   transition:background .18s ease, color .18s ease, transform .18s ease, border-color .18s ease, box-shadow .18s ease;
 }
-
-.nav-link span{letter-spacing:.02em;}
 
 .nav-link::after{
   content:"";
   position:absolute;
   inset:0;
   border-radius:inherit;
-  border:1px solid rgba(117,151,212,.18);
+  border:1px solid rgba(117,151,212,.15);
   pointer-events:none;
   transition:opacity .2s ease;
   opacity:.7;
@@ -357,42 +333,28 @@ textarea{min-height:140px; resize:vertical;}
   color:#fff;
   transform:translateY(-1px);
   border-color:rgba(125,165,238,.45);
-  box-shadow:0 24px 36px -26px rgba(70,128,255,.74);
+  box-shadow:0 22px 34px -26px rgba(70,128,255,.75);
 }
 
 .nav-link.active{
-  background:linear-gradient(135deg, rgba(61,125,255,.95), rgba(102,155,255,.78));
-  border-color:rgba(116,162,255,.95);
+  background:linear-gradient(135deg, rgba(61,125,255,.95), rgba(102,155,255,.75));
+  border-color:rgba(116,162,255,.9);
   color:#fff;
-  box-shadow:0 30px 40px -28px rgba(61,125,255,.72);
+  box-shadow:0 28px 36px -26px rgba(61,125,255,.72);
 }
 
 .nav-link.active::after{opacity:0;}
 
-.nav-link:focus-visible{outline:2px solid rgba(111,155,255,.85); outline-offset:3px;}
-
-@media (max-width: 991.98px){
-  .nav-toggle{display:inline-flex;}
-  .main-nav{
-    position:absolute;
-    left:1.25rem;
-    right:1.25rem;
-    top:100%;
-    margin-top:.75rem;
-    background:rgba(12,20,35,.92);
-    border:1px solid rgba(108,129,168,.3);
-    border-radius:var(--radius-lg);
-    box-shadow:0 28px 48px -32px rgba(5,12,26,.85);
-    display:none;
-    padding:.85rem;
-  }
-  .main-nav.is-open{display:block;}
-  .nav-list{flex-direction:column; align-items:stretch;}
-  .nav-link{justify-content:flex-start; width:100%;}
+.nav-link:focus-visible{
+  outline:2px solid rgba(111,155,255,.8);
+  outline-offset:3px;
 }
 
-@media (min-width: 992px){
-  .main-nav{display:flex !important;}
+@media (max-width: 900px){
+  .nav-container{flex-direction:column; align-items:flex-start;}
+  .brand{align-items:flex-start;}
+  .main-nav{width:100%; justify-content:flex-start;}
+  .nav-link{padding:.45rem .9rem;}
 }
 
 /* ==============================

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,72 +25,30 @@
 <body class="app-body">
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
-    <div class="nav-container container-xl">
-      <a class="brand" href="{{ url_for('index') if current_user.is_authenticated else url_for('login') }}">
-        <span class="brand-mark">ATC Roster Tool</span>
-        <span class="brand-sub">Precision scheduling for elite controllers</span>
-      </a>
-      <button class="nav-toggle btn btn-outline-light d-lg-none" type="button" data-nav-toggle aria-expanded="false" aria-controls="primary-nav">
-        <span class="visually-hidden">Toggle navigation</span>
-        <i class="fa-solid fa-bars"></i>
-      </button>
-      <nav class="main-nav" id="primary-nav" aria-label="Primary">
-        <ul class="nav-list">
-          {% if current_user.is_authenticated %}
-            <li class="nav-item">
-              <a href="{{ url_for('index') }}" class="nav-link {% if request.endpoint == 'roster_month' %}active{% endif %}">
-                <i class="fa-solid fa-calendar-days"></i><span>Roster</span>
-              </a>
-            </li>
-            <li class="nav-item">
-              <a href="{{ url_for('requests_page') }}" class="nav-link {% if request.endpoint == 'requests_page' %}active{% endif %}">
-                <i class="fa-solid fa-clipboard-list"></i><span>Requests</span>
-              </a>
-            </li>
-            <li class="nav-item">
-              <a href="{{ url_for('staff_profile', sid=current_user.id) }}" class="nav-link {% if request.endpoint == 'staff_profile' %}active{% endif %}">
-                <i class="fa-solid fa-user"></i><span>Profile</span>
-              </a>
-            </li>
+    <div class="nav-container">
+      <div class="brand">
+        <h1 class="logo">ATC Roster Tool</h1>
+        <p class="logo-sub">Precision scheduling for elite controllers</p>
+      </div>
+      <nav class="main-nav" aria-label="Primary">
+        {% if current_user.is_authenticated %}
+          <a href="{{ url_for('index') }}" class="nav-link {% if request.endpoint == 'roster_month' %}active{% endif %}">📅 Roster</a>
+          <a href="{{ url_for('requests_page') }}" class="nav-link {% if request.endpoint == 'requests_page' %}active{% endif %}">📝 Requests</a>
+          <a href="{{ url_for('staff_profile', sid=current_user.id) }}" class="nav-link {% if request.endpoint == 'staff_profile' %}active{% endif %}">👤 Profile</a>
 
-            {% if is_admin or is_editor %}
-              <li class="nav-item">
-                <a href="{{ url_for('overtime') }}" class="nav-link {% if request.endpoint == 'overtime' %}active{% endif %}">
-                  <i class="fa-solid fa-satellite"></i><span>Overtime</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a href="{{ url_for('leave') }}" class="nav-link {% if request.endpoint == 'leave' %}active{% endif %}">
-                  <i class="fa-solid fa-plane-departure"></i><span>Leave</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a href="{{ url_for('reports_index') }}" class="nav-link {% if request.endpoint in ('reports_index','report_leave','report_fatigue','report_leave_year','report_leave_month','report_sickness') %}active{% endif %}">
-                  <i class="fa-solid fa-chart-simple"></i><span>Reports</span>
-                </a>
-              </li>
-            {% endif %}
-            {% if is_admin %}
-              <li class="nav-item">
-                <a href="{{ url_for('admin') }}" class="nav-link {% if request.endpoint == 'admin' %}active{% endif %}">
-                  <i class="fa-solid fa-gear"></i><span>Admin</span>
-                </a>
-              </li>
-            {% endif %}
-
-            <li class="nav-item">
-              <a href="{{ url_for('logout') }}" class="nav-link">
-                <i class="fa-solid fa-right-from-bracket"></i><span>Logout</span>
-              </a>
-            </li>
-          {% else %}
-            <li class="nav-item">
-              <a href="{{ url_for('login') }}" class="nav-link {% if request.endpoint == 'login' %}active{% endif %}">
-                <i class="fa-solid fa-lock"></i><span>Login</span>
-              </a>
-            </li>
+          {% if is_admin or is_editor %}
+            <a href="{{ url_for('overtime') }}" class="nav-link {% if request.endpoint == 'overtime' %}active{% endif %}">🛰️ Overtime Finder</a>
+            <a href="{{ url_for('leave') }}" class="nav-link {% if request.endpoint == 'leave' %}active{% endif %}">📝 Leave / Sickness</a>
+            <a href="{{ url_for('reports_index') }}" class="nav-link {% if request.endpoint in ('reports_index','report_leave','report_fatigue','report_leave_year','report_leave_month','report_sickness') %}active{% endif %}">📑 Reports</a>
           {% endif %}
-        </ul>
+          {% if is_admin %}
+            <a href="{{ url_for('admin') }}" class="nav-link {% if request.endpoint == 'admin' %}active{% endif %}">⚙️ Admin</a>
+          {% endif %}
+
+          <a href="{{ url_for('logout') }}" class="nav-link">🚪 Logout</a>
+        {% else %}
+          <a href="{{ url_for('login') }}" class="nav-link {% if request.endpoint == 'login' %}active{% endif %}">🔐 Login</a>
+        {% endif %}
       </nav>
     </div>
   </header>
@@ -124,16 +82,6 @@
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
   <script>
-    const navToggle = document.querySelector('[data-nav-toggle]');
-    const primaryNav = document.getElementById('primary-nav');
-    if (navToggle && primaryNav) {
-      navToggle.addEventListener('click', () => {
-        const expanded = navToggle.getAttribute('aria-expanded') === 'true';
-        navToggle.setAttribute('aria-expanded', (!expanded).toString());
-        primaryNav.classList.toggle('is-open');
-      });
-    }
-
     function printRoster(){ window.print(); }
 
     // Auto-fit roster to viewport (scale UI, avoid horizontal scroll)


### PR DESCRIPTION
## Summary
- revert the site header to the original emoji-based navigation layout
- realign the navigation styling to the classic gradient look and remove the unused mobile toggle script

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dee2c5a45483248c3993609eaf27ce