### PR TITLE
Remove skip link from base layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -89,23 +89,6 @@ body::before{
   gap:clamp(1.5rem, 1vw + 1rem, 2.5rem);
 }
 
-.skip-link{
-  position:fixed;
-  left:1.5rem;
-  top:1rem;
-  padding:.65rem 1.25rem;
-  border-radius:999px;
-  background:var(--accent-strong);
-  color:#fff;
-  font-weight:600;
-  text-decoration:none;
-  transform:translateY(-160%);
-  transition:transform .25s ease;
-  z-index:2000;
-}
-
-.skip-link:focus{transform:none;}
-
 h1,h2,h3{
   margin:0 0 1rem;
   color:#fff;

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,7 +23,6 @@
   {% block extra_head %}{% endblock %}
 </head>
 <body class="app-body">
-  <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <div class="nav-container">
       <div class="brand">


### PR DESCRIPTION
## Summary
- remove the "Skip to content" link from the base layout template
- delete the associated skip-link styling that is no longer used

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df5aa7c3088324b9d07aa99e543e63