### PR TITLE
Add admin reference data configuration for annotations and roster codes

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -211,6 +211,7 @@
   <h3>Quick Actions</h3>
   <div class="action-buttons">
     <a class="btn" href="{{ url_for('admin_toil_new') }}">Manual TOIL Entry</a>
+    <a class="btn" href="{{ url_for('admin_reference') }}">Reference Data</a>
     <a class="btn" href="{{ url_for('admin_ai_rules') }}">AI Rules</a>
     <a class="btn" href="{{ url_for('change_log_page') }}">Change Log</a>
   </div>

--- a/templates/admin_reference.html
+++ b/templates/admin_reference.html
@@ -1,0 +1,112 @@
+{% extends "base.html" %}
+{% block title %}Reference Data{% endblock %}
+
+{% block content %}
+<div class="admin-intro">
+  <h2 class="page-title">Reference Data</h2>
+  <p class="intro-lead">Configure annotation codes and roster code lists so the roster matches your unit's terminology.</p>
+</div>
+
+<section class="admin-section">
+  <header class="section-header">
+    <div>
+      <h3>Annotation Codes</h3>
+      <p class="section-subtitle">Add, rename, or hide annotation options and define how they behave.</p>
+    </div>
+  </header>
+  <div class="section-body stack">
+    <details class="collapsible-card" open>
+      <summary class="collapsible-title">Add Annotation</summary>
+      <form method="post" class="row inline-form">
+        <input type="hidden" name="form" value="annotation_new">
+        <label>Code <input name="code" required class="input-sm" placeholder="e.g. A2"></label>
+        <label>Label <input name="label" class="input-xl" placeholder="Display name"></label>
+        <label>Category <input name="category" class="input-lg" placeholder="Dropdown group"></label>
+        <label>Tags <input name="tags" class="input-xl" placeholder="Comma-separated e.g. ot,aava"></label>
+        <label>Allow suffix <input type="checkbox" name="allow_suffix"></label>
+        <label>Suffixes <input name="suffixes" class="input-sm" placeholder="MDAN"></label>
+        <label>TOIL half-days <input type="number" name="toil_half_days" class="input-sm" min="0" value="0"></label>
+        <label>Sort order <input type="number" name="sort_order" class="input-sm" value="0"></label>
+        <label>Active <input type="checkbox" name="is_active" checked></label>
+        <div class="form-actions">
+          <button class="btn btn-primary" type="submit">Add Annotation</button>
+        </div>
+      </form>
+    </details>
+
+    <details class="collapsible-card" open>
+      <summary class="collapsible-title">Existing Annotations</summary>
+      <div class="table-scroll">
+        <table class="mini admin-table">
+          <thead>
+            <tr>
+              <th>Code</th>
+              <th>Label</th>
+              <th>Category</th>
+              <th>Tags</th>
+              <th>Allow suffix</th>
+              <th>Suffixes</th>
+              <th>TOIL ½ days</th>
+              <th>Sort</th>
+              <th>Active</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for ann in annotations %}
+            <tr>
+              <td><input form="ann-form-{{ ann.id }}" name="code" value="{{ ann.code }}" class="input-sm"></td>
+              <td><input form="ann-form-{{ ann.id }}" name="label" value="{{ ann.label }}" class="input-xl"></td>
+              <td><input form="ann-form-{{ ann.id }}" name="category" value="{{ ann.category }}" class="input-lg"></td>
+              <td><input form="ann-form-{{ ann.id }}" name="tags" value="{{ ann.tags }}" class="input-xl" placeholder="Comma-separated"></td>
+              <td class="center"><input form="ann-form-{{ ann.id }}" type="checkbox" name="allow_suffix" {% if ann.allow_suffix %}checked{% endif %}></td>
+              <td><input form="ann-form-{{ ann.id }}" name="suffixes" value="{{ ann.suffixes }}" class="input-sm"></td>
+              <td><input form="ann-form-{{ ann.id }}" type="number" name="toil_half_days" value="{{ ann.toil_half_days }}" class="input-xs"></td>
+              <td><input form="ann-form-{{ ann.id }}" type="number" name="sort_order" value="{{ ann.sort_order or 0 }}" class="input-xs"></td>
+              <td class="center"><input form="ann-form-{{ ann.id }}" type="checkbox" name="is_active" {% if ann.is_active %}checked{% endif %}></td>
+              <td class="table-actions">
+                <form method="post" id="ann-form-{{ ann.id }}" class="inline-form inline-form--tight">
+                  <input type="hidden" name="form" value="annotation_edit">
+                  <input type="hidden" name="annotation_id" value="{{ ann.id }}">
+                  <button class="btn" type="submit">Save</button>
+                </form>
+                <form method="post" class="inline-form" onsubmit="return confirm('Remove annotation {{ ann.code }}?');">
+                  <input type="hidden" name="form" value="annotation_delete">
+                  <input type="hidden" name="annotation_id" value="{{ ann.id }}">
+                  <button class="btn" type="submit">Delete</button>
+                </form>
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </details>
+  </div>
+</section>
+
+<section class="admin-section">
+  <header class="section-header">
+    <div>
+      <h3>Roster Code Lists</h3>
+      <p class="section-subtitle">Update the reusable code groups that power dropdowns and fatigue logic.</p>
+    </div>
+  </header>
+  <div class="section-body stack">
+    {% for item in settings %}
+    <form method="post" class="card">
+      <input type="hidden" name="form" value="settings_codes">
+      <input type="hidden" name="key" value="{{ item.key }}">
+      <div class="card-body">
+        <h4>{{ item.label }}</h4>
+        <p class="muted">{{ item.help }}</p>
+        <textarea name="values" rows="3" class="input-xl" placeholder="Comma or space separated codes">{{ item.value }}</textarea>
+        <div class="form-actions">
+          <button class="btn btn-primary" type="submit">Save {{ item.label }}</button>
+        </div>
+      </div>
+    </form>
+    {% endfor %}
+  </div>
+</section>
+{% endblock %}

