### PR TITLE
Bust cached static CSS to surface new dark blue theme

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -11,7 +11,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-TbP2oT4maGdTKStZJ9+doRTO1D94avYVbwybXDq3s1ymUOI1IKXey9HvK+nZd9kpGdn6FQkR0fF6Bw7+Xw8FfA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+  <link rel="stylesheet" href="{{ asset_url('styles.css') }}">
 
   <!-- Preserve colours and force landscape when printing -->
   <style>


### PR DESCRIPTION
## Summary
- add a Jinja helper that appends the static file mtime as a cache-busting query string
- update the base template to reference the stylesheet through the new helper so colour changes deploy immediately

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0fa8551688324b579208c7a9807ab