### PR TITLE
Add multi-unit support with super admin capabilities

### DIFF
--- a/app.py
+++ b/app.py
@@ -519,6 +519,11 @@ def _shift_by_code(code: str, unit_id: int | None = None):
         for row in rows:
             if row.unit_id == unit_id:
                 return row
+        for row in rows:
+            if row.unit_id is None:
+                return row
+        # No unit-specific or global definition – treat as unknown in this unit.
+        return None
     for row in rows:
         if row.unit_id is None:
             return row

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -5,6 +5,11 @@
 <div class="admin-intro">
   <h2 class="page-title">Administration</h2>
   <p class="intro-lead">Manage staffing requirements, shift definitions, and team access from one streamlined hub.</p>
+  {% if current_unit %}
+    <p class="text-secondary">Managing unit: <strong>{{ current_unit.name }}</strong></p>
+  {% elif is_super_admin %}
+    <p class="text-secondary">Managing unit: <strong>All units</strong></p>
+  {% endif %}
 </div>
 
 <div class="admin-dashboard">
@@ -70,6 +75,16 @@
           <label>End <input name="end" placeholder="HH:MM" class="input-sm"></label>
           <label class="checkbox"><input type="checkbox" name="is_working"> Working</label>
           <label class="checkbox"><input type="checkbox" name="is_training"> Training</label>
+          {% if is_super_admin %}
+            <label>Unit
+              <select name="shift_unit_id" class="input-lg">
+                <option value="global">Global (all units)</option>
+                {% for unit in available_units %}
+                  <option value="{{ unit.id }}" {% if current_unit and unit.id == current_unit.id %}selected{% endif %}>{{ unit.name }}</option>
+                {% endfor %}
+              </select>
+            </label>
+          {% endif %}
           <button class="btn" type="submit">Add</button>
         </form>
       </details>
@@ -86,6 +101,7 @@
                 <th>End</th>
                 <th>Working</th>
                 <th>Training</th>
+                <th>Unit</th>
                 <th colspan="2">Actions</th>
               </tr>
             </thead>
@@ -98,6 +114,7 @@
                   <td>{{ sh.end_time and sh.end_time.strftime("%H:%M") or "" }}</td>
                   <td>{{ "Yes" if sh.is_working else "No" }}</td>
                   <td>{{ "Yes" if sh.is_training else "No" }}</td>
+                  <td>{{ sh.unit.name if sh.unit else 'All units' }}</td>
                   <td>
                     <form method="post" class="row inline-form inline-form--tight">
                       <input type="hidden" name="form" value="shift_edit">
@@ -149,11 +166,23 @@
               {% endfor %}
             </select>
           </label>
+          {% if is_super_admin %}
+            <label>Unit
+              <select name="unit_id" required>
+                {% for unit in available_units %}
+                  <option value="{{ unit.id }}" {% if current_unit and unit.id == current_unit.id %}selected{% endif %}>{{ unit.name }}</option>
+                {% endfor %}
+              </select>
+            </label>
+          {% endif %}
           <label>Role
             <select name="role">
               <option value="user">user</option>
               <option value="editor">editor</option>
               <option value="admin">admin</option>
+              {% if is_super_admin %}
+                <option value="superadmin">superadmin</option>
+              {% endif %}
             </select>
           </label>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -49,6 +49,24 @@
           <a href="{{ url_for('login') }}" class="nav-link {% if request.endpoint == 'login' %}active{% endif %}">🔐 Login</a>
         {% endif %}
       </nav>
+      {% if current_user.is_authenticated and available_units %}
+        <div class="unit-switch">
+          {% if is_super_admin %}
+            <form method="post" action="{{ url_for('switch_unit') }}">
+              {% set next_url = request.full_path if request.query_string else request.path %}
+              <input type="hidden" name="next" value="{{ next_url }}">
+              <label for="unit-select" class="visually-hidden">Active unit</label>
+              <select id="unit-select" name="unit_id" class="form-select form-select-sm" onchange="this.form.submit()">
+                {% for unit in available_units %}
+                  <option value="{{ unit.id }}" {% if active_unit and unit.id == active_unit.id %}selected{% endif %}>{{ unit.name }}</option>
+                {% endfor %}
+              </select>
+            </form>
+          {% elif active_unit %}
+            <span class="badge bg-secondary">{{ active_unit.name }}</span>
+          {% endif %}
+        </div>
+      {% endif %}
     </div>
   </header>
 

--- a/templates/staff_edit.html
+++ b/templates/staff_edit.html
@@ -17,10 +17,25 @@
           {% for w in watches %}<option value="{{ w.id }}" {% if s.watch_id == w.id %}selected{% endif %}>{{ w.name }}</option>{% endfor %}
         </select>
       </label>
+      {% if is_super_admin %}
+        <label>Unit
+          <select name="unit_id">
+            {% for unit in available_units %}
+              <option value="{{ unit.id }}" {% if s.unit_id == unit.id %}selected{% endif %}>{{ unit.name }}</option>
+            {% endfor %}
+          </select>
+        </label>
+      {% else %}
+        <input type="hidden" name="unit_id" value="{{ s.unit_id }}">
+      {% endif %}
 
       <label>Role
+        {% set roles = ['user','editor','admin'] %}
+        {% if is_super_admin %}
+          {% set roles = roles + ['superadmin'] %}
+        {% endif %}
         <select name="role">
-          {% for r in ['user','editor','admin'] %}
+          {% for r in roles %}
             <option value="{{ r }}" {% if s.role == r %}selected{% endif %}>{{ r|capitalize }}</option>
           {% endfor %}
         </select>


### PR DESCRIPTION
## Summary
- add a Unit model, unit-aware shift definitions, and a super admin role so users only see their own unit’s data
- scope roster queries, reports, and admin workflows to the active unit and seed a default super admin account
- update navigation and admin/staff management UIs with unit selectors for super administrators
- fix the cached shift lookup to allow optional unit context so legacy call sites continue to function without errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0fa4a74948324b3f508087dcffbe4