--- a/templates/metrics.html
+++ b/templates/metrics.html
@@ -6,9 +6,8 @@
   <h1 class="page-title">OT/Swap/EXT Totals</h1>
 
   <p class="muted" style="margin-top:-.5rem">
-    Counts are based on <strong>assignment annotations</strong>:
-    <em>EXTL</em>/<em>EXTS</em> (Extensions), <em>SWAP</em>, and OT types <em>A2/A4/A6/A8</em> plus <em>SOAL</em>.
-    “AAVA Total” = A2+A4+A6+A8. “OT Total” = AAVA Total + SOAL.
+    Counts are based on the <strong>annotation definitions</strong> configured in Admin → Reference Data.
+    “AAVA Total” adds all overtime annotations tagged with <code>aava</code>; “OT Total” includes every annotation tagged with <code>ot</code>.
   </p>
 
   <form method="get" class="bar">
@@ -31,7 +30,9 @@
             <th>Ext S</th>
             <th>Ext Total</th>
             <th>Swaps</th>
-            <th>A2</th><th>A4</th><th>A6</th><th>A8</th><th>SOAL</th>
+            {% for col in ot_columns %}
+              <th>{{ col.label }}</th>
+            {% endfor %}
             <th>AAVA Total</th>
             <th>OT Total</th>
           </tr>
@@ -45,11 +46,9 @@
             <td>{{ r.ext_short }}</td>
             <td>{{ r.ext_total }}</td>
             <td>{{ r.swaps }}</td>
-            <td>{{ r.ot.A2 }}</td>
-            <td>{{ r.ot.A4 }}</td>
-            <td>{{ r.ot.A6 }}</td>
-            <td>{{ r.ot.A8 }}</td>
-            <td>{{ r.ot.SOAL }}</td>
+            {% for col in ot_columns %}
+              <td>{{ r.ot[col.code] }}</td>
+            {% endfor %}
             <td>{{ r.aava_total }}</td>
             <td>{{ r.ot_total }}</td>
           </tr>
