### PR TITLE
Apply new theme styling to AI rules and change log pages

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -195,6 +195,12 @@ a.btn.ghost:hover{color:#fff; background:rgba(40,64,110,.65);}
 
 label{font-size:.85rem; letter-spacing:.02em; text-transform:uppercase; color:var(--text-muted); font-weight:600;}
 
+.form-check{display:flex; align-items:center; gap:.65rem; padding:.6rem .85rem; border-radius:var(--radius-sm); border:1px solid rgba(116,138,178,.28); background:rgba(16,24,40,.75); box-shadow:inset 0 1px 0 rgba(255,255,255,.03);}
+.form-check + .form-check{margin-top:.5rem;}
+.form-check-input{width:1.1rem; height:1.1rem; margin:0; border-radius:6px; background:rgba(11,17,30,.9); border:1px solid rgba(116,138,178,.45); cursor:pointer; transition:border-color .2s ease, box-shadow .2s ease, background .2s ease;}
+.form-check-input:focus{outline:none; box-shadow:0 0 0 3px rgba(79,125,255,.22); border-color:rgba(108,148,228,.75);}
+.form-check-label{font-size:.95rem; font-weight:500; text-transform:none; color:var(--text); letter-spacing:.01em; cursor:pointer;}
+
 input,
 select,
 textarea,
@@ -225,6 +231,9 @@ textarea:focus,
 }
 
 textarea{min-height:140px; resize:vertical;}
+
+.simple-list{list-style:none; margin:0; padding:0; display:grid; gap:.45rem;}
+.simple-list li{padding:.55rem .75rem; border-radius:var(--radius-sm); border:1px solid rgba(116,138,178,.24); background:rgba(15,23,38,.78); box-shadow:inset 0 1px 0 rgba(255,255,255,.02);}
 
 .form-text{color:var(--text-muted);}
 .form-check-input:checked{background-color:var(--accent-strong); border-color:var(--accent-strong);}
@@ -456,6 +465,9 @@ table:not(.roster) td{
 }
 
 table:not(.roster) tfoot td{font-weight:600;}