@@ -63,11 +62,9 @@
             <td>{{ totals.ext_short }}</td>
             <td>{{ totals.ext_total }}</td>
             <td>{{ totals.swaps }}</td>
-            <td>{{ totals.ot.A2 }}</td>
-            <td>{{ totals.ot.A4 }}</td>
-            <td>{{ totals.ot.A6 }}</td>
-            <td>{{ totals.ot.A8 }}</td>
-            <td>{{ totals.ot.SOAL }}</td>
+            {% for col in ot_columns %}
+              <td>{{ totals.ot[col.code] }}</td>
+            {% endfor %}
             <td>{{ totals.aava_total }}</td>
             <td>{{ totals.ot_total }}</td>
           </tr>

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -189,22 +189,15 @@
                 title="Annotate"
               >
                 <option value="" {% if not ann %}selected{% endif %}>—</option>
-                <optgroup label="Extensions">
-                  <option value="EXTS" {% if ann=='EXTS' %}selected{% endif %}>Short EXT</option>
-                  <option value="EXTL" {% if ann=='EXTL' %}selected{% endif %}>Long EXT</option>
-                </optgroup>
-                <optgroup label="Swap">
-                  <option value="SWAP" {% if ann=='SWAP' %}selected{% endif %}>Swap</option>
-                </optgroup>
-                <optgroup label="Overtime">
-                  <option value="A2"  {% if ann=='A2' %}selected{% endif %}>A2</option>
-                  <option value="A4"  {% if ann=='A4' %}selected{% endif %}>A4</option>
-                  <option value="A6"  {% if ann=='A6' %}selected{% endif %}>A6</option>
-                  <option value="A8"  {% if ann=='A8' %}selected{% endif %}>A8</option>
-                  <option value="SOAL" {% if ann=='SOAL' %}selected{% endif %}>SOAL</option>
-                  <option value="TOA8" {% if ann=='TOA8' %}selected{% endif %}>TOA8 (TOIL +1.0)</option>
-                  <option value="TOAI" {% if ann=='TOAI' %}selected{% endif %}>TOAI (TOIL +0.5)</option>
-                </optgroup>
+                {% for group, opts in annotation_groups.items() %}
+                  {% if opts %}
+                  <optgroup label="{{ group }}">
+                    {% for opt in opts %}
+                      <option value="{{ opt.code }}" {% if ann==opt.code %}selected{% endif %}>{{ opt.label }}</option>
+                    {% endfor %}
+                  </optgroup>
+                  {% endif %}
+                {% endfor %}
               </select>
             </form>
           </td>

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -30,6 +30,7 @@ from app import (
     _month_add,
     _parse_date,
     _parse_hhmm,
+    bootstrap_reference_data,
     parse_annotation,
     is_month_locked,
     lock_date_for_month,
@@ -47,6 +48,7 @@ def setup_database():
     with app.app.app_context():
         db.drop_all()
         db.create_all()
+        bootstrap_reference_data()
     yield
     with app.app.app_context():
         db.session.remove()
@@ -70,10 +72,11 @@ def test_parse_date():
 
 
 def test_parse_annotation():
-    assert parse_annotation("a6m") == {"type": "A6", "suffix": "M"}
-    assert parse_annotation(" TOAI ") == {"type": "TOAI", "suffix": None}
-    assert parse_annotation("invalid") is None
-    assert parse_annotation("") is None
+    with app.app.app_context():
+        assert parse_annotation("a6m") == {"type": "A6", "suffix": "M"}
+        assert parse_annotation(" TOAI ") == {"type": "TOAI", "suffix": None}
+        assert parse_annotation("invalid") is None
+        assert parse_annotation("") is None
 
 
 def test_context_month_for_date():


### PR DESCRIPTION
## Summary
- add persistent models and helpers for annotation types and roster code settings with bootstrap defaults
- expose a Reference Data admin page and update roster and metrics views to respect configurable annotations
- update automated tests to initialise the new reference data defaults

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0f9c233908324b82d6b6c7a0d5f89