+
+.table-scroll{overflow:auto; border-radius:var(--radius-md); border:1px solid rgba(108,129,168,.2); box-shadow:var(--shadow-soft);}
+.table-scroll table{min-width:880px; border:none; box-shadow:none; border-radius:0;}
 
 /* ==============================
    Month navigation & helpers

--- a/templates/ai_rules.html
+++ b/templates/ai_rules.html
@@ -1,51 +1,131 @@
-<!doctype html>
-<html>
-<head>
-  <meta charset="utf-8"><title>AI Rules</title>
-  <style>body{font-family:system-ui,sans-serif;max-width:1000px;margin:2rem auto;padding:0 1rem}textarea{width:100%;min-height:280px}.card{border:1px solid #ddd;border-radius:8px;padding:1rem;margin:1rem 0}label{display:block;margin:.25rem 0}</style>
-</head>
-<body>
-  <h1>AI Rules — {{ ym }}</h1>
-  <form method="get">
-    <label>Month (YYYY-MM): <input type="text" name="ym" value="{{ ym }}"></label>
-    <button type="submit">Load</button>
-  </form>
+{% extends "base.html" %}
+{% block title %}AI Rules{% endblock %}
+
+{% block content %}
+<div class="stack">
+  <header class="stack">
+    <h1 class="page-title">AI Rules</h1>
+    <p class="muted">Fine-tune how the roster generator balances fairness, coverage, and preferences for {{ ym }}.</p>
+  </header>
 
   <div class="card">
-    <h3>Simple Editor</h3>
-    <form method="post">
-      <input type="hidden" name="mode" value="form">
-      <label><input type="checkbox" name="respect_user_requests" {% if rules.respect_user_requests %}checked{% endif %}> Respect user requests</label>
-      <label><input type="checkbox" name="equalize_nights" {% if rules.equalize_nights %}checked{% endif %}> Equalize nights</label>
-      <label><input type="checkbox" name="nights_in_pairs" {% if rules.nights_in_pairs %}checked{% endif %}> Assign nights in pairs</label>
-      <label><input type="checkbox" name="avoid_night_before_AL" {% if rules.avoid_night_before_AL %}checked{% endif %}> Avoid night before AL</label>
-      <label><input type="checkbox" name="fill_short_with_D" {% if rules.fill_short_with_D %}checked{% endif %}> Fill shortages with Day</label>
-      <label>Night pool (watches CSV): <input type="text" name="night_pool_watches" value="{{ rules.night_pool_watches|join(',') }}"></label>
-      <label>Weekday Day code: <input type="text" name="day_weekday" value="{{ rules.day_shift_codes.weekday }}"></label>
-      <label>Sunday Day code: <input type="text" name="day_sunday" value="{{ rules.day_shift_codes.sunday }}"></label>
-      <label>No-nights list (staff IDs): <input type="text" name="no_nights_list" value="{{ rules.no_nights_list|join(', ') }}"></label>
-      <label><input type="checkbox" name="nops_integrate_required" {% if rules.nops_policy.integrate_required %}checked{% endif %}> Integrate NOPS when required</label>
-      <label><input type="checkbox" name="nops_only_if_needed" {% if rules.nops_policy.only_if_needed %}checked{% endif %}> Only if needed to meet reqs</label>
-      <button type="submit">Save Rules</button>
-    </form>
+    <div class="card-hd"><i class="fa-solid fa-calendar-days"></i> Configuration period</div>
+    <div class="card-bd">
+      <form method="get" class="row g-3 align-items-end">
+        <div class="col-md-4 col-lg-3">
+          <label class="form-label" for="ai-rules-month">Month (YYYY-MM)</label>
+          <input id="ai-rules-month" type="text" name="ym" value="{{ ym }}" class="form-control" autocomplete="off" placeholder="2024-08">
+        </div>
+        <div class="col-auto">
+          <button class="btn btn-primary" type="submit"><i class="fa-solid fa-rotate"></i> Load month</button>
+        </div>
+      </form>
+    </div>
   </div>
 
   <div class="card">
-    <h3>Advanced JSON</h3>
-    <form method="post">
-      <input type="hidden" name="mode" value="json">
-      <textarea name="rules_json">{{ rules_json }}</textarea>
-      <p><button type="submit">Save JSON</button></p>
-    </form>
+    <div class="card-hd"><i class="fa-solid fa-robot"></i> Simple editor</div>
+    <div class="card-bd">
+      <form method="post" class="stack">
+        <input type="hidden" name="mode" value="form">
+
+        <div class="row g-3">
+          <div class="col-md-6 col-xl-4">
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" id="respect_user_requests" name="respect_user_requests" {% if rules.respect_user_requests %}checked{% endif %}>
+              <label class="form-check-label" for="respect_user_requests">Respect user requests</label>
+            </div>
+          </div>
+          <div class="col-md-6 col-xl-4">
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" id="equalize_nights" name="equalize_nights" {% if rules.equalize_nights %}checked{% endif %}>
+              <label class="form-check-label" for="equalize_nights">Equalise nights</label>
+            </div>
+          </div>
+          <div class="col-md-6 col-xl-4">
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" id="nights_in_pairs" name="nights_in_pairs" {% if rules.nights_in_pairs %}checked{% endif %}>
+              <label class="form-check-label" for="nights_in_pairs">Assign nights in pairs</label>
+            </div>
+          </div>
+          <div class="col-md-6 col-xl-4">
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" id="avoid_night_before_AL" name="avoid_night_before_AL" {% if rules.avoid_night_before_AL %}checked{% endif %}>
+              <label class="form-check-label" for="avoid_night_before_AL">Avoid night before AL</label>
+            </div>
+          </div>
+          <div class="col-md-6 col-xl-4">
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" id="fill_short_with_D" name="fill_short_with_D" {% if rules.fill_short_with_D %}checked{% endif %}>
+              <label class="form-check-label" for="fill_short_with_D">Fill shortages with Day</label>
+            </div>
+          </div>
+          <div class="col-md-6 col-xl-4">
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" id="nops_integrate_required" name="nops_integrate_required" {% if rules.nops_policy.integrate_required %}checked{% endif %}>
+              <label class="form-check-label" for="nops_integrate_required">Integrate NOPS when required</label>
+            </div>
+          </div>
+          <div class="col-md-6 col-xl-4">
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" id="nops_only_if_needed" name="nops_only_if_needed" {% if rules.nops_policy.only_if_needed %}checked{% endif %}>
+              <label class="form-check-label" for="nops_only_if_needed">Use NOPS only if needed</label>
+            </div>
+          </div>
+        </div>
+
+        <div class="row g-3">
+          <div class="col-md-6 col-xl-4">
+            <label class="form-label" for="night_pool_watches">Night pool (watches CSV)</label>
+            <input class="form-control" id="night_pool_watches" name="night_pool_watches" value="{{ rules.night_pool_watches|join(',') }}" placeholder="A1,B2,B3">
+          </div>
+          <div class="col-md-6 col-xl-4">
+            <label class="form-label" for="day_weekday">Weekday Day code</label>
+            <input class="form-control" id="day_weekday" name="day_weekday" value="{{ rules.day_shift_codes.weekday }}" maxlength="10">
+          </div>
+          <div class="col-md-6 col-xl-4">
+            <label class="form-label" for="day_sunday">Sunday Day code</label>
+            <input class="form-control" id="day_sunday" name="day_sunday" value="{{ rules.day_shift_codes.sunday }}" maxlength="10">
+          </div>
+          <div class="col-md-6 col-xl-4">
+            <label class="form-label" for="no_nights_list">No-nights list (staff IDs)</label>
+            <input class="form-control" id="no_nights_list" name="no_nights_list" value="{{ rules.no_nights_list|join(', ') }}" placeholder="123, 456">
+          </div>
+        </div>
+
+        <div>
+          <button class="btn btn-primary" type="submit"><i class="fa-solid fa-floppy-disk"></i> Save rules</button>
+        </div>
+      </form>
+    </div>
   </div>
 
   <div class="card">
-    <h3>Staff IDs (for no-nights)</h3>
-    <ul>
-      {% for name, sid in staff_map %}
-        <li>{{ name }} — <code>{{ sid }}</code></li>
-      {% endfor %}
-    </ul>
+    <div class="card-hd"><i class="fa-solid fa-code"></i> Advanced JSON</div>
+    <div class="card-bd">
+      <form method="post" class="stack">
+        <input type="hidden" name="mode" value="json">
+        <label class="form-label" for="rules_json">Rules JSON</label>
+        <textarea class="form-control font-monospace" id="rules_json" name="rules_json" rows="12">{{ rules_json }}</textarea>
+        <div>
+          <button class="btn btn-secondary" type="submit"><i class="fa-solid fa-floppy-disk"></i> Save JSON</button>
+        </div>
+      </form>
+    </div>
   </div>
-</body>
-</html>
+
+  <div class="card">
+    <div class="card-hd"><i class="fa-solid fa-users"></i> Staff IDs (for no-nights)</div>
+    <div class="card-bd">
+      <ul class="simple-list">
+        {% for name, sid in staff_map %}
+          <li><strong>{{ name }}</strong> — <code>{{ sid }}</code></li>
+        {% endfor %}
+        {% if not staff_map %}
+          <li class="muted">No staff records available.</li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/change_log.html
+++ b/templates/change_log.html
@@ -1,46 +1,74 @@
-<!doctype html>
-<html>
-<head>
-  <meta charset="utf-8"><title>Change Log</title>
-  <style>body{font-family:system-ui,sans-serif;max-width:1100px;margin:2rem auto;padding:0 1rem}table{border-collapse:collapse;width:100%}th,td{border:1px solid #ddd;padding:.5rem;vertical-align:top}th{background:#fafafa;text-align:left}.filters{margin:.5rem 0;padding:.5rem;border:1px solid #eee;border-radius:8px}code{white-space:pre-wrap;word-break:break-word}</style>
-</head>
-<body>
-  <h1>Change Log</h1>
-  <form method="get" class="filters">
-    <label>Month (YYYY-MM): <input type="text" name="ym" value="{{ ym or '' }}"></label>
-    <label>Entity type: <input type="text" name="entity_type" value="{{ entity_type or '' }}"></label>
-    <label>User ID: <input type="text" name="who" value="{{ who or '' }}"></label>
-    <button type="submit">Filter</button>
-  </form>
+{% extends "base.html" %}
+{% block title %}Change Log{% endblock %}
 
-  <table>
-    <thead>
-      <tr>
-        <th>When (UTC)</th>
-        <th>User</th>
-        <th>Entity</th>
-        <th>Field</th>
-        <th>Old → New</th>
-        <th>Month</th>
-        <th>Note</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for r in rows %}
-      <tr>
-        <td>{{ r.when }}</td>
-        <td>{{ r.who_user_id }}</td>
-        <td>{{ r.entity_type }} #{{ r.entity_id }}</td>
-        <td>{{ r.field }}</td>
-        <td><code>{{ r.old_value }}</code> → <code>{{ r.new_value }}</code></td>
-        <td>{{ r.context_month }}</td>
-        <td>{{ r.note }}</td>
-      </tr>
-      {% endfor %}
-      {% if not rows %}
-      <tr><td colspan="7">No results.</td></tr>
-      {% endif %}
-    </tbody>
-  </table>
-</body>
-</html>
+{% block content %}
+<div class="stack">
+  <header class="stack">
+    <h1 class="page-title">Change Log</h1>
+    <p class="muted">Audit every roster adjustment, leave update, and admin action in one consistent view.</p>
+  </header>
+
+  <div class="card">
+    <div class="card-hd"><i class="fa-solid fa-filter"></i> Filter entries</div>
+    <div class="card-bd">
+      <form method="get" class="row g-3 align-items-end">
+        <div class="col-sm-6 col-lg-3">
+          <label class="form-label" for="change-log-month">Month (YYYY-MM)</label>
+          <input class="form-control" id="change-log-month" type="text" name="ym" value="{{ ym or '' }}" autocomplete="off" placeholder="2024-08">
+        </div>
+        <div class="col-sm-6 col-lg-3">
+          <label class="form-label" for="change-log-entity">Entity type</label>
+          <input class="form-control" id="change-log-entity" type="text" name="entity_type" value="{{ entity_type or '' }}" placeholder="shift, leave…">
+        </div>
+        <div class="col-sm-6 col-lg-3">
+          <label class="form-label" for="change-log-user">User ID</label>
+          <input class="form-control" id="change-log-user" type="text" name="who" value="{{ who or '' }}" placeholder="123">
+        </div>
+        <div class="col-auto">
+          <button class="btn btn-primary" type="submit"><i class="fa-solid fa-search"></i> Apply filters</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-hd"><i class="fa-solid fa-clock-rotate-left"></i> Recent changes</div>
+    <div class="card-bd">
+      <div class="table-scroll">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">When (UTC)</th>
+              <th scope="col">User</th>
+              <th scope="col">Entity</th>
+              <th scope="col">Field</th>
+              <th scope="col">Old → New</th>
+              <th scope="col">Month</th>
+              <th scope="col">Note</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% if rows %}
+              {% for r in rows %}
+                <tr>
+                  <td>{{ r.when }}</td>
+                  <td>{{ r.who_user_id }}</td>
+                  <td>{{ r.entity_type }} #{{ r.entity_id }}</td>
+                  <td>{{ r.field }}</td>
+                  <td><code>{{ r.old_value }}</code> → <code>{{ r.new_value }}</code></td>
+                  <td>{{ r.context_month }}</td>
+                  <td>{{ r.note }}</td>
+                </tr>
+              {% endfor %}
+            {% else %}
+              <tr>
+                <td colspan="7" class="text-center text-muted py-4">No results for the selected filters.</td>
+              </tr>
+            {% endif %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Rebuilt the AI rules admin screen on the shared base layout and restyled the forms to match the refreshed palette.
- Migrated the change log view onto the global theme with responsive filters and the updated table styling.
- Added reusable form-check, table scroll, and simple list styles so future admin tools inherit the colour scheme automatically.

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0faa35b44832481695111aa905cce