### PR TITLE
Improve airport administration and account controls

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ from collections import defaultdict, Counter, OrderedDict, deque
 from typing import Optional, Tuple
 import base64
 from urllib import parse as urllib_parse, request as urllib_request, error as urllib_error
-from flask import Flask, render_template, request, redirect, url_for, flash, Response, abort, session, g
+from flask import Flask, render_template, request, redirect, url_for, flash, Response, abort, session, g, send_from_directory
 from flask import render_template as flask_render_template
 import os
 import re
@@ -115,6 +115,13 @@ def _validate_csrf() -> None:
 
 app.jinja_env.globals["csrf_token"] = csrf_token
 
+
+@app.route("/favicon.ico")
+def favicon():
+    return send_from_directory(
+        app.static_folder, "favicon.svg", mimetype="image/svg+xml"
+    )
+
 # Database & login
 db = SQLAlchemy(app, session_options={"expire_on_commit": False})
 login_manager = LoginManager(app)
@@ -126,7 +133,7 @@ from tenancy import bind_authenticated_unit, reset_authenticated_unit
 @app.before_request
 def _bind_tenant_context():
     g.tenant_context_token = None
-    if current_user.is_authenticated:
+    if current_user.is_authenticated and getattr(current_user, "role", "") != "superadmin":
         unit_id = int(getattr(current_user, "unit_id", 0) or 0)
         if unit_id:
             g.tenant_context_token = bind_authenticated_unit(unit_id)
@@ -815,8 +822,9 @@ def _scope_operational_selects(execute_state):
     statement = execute_state.statement
     for model in TENANT_OPERATIONAL_MODELS:
         statement = statement.options(with_loader_criteria(
-            model, lambda cls, tenant=unit_id: cls.unit_id == tenant,
+            model, lambda cls: cls.unit_id == unit_id,
             include_aliases=True,
+            track_closure_variables=True,
         ))
     execute_state.statement = statement
 
@@ -1986,7 +1994,7 @@ def migrate_add_role_and_calendar_token():
 
     changed = False
     for u in Staff.query.all():
-        if not u.role or u.role not in ("admin", "editor", "user"):
+        if not u.role or u.role not in ("superadmin", "admin", "editor", "user"):
             u.role = "admin" if getattr(u, "is_admin", False) else "user"
             changed = True
         if not u.calendar_token:
@@ -2195,13 +2203,13 @@ def seed_once():
 
     db.session.add_all([
         ShiftType(code="M",   name="Morning",     start_time=time(
-            6, 0),  end_time=time(14, 0), is_working=True),
+            6, 0),  end_time=time(14, 0), is_working=True, is_requestable=True),
         ShiftType(code="D",   name="Day",         start_time=time(
-            8, 0),  end_time=time(16, 0), is_working=True),
+            8, 0),  end_time=time(16, 0), is_working=True, is_requestable=True),
         ShiftType(code="A",   name="Afternoon",   start_time=time(
-            14, 0), end_time=time(22, 0), is_working=True),
+            14, 0), end_time=time(22, 0), is_working=True, is_requestable=True),
         ShiftType(code="N",   name="Night",       start_time=time(
-            22, 0), end_time=time(6, 0),  is_working=True),
+            22, 0), end_time=time(6, 0),  is_working=True, is_requestable=True),
         ShiftType(code="OFF", name="Rest Day",    is_working=False),
         ShiftType(code="AL",  name="Annual Leave",    is_working=False),
         ShiftType(code="PL",  name="Parental Leave",  is_working=False),
@@ -2671,9 +2679,14 @@ def _clamp_prev_next(year, month):
 def inject_perms():
     au = current_user if getattr(
         current_user, "is_authenticated", False) else None
+    current_unit = (
+        db.session.get(Unit, int(getattr(au, "unit_id", 0) or 0))
+        if au and getattr(au, "role", "") != "superadmin" else None
+    )
     return {
         "is_admin":  bool(au) and is_admin_user(au),
         "is_editor": bool(au) and is_editor_user(au),
+        "current_unit": current_unit,
     }
 
 
@@ -3182,13 +3195,25 @@ def admin():
             end = _parse_hhmm(request.form.get("end"))
             is_working = bool(request.form.get("is_working"))
             is_training = bool(request.form.get("is_training"))
+            is_active = bool(request.form.get("is_active"))
+            is_requestable = bool(request.form.get("is_requestable"))
+            required_qualification = (
+                request.form.get("required_qualification") or ""
+            ).strip().lower()
+            allowed_qualifications = {"", "medical", "tower", "radar", "met", "ojti", "assessor"}
             if not code:
                 flash("Shift code is required.", "error")
+            elif required_qualification not in allowed_qualifications:
+                flash("Unknown required qualification.", "error")
+            elif is_requestable and (not is_active or not is_working):
+                flash("Only active working shifts can be requestable.", "error")
             elif ShiftType.query.filter_by(code=code).first():
                 flash("Shift code already exists.", "error")
             else:
                 sh = ShiftType(code=code, name=name or code, start_time=start, end_time=end,
-                               is_working=is_working, is_training=is_training)
+                               is_working=is_working, is_training=is_training,
+                               is_active=is_active, is_requestable=is_requestable,
+                               required_qualification=required_qualification)
                 db.session.add(sh)
                 db.session.commit()
                 refresh_shift_cache()
@@ -3204,6 +3229,20 @@ def admin():
             sh.end_time = _parse_hhmm(request.form.get("end"))
             sh.is_working = bool(request.form.get("is_working"))
             sh.is_training = bool(request.form.get("is_training"))
+            sh.is_active = bool(request.form.get("is_active"))
+            requested = bool(request.form.get("is_requestable"))
+            required_qualification = (
+                request.form.get("required_qualification") or ""
+            ).strip().lower()
+            allowed_qualifications = {"", "medical", "tower", "radar", "met", "ojti", "assessor"}
+            if required_qualification not in allowed_qualifications:
+                flash("Unknown required qualification.", "error")
+                return redirect(url_for("admin"))
+            if requested and (not sh.is_active or not sh.is_working):
+                flash("Only active working shifts can be requestable.", "error")
+                return redirect(url_for("admin"))
+            sh.is_requestable = requested
+            sh.required_qualification = required_qualification
             db.session.commit()
             refresh_shift_cache()
             _shift_groups_snapshot.cache_clear()
@@ -5020,14 +5059,157 @@ def admin_request_respond(rid):
     return redirect(url_for("requests_page", ym=request.form.get("ym") or ""))
 
 
-@app.route("/platform/admin")
+@app.route("/platform/admin", methods=["GET", "POST"])
 @login_required
 def platform_admin():
     """Privacy-preserving control plane: aggregates and unit metadata only."""
     if getattr(current_user, "role", "") != "superadmin":
         abort(403)
+    platform_actor = PlatformIdentity.query.filter_by(
+        username=current_user.username
+    ).first()
+    if not platform_actor:
+        abort(403, "Super Admin identity is not provisioned in the control plane.")
+    if request.method == "POST":
+        _validate_csrf()
+        action = (request.form.get("action") or "").strip()
+        if action == "create_unit":
+            code = (request.form.get("code") or "").strip().upper()
+            name = (request.form.get("name") or "").strip()
+            plan = (request.form.get("plan") or "starter").strip()[:40]
+            admin_name = (request.form.get("admin_name") or "").strip()
+            admin_username = (request.form.get("admin_username") or "").strip().lower()
+            admin_password = request.form.get("admin_password") or ""
+            try:
+                limit = int(request.form.get("active_user_limit") or 10)
+            except ValueError:
+                limit = 0
+            if not re.fullmatch(r"[A-Z0-9]{2,12}", code):
+                flash("Airport code must be 2–12 letters or numbers.", "error")
+            elif not name or not admin_name or not admin_username:
+                flash("Airport and initial admin details are required.", "error")
+            elif len(admin_password) < 12:
+                flash("The initial admin password must be at least 12 characters.", "error")
+            elif not 1 <= limit <= 10000:
+                flash("Active-user limit must be between 1 and 10,000.", "error")
+            elif Unit.query.filter_by(code=code).first():
+                flash("That airport code already exists.", "error")
+            elif db.session.query(Staff).execution_options(skip_tenant_scope=True).filter_by(
+                username=admin_username
+            ).first():
+                flash("That admin username already exists.", "error")
+            else:
+                try:
+                    unit = Unit(
+                        code=code, name=name, plan=plan,
+                        active_user_limit=limit, onboarding_step=1,
+                    )
+                    db.session.add(unit)
+                    db.session.flush()
+                    watch = Watch(
+                        unit_id=unit.id, name=f"{code} Initial Watch", order_index=1
+                    )
+                    db.session.add(watch)
+                    db.session.flush()
+                    admin_user = Staff(
+                        unit_id=unit.id, username=admin_username,
+                        name=admin_name, staff_no=f"{code}-ADMIN",
+                        role="admin", watch_id=watch.id, is_operational=False,
+                    )
+                    admin_user.set_password(admin_password)
+                    db.session.add(admin_user)
+                    db.session.flush()
+                    identity = PlatformIdentity(
+                        public_id=f"unit-admin-{secrets.token_hex(12)}",
+                        username=admin_username,
+                        password_hash=admin_user.password_hash,
+                    )
+                    db.session.add(identity)
+                    db.session.flush()
+                    membership = UnitMembership(
+                        identity_id=identity.id, unit_id=unit.id,
+                        person_id=admin_user.id, role="UnitAdmin",
+                        status="active", activated_at=utcnow(),
+                    )
+                    db.session.add(membership)
+                    db.session.add(PlanHistory(
+                        unit_id=unit.id, plan=plan,
+                        active_user_limit=limit,
+                    ))
+                    db.session.add(SuperAdminAudit(
+                        actor_identity_id=platform_actor.id, unit_id=unit.id,
+                        action="airport_created",
+                        safe_summary=f"Created airport {code} on {plan} plan with limit {limit}",
+                    ))
+                    db.session.commit()
+                    flash(
+                        f"{name} created. Give the initial Unit Admin their credentials securely.",
+                        "ok",
+                    )
+                    return redirect(url_for("platform_admin"))
+                except Exception:
+                    db.session.rollback()
+                    raise
+        elif action == "update_limit":
+            try:
+                unit_id = int(request.form.get("unit_id") or 0)
+                new_limit = int(request.form.get("active_user_limit") or 0)
+            except ValueError:
+                abort(400)
+            unit = db.session.get(Unit, unit_id)
+            if not unit or unit.status == "platform_control":
+                abort(404)
+            if not 1 <= new_limit <= 10000:
+                flash("Active-user limit must be between 1 and 10,000.", "error")
+            else:
+                active_count = UnitMembership.query.filter_by(
+                    unit_id=unit.id, status="active"
+                ).count()
+                if new_limit < active_count:
+                    flash(
+                        f"Limit cannot be below the {active_count} active accounts.",
+                        "error",
+                    )
+                else:
+                    old_limit = unit.active_user_limit
+                    unit.active_user_limit = new_limit
+                    db.session.add(PlanHistory(
+                        unit_id=unit.id, plan=unit.plan,
+                        active_user_limit=new_limit,
+                    ))
+                    db.session.add(SuperAdminAudit(
+                        actor_identity_id=platform_actor.id, unit_id=unit.id,
+                        action="account_limit_changed",
+                        safe_summary=f"Changed active-user limit from {old_limit} to {new_limit}",
+                    ))
+                    db.session.commit()
+                    flash(f"{unit.code} account limit updated.", "ok")
+                    return redirect(url_for("platform_admin"))
+        elif action == "toggle_suspension":
+            unit_id = int(request.form.get("unit_id") or 0)
+            unit = db.session.get(Unit, unit_id)
+            if not unit or unit.status == "platform_control":
+                abort(404)
+            if unit.status == "suspended":
+                unit.status = "active"
+                unit.suspended_at = None
+                action_name = "airport_restored"
+            else:
+                unit.status = "suspended"
+                unit.suspended_at = utcnow()
+                action_name = "airport_suspended"
+            db.session.add(SuperAdminAudit(
+                actor_identity_id=platform_actor.id, unit_id=unit.id,
+                action=action_name, safe_summary=f"{action_name}: {unit.code}",
+            ))
+            db.session.commit()
+            return redirect(url_for("platform_admin"))
+        else:
+            abort(400)
     rows = []
-    for unit in Unit.query.order_by(Unit.code).all():
+    for unit in Unit.query.filter(
+        Unit.status != "platform_control"
+    ).order_by(Unit.code).all():
         active_accounts = UnitMembership.query.filter_by(
             unit_id=unit.id, status="active"
         ).count()
@@ -5049,6 +5231,87 @@ def platform_admin():
             "activity_count": int(activity or 0),
         })
     return render_template("platform_admin.html", rows=rows)
+
+
+@app.route("/unit/accounts", methods=["GET", "POST"])
+@login_required
+def unit_accounts():
+    if not is_admin_user(current_user):
+        abort(403)
+    unit_id = _current_unit_id()
+    unit = db.session.get(Unit, unit_id)
+    if not unit:
+        abort(404)
+    if request.method == "POST":
+        _validate_csrf()
+        action = (request.form.get("action") or "").strip()
+        if action == "create_account":
+            name = (request.form.get("name") or "").strip()
+            username = (request.form.get("username") or "").strip().lower()
+            password = request.form.get("password") or ""
+            if not name or not username or len(password) < 12:
+                flash("Name, username, and a 12-character password are required.", "error")
+                return redirect(url_for("unit_accounts"))
+            if db.session.query(Staff).execution_options(skip_tenant_scope=True).filter_by(
+                username=username
+            ).first():
+                flash("That username already exists.", "error")
+                return redirect(url_for("unit_accounts"))
+            try:
+                staff = Staff(
+                    unit_id=unit_id, username=username, name=name,
+                    staff_no=f"{unit.code}-LOGIN-{secrets.token_hex(3).upper()}",
+                    role="user", is_operational=False,
+                )
+                staff.set_password(password)
+                db.session.add(staff)
+                db.session.flush()
+                identity = PlatformIdentity(
+                    public_id=f"member-{secrets.token_hex(12)}",
+                    username=username, password_hash=staff.password_hash,
+                )
+                db.session.add(identity)
+                db.session.flush()
+                membership = UnitMembership(
+                    identity_id=identity.id, unit_id=unit_id,
+                    person_id=staff.id, role="StaffUser", status="invited",
+                )
+                db.session.add(membership)
+                db.session.flush()
+                from account_limits import activate_membership
+                activate_membership(db, Unit, UnitMembership, membership.id)
+                membership.activated_at = utcnow()
+                db.session.commit()
+                flash("Account activated.", "ok")
+            except ValueError as exc:
+                db.session.rollback()
+                flash(str(exc), "error")
+            return redirect(url_for("unit_accounts"))
+        if action == "deactivate":
+            membership_id = int(request.form.get("membership_id") or 0)
+            membership = UnitMembership.query.filter_by(
+                id=membership_id, unit_id=unit_id, status="active"
+            ).first_or_404()
+            if membership.person_id == current_user.id:
+                flash("You cannot deactivate your own account.", "error")
+            else:
+                membership.status = "suspended"
+                membership.suspended_at = utcnow()
+                linked = db.session.get(Staff, membership.person_id) if membership.person_id else None
+                if linked:
+                    linked.membership_status = "suspended"
+                db.session.commit()
+                flash("Account deactivated.", "ok")
+            return redirect(url_for("unit_accounts"))
+        abort(400)
+    memberships = UnitMembership.query.filter_by(unit_id=unit_id).order_by(
+        UnitMembership.id
+    ).all()
+    active_count = sum(1 for row in memberships if row.status == "active")
+    return render_template(
+        "unit_accounts.html", unit=unit, memberships=memberships,
+        active_count=active_count,
+    )
 
 
 @app.route("/unit/onboarding", methods=["GET", "POST"])

--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#101827"/>
+  <circle cx="32" cy="32" r="21" fill="none" stroke="#38bdf8" stroke-width="4"/>
+  <path d="M32 8v48M8 32h48" stroke="#38bdf8" stroke-width="2" opacity=".55"/>
+  <path d="M32 32 49 20" stroke="#f8fafc" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="32" cy="32" r="5" fill="#f8fafc"/>
+</svg>

--- a/static/styles.css
+++ b/static/styles.css
@@ -285,6 +285,51 @@ textarea{min-height:140px; resize:vertical;}
   font-weight:600;
 }
 
+.airport-context{
+  display:flex;
+  align-items:center;
+  flex-wrap:wrap;
+  gap:.45rem;
+  width:max-content;
+  max-width:100%;
+  margin-top:.45rem;
+  padding:.36rem .55rem .36rem .7rem;
+  border:1px solid rgba(108,179,255,.5);
+  border-radius:999px;
+  background:linear-gradient(135deg, rgba(34,87,150,.62), rgba(25,52,92,.88));
+  box-shadow:0 12px 30px -20px rgba(56,189,248,.8);
+  color:#f8fbff;
+  line-height:1.2;
+}
+
+.airport-context__label{
+  color:rgba(201,222,255,.78);
+  font-size:.68rem;
+  font-weight:700;
+  letter-spacing:.1em;
+  text-transform:uppercase;
+}
+
+.airport-context__name{
+  font-size:.82rem;
+  font-weight:700;
+}
+
+.airport-context__code{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  min-width:2.8rem;
+  padding:.2rem .45rem;
+  border-radius:999px;
+  background:#e8f5ff;
+  color:#0b3158;
+  font-family:var(--font-mono);
+  font-size:.72rem;
+  font-weight:700;
+  letter-spacing:.08em;
+}
+
 .main-nav {
   display:flex;
   gap:.65rem;
@@ -671,6 +716,297 @@ tfoot td{background:var(--card); font-weight:bold; color:var(--text);}
   max-width:780px;
 }
 
+.admin-intro{
+  flex-direction:row;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:1.5rem;
+}
+
+.admin-eyebrow,
+.admin-step{
+  display:block;
+  margin-bottom:.3rem;
+  color:var(--accent);
+  font-size:.7rem;
+  font-weight:700;
+  letter-spacing:.14em;
+  text-transform:uppercase;
+}
+
+.admin-section-nav{
+  position:sticky;
+  top:94px;
+  z-index:20;
+  display:grid;
+  grid-template-columns:repeat(5, minmax(120px, 1fr));
+  gap:.55rem;
+  padding:.65rem;
+  border:1px solid rgba(108,129,168,.28);
+  border-radius:var(--radius-lg);
+  background:rgba(11,20,36,.9);
+  box-shadow:var(--shadow-soft);
+  backdrop-filter:blur(18px);
+}
+
+.admin-section-tab{
+  min-height:58px;
+  border:1px solid transparent;
+  background:transparent;
+  box-shadow:none;
+  color:var(--text-muted);
+}
+
+.admin-section-tab:hover{transform:none;}
+.admin-section-tab i{color:var(--accent); font-size:1rem;}
+.admin-section-tab.active{
+  color:#fff;
+  border-color:rgba(108,179,255,.55);
+  background:linear-gradient(135deg, rgba(45,102,185,.82), rgba(31,61,108,.88));
+  box-shadow:0 14px 30px -22px rgba(56,189,248,.9);
+}
+
+.admin-workspace{scroll-margin-top:180px;}
+
+.admin-panel{
+  min-height:460px;
+  padding:clamp(1.25rem, 2vw, 2rem);
+  border:1px solid rgba(101,126,173,.26);
+  border-radius:var(--radius-lg);
+  background:linear-gradient(150deg, rgba(24,33,53,.92), rgba(14,22,38,.94));
+  box-shadow:var(--shadow-pop);
+}
+
+.admin-panel[hidden]{display:none;}
+
+.admin-panel-heading{
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:1rem;
+  margin-bottom:1.5rem;
+  padding-bottom:1.15rem;
+  border-bottom:1px solid rgba(108,129,168,.22);
+}
+
+.admin-panel-heading h3{margin:0 0 .3rem;}
+.admin-panel-heading p{margin:0;}
+
+.admin-overview-grid{
+  display:grid;
+  grid-template-columns:repeat(2, minmax(250px, 1fr));
+  gap:1rem;
+}
+
+.admin-overview-card{
+  min-height:128px;
+  display:grid;
+  grid-template-columns:auto 1fr auto;
+  gap:1rem;
+  text-align:left;
+  background:rgba(15,27,48,.82);
+}
+
+.admin-overview-card:hover{border-color:rgba(108,179,255,.55);}
+.admin-overview-card span:nth-child(2){display:flex; flex-direction:column; gap:.25rem;}
+.admin-overview-card strong{font-size:1rem;}
+.admin-overview-card small{color:var(--text-muted); font-weight:500;}
+
+.admin-overview-icon{
+  width:44px;
+  height:44px;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  border-radius:12px;
+  background:rgba(59,130,246,.2);
+  color:var(--accent);
+}
+
+.admin-sticky-actions{
+  position:sticky;
+  bottom:1rem;
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:1rem;
+  margin-top:1rem;
+  padding:.8rem 1rem;
+  border:1px solid rgba(108,179,255,.32);
+  border-radius:var(--radius-md);
+  background:rgba(12,25,45,.95);
+  box-shadow:0 20px 45px -26px #000;
+}
+
+.admin-sticky-actions span{color:var(--text-muted); font-size:.85rem;}
+
+.admin-create-drawer{
+  margin-bottom:1.25rem;
+  padding:1.25rem;
+  border:1px solid rgba(108,179,255,.36);
+  border-radius:var(--radius-md);
+  background:rgba(22,40,69,.78);
+}
+
+.admin-create-drawer[hidden]{display:none;}
+.admin-create-drawer h4{margin:0 0 1rem;}
+
+.admin-form-grid{
+  display:grid;
+  grid-template-columns:repeat(4, minmax(145px, 1fr));
+  gap:1rem;
+  align-items:end;
+}
+
+.admin-form-grid label:not(.checkbox){
+  display:flex;
+  flex-direction:column;
+  gap:.35rem;
+}
+
+.admin-form-grid input,
+.admin-form-grid select{width:100%;}
+
+.admin-check-row{
+  grid-column:1 / -1;
+  display:flex;
+  flex-wrap:wrap;
+  gap:.65rem;
+  padding:.75rem;
+  border:1px solid rgba(108,129,168,.22);
+  border-radius:var(--radius-sm);
+  background:rgba(10,18,32,.45);
+}
+
+.admin-form-grid .form-actions{grid-column:1 / -1;}
+
+.admin-shift-list{display:grid; gap:.65rem;}
+
+.admin-shift-row{
+  border:1px solid rgba(108,129,168,.28);
+  border-radius:var(--radius-md);
+  background:rgba(12,23,41,.72);
+  overflow:hidden;
+}
+
+.admin-shift-row summary{
+  display:grid;
+  grid-template-columns:70px minmax(180px, 1fr) auto auto 30px;
+  align-items:center;
+  gap:.75rem;
+  padding:.9rem 1rem;
+  cursor:pointer;
+  list-style:none;
+}
+
+.admin-shift-row summary::-webkit-details-marker{display:none;}
+.admin-shift-row[open] summary{background:rgba(59,130,246,.1);}
+.shift-code{font-family:var(--font-mono); color:#fff; font-weight:700;}
+.shift-summary-name{display:flex; flex-direction:column;}
+.shift-summary-name small{color:var(--text-muted);}
+.shift-expand{color:var(--accent); transition:transform .2s ease;}
+.admin-shift-row[open] .shift-expand{transform:rotate(180deg);}
+
+.status-pill{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:max-content;
+  padding:.28rem .55rem;
+  border-radius:999px;
+  background:rgba(108,129,168,.2);
+  color:#d9e5ff;
+  font-size:.7rem;
+  font-weight:700;
+}
+
+.status-pill--on{background:rgba(39,174,96,.18); color:#8cf0b5;}
+.status-pill--off{background:rgba(231,76,60,.16); color:#ffaaa1;}
+.status-pill--request{background:rgba(59,130,246,.2); color:#9dcbff;}
+
+.admin-shift-editor{
+  padding:1.1rem;
+  border-top:1px solid rgba(108,129,168,.22);
+}
+
+.admin-danger-action{
+  display:flex;
+  justify-content:flex-end;
+  margin-top:.75rem;
+}
+
+.admin-danger-action .btn{color:#ffb4ae; border-color:rgba(231,76,60,.35);}
+
+.admin-search{
+  display:flex;
+  flex-direction:column;
+  gap:.4rem;
+  max-width:520px;
+  margin-bottom:1rem;
+}
+
+.admin-staff-list{display:grid; gap:.6rem;}
+
+.admin-staff-card{
+  display:grid;
+  grid-template-columns:auto minmax(180px, 1fr) auto auto;
+  align-items:center;
+  gap:.85rem;
+  padding:.75rem .9rem;
+  border:1px solid rgba(108,129,168,.24);
+  border-radius:var(--radius-md);
+  background:rgba(12,23,41,.68);
+}
+
+.admin-staff-card[hidden]{display:none;}
+.staff-avatar{width:40px; height:40px; display:inline-flex; align-items:center; justify-content:center; border-radius:50%; background:linear-gradient(135deg,#3b82f6,#38bdf8); color:#fff; font-weight:700;}
+.staff-card-name{display:flex; flex-direction:column;}
+.staff-card-name small{color:var(--text-muted);}
+.admin-empty-search{padding:1rem; text-align:center;}
+
+.admin-tool-grid{
+  display:grid;
+  grid-template-columns:repeat(2, minmax(240px, 1fr));
+  gap:1rem;
+}
+
+.admin-tool-grid a{
+  display:grid;
+  grid-template-columns:42px 1fr;
+  align-items:center;
+  gap:.85rem;
+  padding:1rem;
+  border:1px solid rgba(108,129,168,.26);
+  border-radius:var(--radius-md);
+  background:rgba(12,23,41,.68);
+  color:var(--text);
+}
+
+.admin-tool-grid a:hover{border-color:rgba(108,179,255,.55); background:rgba(24,49,84,.75);}
+.admin-tool-grid a > i{color:var(--accent); font-size:1.15rem; text-align:center;}
+.admin-tool-grid span{display:flex; flex-direction:column;}
+.admin-tool-grid small{color:var(--text-muted);}
+
+@media (max-width: 900px){
+  .admin-intro{flex-direction:column;}
+  .admin-section-nav{top:132px; grid-template-columns:repeat(5, minmax(72px, 1fr)); overflow-x:auto;}
+  .admin-section-tab{padding:.5rem; flex-direction:column; font-size:.72rem;}
+  .admin-overview-grid,.admin-tool-grid{grid-template-columns:1fr;}
+  .admin-form-grid{grid-template-columns:repeat(2, minmax(140px, 1fr));}
+  .admin-shift-row summary{grid-template-columns:60px 1fr auto;}
+  .admin-shift-row summary .status-pill{display:none;}
+  .admin-staff-card{grid-template-columns:auto 1fr auto;}
+  .admin-staff-card .status-pill{display:none;}
+}
+
+@media (max-width: 560px){
+  .admin-form-grid{grid-template-columns:1fr;}
+  .admin-section-nav{grid-template-columns:repeat(5, 86px);}
+  .admin-staff-card{grid-template-columns:auto 1fr;}
+  .admin-staff-card .btn{grid-column:1 / -1;}
+  .admin-sticky-actions{position:static; flex-direction:column; align-items:stretch;}
+}
+
 .admin-dashboard{
   display:grid;
   gap:1.75rem;
@@ -987,4 +1323,3 @@ table.roster { transform-origin: top left; transform: scale(var(--ui-scale)); }
 /* EM uses Morning colour */
 .code-input.em { background: var(--yellow); color: #000; }
 .code-input.group-e { background: var(--yellow); color: #000; }
-

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -3,217 +3,243 @@
 
 {% block content %}
 <div class="admin-intro">
-  <h2 class="page-title">Administration</h2>
-  <p class="intro-lead">Manage staffing requirements, shift definitions, and team access from one streamlined hub.</p>
+  <div>
+    <span class="admin-eyebrow">Unit administration</span>
+    <h2 class="page-title">Administration</h2>
+    <p class="intro-lead">Choose a section and focus on one task at a time. Your last section stays open when you return.</p>
+  </div>
+  <a class="btn" href="{{ url_for('unit_accounts') }}"><i class="fa-solid fa-users"></i> Manage accounts</a>
 </div>
 
-<div class="admin-dashboard">
-  <section class="admin-section">
-    <header class="section-header">
-      <div>
-        <h3>Monthly Requirements</h3>
-        <p class="section-subtitle">Tune the minimum staffing levels for each shift category across the upcoming months.</p>
-      </div>
+<nav class="admin-section-nav" aria-label="Administration sections">
+  <button type="button" class="admin-section-tab active" data-admin-section="overview" aria-controls="admin-overview" aria-selected="true">
+    <i class="fa-solid fa-table-cells-large"></i><span>Overview</span>
+  </button>
+  <button type="button" class="admin-section-tab" data-admin-section="requirements" aria-controls="admin-requirements" aria-selected="false">
+    <i class="fa-solid fa-chart-column"></i><span>Requirements</span>
+  </button>
+  <button type="button" class="admin-section-tab" data-admin-section="shifts" aria-controls="admin-shifts" aria-selected="false">
+    <i class="fa-solid fa-clock"></i><span>Shifts</span>
+  </button>
+  <button type="button" class="admin-section-tab" data-admin-section="staff" aria-controls="admin-staff" aria-selected="false">
+    <i class="fa-solid fa-user-group"></i><span>Staff</span>
+  </button>
+  <button type="button" class="admin-section-tab" data-admin-section="tools" aria-controls="admin-tools" aria-selected="false">
+    <i class="fa-solid fa-screwdriver-wrench"></i><span>Tools</span>
+  </button>
+</nav>
+
+<div class="admin-workspace">
+  <section id="admin-overview" class="admin-panel active" data-admin-panel="overview">
+    <header class="admin-panel-heading">
+      <div><span class="admin-step">Overview</span><h3>What would you like to manage?</h3></div>
+    </header>
+    <div class="admin-overview-grid">
+      <button type="button" class="admin-overview-card" data-open-admin-section="requirements">
+        <span class="admin-overview-icon"><i class="fa-solid fa-chart-column"></i></span>
+        <span><strong>Staffing requirements</strong><small>{{ months|length }} configured month slots</small></span>
+        <i class="fa-solid fa-arrow-right"></i>
+      </button>
+      <button type="button" class="admin-overview-card" data-open-admin-section="shifts">
+        <span class="admin-overview-icon"><i class="fa-solid fa-clock"></i></span>
+        <span><strong>Shift definitions</strong><small>{{ shifts|length }} shift codes</small></span>
+        <i class="fa-solid fa-arrow-right"></i>
+      </button>
+      <button type="button" class="admin-overview-card" data-open-admin-section="staff">
+        <span class="admin-overview-icon"><i class="fa-solid fa-user-group"></i></span>
+        <span><strong>People and roles</strong><small>{{ staff|length }} staff records</small></span>
+        <i class="fa-solid fa-arrow-right"></i>
+      </button>
+      <button type="button" class="admin-overview-card" data-open-admin-section="tools">
+        <span class="admin-overview-icon"><i class="fa-solid fa-screwdriver-wrench"></i></span>
+        <span><strong>Reference and audit tools</strong><small>Codes, AI rules, TOIL and change history</small></span>
+        <i class="fa-solid fa-arrow-right"></i>
+      </button>
+    </div>
+  </section>
+
+  <section id="admin-requirements" class="admin-panel" data-admin-panel="requirements" hidden>
+    <header class="admin-panel-heading">
+      <div><span class="admin-step">Planning</span><h3>Monthly staffing requirements</h3><p>Set the minimum staffing for each duty group.</p></div>
     </header>
     <form method="post" class="section-body">
       <input type="hidden" name="form" value="req">
-      <table class="mini admin-table">
-        <thead>
-          <tr>
-            <th>Month</th>
-            <th>M</th>
-            <th>D</th>
-            <th>A</th>
-            <th>N</th>
-          </tr>
-        </thead>
-        <tbody>
+      <div class="table-scroll admin-requirements-table">
+        <table class="mini admin-table">
+          <thead><tr><th>Month</th><th>Morning</th><th>Day</th><th>Afternoon</th><th>Night</th></tr></thead>
+          <tbody>
           {% for y,m in months %}
             {% set r = requirements_by_month.get((y,m)) %}
             <tr>
-              <td class="table-label">
-                <input type="hidden" name="ym" value="{{ '%04d-%02d'|format(y,m) }}">
-                {{ '%04d-%02d'|format(y,m) }}
-              </td>
-              <td><input type="number" name="req_m" value="{{ r.req_m if r else 0 }}" class="table-input"></td>
-              <td><input type="number" name="req_d" value="{{ r.req_d if r else 0 }}" class="table-input"></td>
-              <td><input type="number" name="req_a" value="{{ r.req_a if r else 0 }}" class="table-input"></td>
-              <td><input type="number" name="req_n" value="{{ r.req_n if r else 0 }}" class="table-input"></td>
+              <td class="table-label"><input type="hidden" name="ym" value="{{ '%04d-%02d'|format(y,m) }}">{{ '%04d-%02d'|format(y,m) }}</td>
+              <td><input type="number" min="0" name="req_m" value="{{ r.req_m if r else 0 }}" class="table-input" aria-label="Morning requirement for {{ '%04d-%02d'|format(y,m) }}"></td>
+              <td><input type="number" min="0" name="req_d" value="{{ r.req_d if r else 0 }}" class="table-input" aria-label="Day requirement for {{ '%04d-%02d'|format(y,m) }}"></td>
+              <td><input type="number" min="0" name="req_a" value="{{ r.req_a if r else 0 }}" class="table-input" aria-label="Afternoon requirement for {{ '%04d-%02d'|format(y,m) }}"></td>
+              <td><input type="number" min="0" name="req_n" value="{{ r.req_n if r else 0 }}" class="table-input" aria-label="Night requirement for {{ '%04d-%02d'|format(y,m) }}"></td>
             </tr>
           {% endfor %}
-        </tbody>
-      </table>
-      <div class="form-actions">
-        <button class="btn btn-primary" type="submit">Save Requirements</button>
+          </tbody>
+        </table>
       </div>
+      <div class="admin-sticky-actions"><span>Changes apply to this airport only.</span><button class="btn btn-primary" type="submit">Save requirements</button></div>
     </form>
   </section>
 
-  <details class="admin-section admin-section--collapsible" open>
-    <summary class="section-header section-header--summary">
-      <div>
-        <h3>Shifts</h3>
-        <p class="section-subtitle">Create, update, or retire shift templates without leaving the page.</p>
-      </div>
-      <span class="section-toggle" aria-hidden="true">
-        <i class="fa-solid fa-chevron-down"></i>
-      </span>
-    </summary>
-    <div class="section-body stack">
-      <details class="collapsible-card" open>
-        <summary class="collapsible-title">Add Shift</summary>
-        <form method="post" class="row inline-form">
-          <input type="hidden" name="form" value="shift_new">
-          <label>Code <input name="code" required class="input-sm"></label>
-          <label>Name <input name="name" class="input-lg"></label>
-          <label>Start <input name="start" placeholder="HH:MM" class="input-sm"></label>
-          <label>End <input name="end" placeholder="HH:MM" class="input-sm"></label>
+  <section id="admin-shifts" class="admin-panel" data-admin-panel="shifts" hidden>
+    <header class="admin-panel-heading">
+      <div><span class="admin-step">Roster setup</span><h3>Shift definitions</h3><p>Create shifts and expand a row only when you need to edit it.</p></div>
+      <button type="button" class="btn btn-primary" data-toggle-create-shift><i class="fa-solid fa-plus"></i> Add shift</button>
+    </header>
+
+    <div class="admin-create-drawer" data-create-shift hidden>
+      <h4>New shift</h4>
+      <form method="post" class="admin-form-grid">
+        <input type="hidden" name="form" value="shift_new">
+        <label>Code<input name="code" required maxlength="10"></label>
+        <label>Name<input name="name" required></label>
+        <label>Start<input type="time" name="start"></label>
+        <label>End<input type="time" name="end"></label>
+        <label>Required qualification<select name="required_qualification"><option value="">None</option><option value="medical">Medical</option><option value="tower">Tower</option><option value="radar">Radar</option><option value="met">MET</option><option value="ojti">OJTI</option><option value="assessor">Assessor</option></select></label>
+        <div class="admin-check-row">
           <label class="checkbox"><input type="checkbox" name="is_working"> Working</label>
           <label class="checkbox"><input type="checkbox" name="is_training"> Training</label>
-          <button class="btn" type="submit">Add</button>
-        </form>
-      </details>
-
-      <details class="collapsible-card" open>
-        <summary class="collapsible-title">Existing Shifts</summary>
-        <div class="table-scroll">
-          <table class="mini admin-table">
-            <thead>
-              <tr>
-                <th>Code</th>
-                <th>Name</th>
-                <th>Start</th>
-                <th>End</th>
-                <th>Working</th>
-                <th>Training</th>
-                <th colspan="2">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for sh in shifts %}
-                <tr>
-                  <td>{{ sh.code }}</td>
-                  <td>{{ sh.name }}</td>
-                  <td>{{ sh.start_time and sh.start_time.strftime("%H:%M") or "" }}</td>
-                  <td>{{ sh.end_time and sh.end_time.strftime("%H:%M") or "" }}</td>
-                  <td>{{ "Yes" if sh.is_working else "No" }}</td>
-                  <td>{{ "Yes" if sh.is_training else "No" }}</td>
-                  <td>
-                    <form method="post" class="row inline-form inline-form--tight">
-                      <input type="hidden" name="form" value="shift_edit">
-                      <input type="hidden" name="shift_id" value="{{ sh.id }}">
-                      <input name="name" value="{{ sh.name }}" class="input-lg">
-                      <input name="start" value="{{ sh.start_time.strftime('%H:%M') if sh.start_time else '' }}" placeholder="HH:MM" class="input-sm">
-                      <input name="end" value="{{ sh.end_time.strftime('%H:%M') if sh.end_time else '' }}" placeholder="HH:MM" class="input-sm">
-                      <label class="checkbox"><input type="checkbox" name="is_working" {% if sh.is_working %}checked{% endif %}> W</label>
-                      <label class="checkbox"><input type="checkbox" name="is_training" {% if sh.is_training %}checked{% endif %}> T</label>
-                      <button class="btn" type="submit">Update</button>
-                    </form>
-                  </td>
-                  <td class="table-actions">
-                    <form method="post" onsubmit="return confirm('Delete shift {{ sh.code }}?');">
-                      <input type="hidden" name="form" value="shift_delete">
-                      <input type="hidden" name="shift_id" value="{{ sh.id }}">
-                      <button class="btn" type="submit">Delete</button>
-                    </form>
-                  </td>
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
+          <label class="checkbox"><input type="checkbox" name="is_active" checked> Active</label>
+          <label class="checkbox"><input type="checkbox" name="is_requestable"> Requestable</label>
         </div>
-      </details>
+        <div class="form-actions"><button class="btn btn-primary" type="submit">Create shift</button></div>
+      </form>
     </div>
-  </details>
 
-  <section class="admin-section admin-section--wide">
-    <header class="section-header">
-      <div>
-        <h3>Staff</h3>
-        <p class="section-subtitle">Onboard new controllers and jump straight to profile maintenance.</p>
-      </div>
-    </header>
-    <div class="section-body stack">
-      <details class="collapsible-card" open>
-        <summary class="collapsible-title">Add ATCO</summary>
-        <form method="post" class="row staff-form">
-          <input type="hidden" name="form" value="staff_new">
-          <label>Name <input name="name" required class="input-xl"></label>
-          <label>Staff # <input name="staff_no" required class="input-sm"></label>
-          <label>Username <input name="username" required class="input-lg"></label>
-          <label>Watch
-            <select name="watch_id" required>
-              <option value="">—</option>
-              {% for w in watches %}
-                <option value="{{ w.id }}">{{ w.name }}</option>
-              {% endfor %}
-            </select>
-          </label>
-          <label>Role
-            <select name="role">
-              <option value="user">user</option>
-              <option value="editor">editor</option>
-              <option value="admin">admin</option>
-            </select>
-          </label>
-
-          <div class="form-divider" aria-hidden="true"></div>
-
-          <label class="checkbox"><input type="checkbox" name="is_wm"> Watch Manager</label>
-          <label class="checkbox"><input type="checkbox" name="is_dwm"> Deputy WM</label>
-          <label class="checkbox"><input type="checkbox" name="exclude_from_ot"> Exclude from OT</label>
-
-          <div class="form-divider" aria-hidden="true"></div>
-
-          <label>Leave year start (month)
-            <input type="number" name="leave_year_start_month" min="1" max="12" value="4" class="input-sm">
-          </label>
-          <label>Entitlement (days) <input type="number" name="leave_entitlement_days" value="25" class="input-sm"></label>
-          <label>Public holidays <input type="number" name="leave_public_holidays" value="8" class="input-sm"></label>
-          <label>Carryover (days) <input type="number" name="leave_carryover_days" value="0" class="input-sm"></label>
-
-          <div class="form-actions">
-            <button class="btn btn-primary" type="submit">Create ATCO</button>
-          </div>
-        </form>
-      </details>
-
-      <details class="collapsible-card">
-        <summary class="collapsible-title">All Staff (quick links)</summary>
-        <div class="table-scroll">
-          <table class="mini admin-table">
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Watch</th>
-                <th>Role</th>
-                <th>Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for s in staff %}
-                <tr>
-                  <td>{{ s.name }}</td>
-                  <td>{{ s.watch.name if s.watch else '-' }}</td>
-                  <td>{{ s.role }}</td>
-                  <td><a class="btn" href="{{ url_for('admin_staff_edit', sid=s.id) }}">Edit</a></td>
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
+    <div class="admin-shift-list">
+      {% for sh in shifts %}
+      <details class="admin-shift-row">
+        <summary>
+          <span class="shift-code">{{ sh.code }}</span>
+          <span class="shift-summary-name"><strong>{{ sh.name }}</strong><small>{{ sh.start_time.strftime('%H:%M') if sh.start_time else '—' }}–{{ sh.end_time.strftime('%H:%M') if sh.end_time else '—' }}</small></span>
+          <span class="status-pill {{ 'status-pill--on' if sh.is_active else 'status-pill--off' }}">{{ 'Active' if sh.is_active else 'Inactive' }}</span>
+          {% if sh.is_requestable %}<span class="status-pill status-pill--request">Requestable</span>{% endif %}
+          <span class="shift-expand"><i class="fa-solid fa-chevron-down"></i></span>
+        </summary>
+        <div class="admin-shift-editor">
+          <form method="post" class="admin-form-grid">
+            <input type="hidden" name="form" value="shift_edit"><input type="hidden" name="shift_id" value="{{ sh.id }}">
+            <label>Name<input name="name" value="{{ sh.name }}"></label>
+            <label>Start<input type="time" name="start" value="{{ sh.start_time.strftime('%H:%M') if sh.start_time else '' }}"></label>
+            <label>End<input type="time" name="end" value="{{ sh.end_time.strftime('%H:%M') if sh.end_time else '' }}"></label>
+            <label>Required qualification<select name="required_qualification" aria-label="Required qualification for {{ sh.code }}">{% for value, label in [('', 'None'), ('medical', 'Medical'), ('tower', 'Tower'), ('radar', 'Radar'), ('met', 'MET'), ('ojti', 'OJTI'), ('assessor', 'Assessor')] %}<option value="{{ value }}" {% if sh.required_qualification == value %}selected{% endif %}>{{ label }}</option>{% endfor %}</select></label>
+            <div class="admin-check-row">
+              <label class="checkbox"><input type="checkbox" name="is_working" {% if sh.is_working %}checked{% endif %}> Working</label>
+              <label class="checkbox"><input type="checkbox" name="is_training" {% if sh.is_training %}checked{% endif %}> Training</label>
+              <label class="checkbox"><input type="checkbox" name="is_active" {% if sh.is_active %}checked{% endif %}> Active</label>
+              <label class="checkbox"><input type="checkbox" name="is_requestable" {% if sh.is_requestable %}checked{% endif %}> Requestable</label>
+            </div>
+            <div class="form-actions"><button class="btn btn-primary" type="submit">Save {{ sh.code }}</button></div>
+          </form>
+          <form method="post" class="admin-danger-action" onsubmit="return confirm('Delete shift {{ sh.code }}?');">
+            <input type="hidden" name="form" value="shift_delete"><input type="hidden" name="shift_id" value="{{ sh.id }}">
+            <button class="btn" type="submit">Delete shift</button>
+          </form>
         </div>
       </details>
+      {% endfor %}
+    </div>
+  </section>
+
+  <section id="admin-staff" class="admin-panel" data-admin-panel="staff" hidden>
+    <header class="admin-panel-heading">
+      <div><span class="admin-step">People</span><h3>Staff and roles</h3><p>Add a controller or find an existing profile.</p></div>
+      <button type="button" class="btn btn-primary" data-toggle-create-staff><i class="fa-solid fa-user-plus"></i> Add ATCO</button>
+    </header>
+    <div class="admin-create-drawer" data-create-staff hidden>
+      <h4>New ATCO</h4>
+      <form method="post" class="admin-form-grid">
+        <input type="hidden" name="form" value="staff_new">
+        <label>Name<input name="name" required></label><label>Staff number<input name="staff_no" required></label><label>Username<input name="username" required></label>
+        <label>Watch<select name="watch_id" required><option value="">Select watch</option>{% for w in watches %}<option value="{{ w.id }}">{{ w.name }}</option>{% endfor %}</select></label>
+        <label>Role<select name="role"><option value="user">Staff user</option><option value="editor">Roster editor</option><option value="admin">Unit admin</option></select></label>
+        <label>Leave year start<input type="number" name="leave_year_start_month" min="1" max="12" value="4"></label>
+        <label>Entitlement days<input type="number" name="leave_entitlement_days" min="0" value="25"></label>
+        <label>Public holidays<input type="number" name="leave_public_holidays" min="0" value="8"></label>
+        <label>Carryover days<input type="number" name="leave_carryover_days" min="0" value="0"></label>
+        <div class="admin-check-row"><label class="checkbox"><input type="checkbox" name="is_wm"> Watch Manager</label><label class="checkbox"><input type="checkbox" name="is_dwm"> Deputy WM</label><label class="checkbox"><input type="checkbox" name="exclude_from_ot"> Exclude from OT</label></div>
+        <div class="form-actions"><button class="btn btn-primary" type="submit">Create ATCO</button></div>
+      </form>
+    </div>
+    <label class="admin-search">Find staff member<input type="search" placeholder="Search by name, watch or role…" data-staff-search></label>
+    <div class="admin-staff-list">
+      {% for s in staff %}
+      <article class="admin-staff-card" data-staff-card data-search="{{ s.name }} {{ s.watch.name if s.watch else '' }} {{ s.role }}">
+        <span class="staff-avatar" aria-hidden="true">{{ s.name[:1] }}</span>
+        <span class="staff-card-name"><strong>{{ s.name }}</strong><small>{{ s.watch.name if s.watch else 'No watch' }} · {{ s.role|capitalize }}</small></span>
+        {% if s.is_wm %}<span class="status-pill status-pill--request">Watch Manager</span>{% elif s.is_dwm %}<span class="status-pill">Deputy WM</span>{% endif %}
+        <a class="btn" href="{{ url_for('admin_staff_edit', sid=s.id) }}">Open profile</a>
+      </article>
+      {% endfor %}
+    </div>
+    <p class="admin-empty-search" data-empty-search hidden>No staff match that search.</p>
+  </section>
+
+  <section id="admin-tools" class="admin-panel" data-admin-panel="tools" hidden>
+    <header class="admin-panel-heading"><div><span class="admin-step">Configuration</span><h3>Tools and reference data</h3><p>Open specialist settings without crowding the main workspace.</p></div></header>
+    <div class="admin-tool-grid">
+      <a href="{{ url_for('admin_reference') }}"><i class="fa-solid fa-tags"></i><span><strong>Reference data</strong><small>Annotations and roster code lists</small></span></a>
+      <a href="{{ url_for('admin_ai_rules') }}"><i class="fa-solid fa-wand-magic-sparkles"></i><span><strong>AI rules</strong><small>Automated roster constraints</small></span></a>
+      <a href="{{ url_for('admin_toil_new') }}"><i class="fa-solid fa-clock-rotate-left"></i><span><strong>Manual TOIL</strong><small>Record a balance adjustment</small></span></a>
+      <a href="{{ url_for('change_log_page') }}"><i class="fa-solid fa-list-check"></i><span><strong>Change log</strong><small>Review administrative history</small></span></a>
+      <a href="{{ url_for('unit_accounts') }}"><i class="fa-solid fa-users-gear"></i><span><strong>Login accounts</strong><small>Usage, limits and deactivation</small></span></a>
+      <a href="{{ url_for('unit_onboarding') }}"><i class="fa-solid fa-plane-circle-check"></i><span><strong>Onboarding</strong><small>Airport setup checklist</small></span></a>
     </div>
   </section>
 </div>
 
-<section class="admin-actions">
-  <h3>Quick Actions</h3>
-  <div class="action-buttons">
-    <a class="btn" href="{{ url_for('admin_toil_new') }}">Manual TOIL Entry</a>
-    <a class="btn" href="{{ url_for('admin_reference') }}">Reference Data</a>
-    <a class="btn" href="{{ url_for('admin_ai_rules') }}">AI Rules</a>
-    <a class="btn" href="{{ url_for('change_log_page') }}">Change Log</a>
-  </div>
-</section>
+<script>
+(() => {
+  const tabs = [...document.querySelectorAll('[data-admin-section]')];
+  const panels = [...document.querySelectorAll('[data-admin-panel]')];
+  const valid = new Set(tabs.map(tab => tab.dataset.adminSection));
+  const show = (name, updateUrl = true) => {
+    if (!valid.has(name)) name = 'overview';
+    tabs.forEach(tab => {
+      const selected = tab.dataset.adminSection === name;
+      tab.classList.toggle('active', selected);
+      tab.setAttribute('aria-selected', String(selected));
+    });
+    panels.forEach(panel => {
+      const selected = panel.dataset.adminPanel === name;
+      panel.classList.toggle('active', selected);
+      panel.hidden = !selected;
+    });
+    localStorage.setItem('atc-admin-section', name);
+    if (updateUrl) history.replaceState(null, '', `#${name}`);
+    document.querySelector('.admin-workspace')?.scrollIntoView({behavior:'smooth', block:'start'});
+  };
+  const initial = location.hash.slice(1) || localStorage.getItem('atc-admin-section') || 'overview';
+  show(initial, false);
+  tabs.forEach(tab => tab.addEventListener('click', () => show(tab.dataset.adminSection)));
+  document.querySelectorAll('[data-open-admin-section]').forEach(button => button.addEventListener('click', () => show(button.dataset.openAdminSection)));
+  const toggle = (buttonSelector, drawerSelector) => {
+    const button = document.querySelector(buttonSelector);
+    const drawer = document.querySelector(drawerSelector);
+    button?.addEventListener('click', () => {
+      drawer.hidden = !drawer.hidden;
+      if (!drawer.hidden) drawer.querySelector('input:not([type=hidden])')?.focus();
+    });
+  };
+  toggle('[data-toggle-create-shift]', '[data-create-shift]');
+  toggle('[data-toggle-create-staff]', '[data-create-staff]');
+  const search = document.querySelector('[data-staff-search]');
+  const cards = [...document.querySelectorAll('[data-staff-card]')];
+  const empty = document.querySelector('[data-empty-search]');
+  search?.addEventListener('input', () => {
+    const term = search.value.trim().toLowerCase();
+    let visible = 0;
+    cards.forEach(card => {
+      const matches = !term || card.dataset.search.toLowerCase().includes(term);
+      card.hidden = !matches;
+      if (matches) visible++;
+    });
+    if (empty) empty.hidden = visible !== 0;
+  });
+})();
+</script>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="dark">
+  <link rel="icon" href="{{ url_for('favicon') }}" type="image/svg+xml">
   <title>{% block title %}{% endblock %} – ATC Roster</title>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -28,22 +29,33 @@
       <div class="brand">
         <h1 class="logo">ATC Roster Tool</h1>
         <p class="logo-sub">Precision scheduling for elite controllers</p>
+        {% if current_user.is_authenticated and current_unit %}
+          <div class="airport-context" role="status"
+               aria-label="Logged into {{ current_unit.name }}, airport code {{ current_unit.code }}">
+            <span class="airport-context__label">Logged into</span>
+            <strong class="airport-context__name">{{ current_unit.name }}</strong>
+            <span class="airport-context__code">{{ current_unit.code }}</span>
+          </div>
+        {% endif %}
       </div>
       <nav class="main-nav" aria-label="Primary">
         {% if current_user.is_authenticated %}
-          <a href="{{ url_for('index') }}" class="nav-link {% if request.endpoint == 'roster_month' %}active{% endif %}">📅 Roster</a>
-          <a href="{{ url_for('requests_page') }}" class="nav-link {% if request.endpoint == 'requests_page' %}active{% endif %}">📝 Requests</a>
-          <a href="{{ url_for('staff_profile', sid=current_user.id) }}" class="nav-link {% if request.endpoint == 'staff_profile' %}active{% endif %}">👤 Profile</a>
-
-          {% if is_admin or is_editor %}
-            <a href="{{ url_for('overtime') }}" class="nav-link {% if request.endpoint == 'overtime' %}active{% endif %}">🛰️ Overtime Finder</a>
-            <a href="{{ url_for('leave') }}" class="nav-link {% if request.endpoint == 'leave' %}active{% endif %}">📝 Leave / Sickness</a>
-            <a href="{{ url_for('reports_index') }}" class="nav-link {% if request.endpoint in ('reports_index','report_leave','report_fatigue','report_leave_year','report_leave_month','report_sickness') %}active{% endif %}">📑 Reports</a>
+          {% if current_user.role == 'superadmin' %}
+            <a href="{{ url_for('platform_admin') }}" class="nav-link {% if request.endpoint == 'platform_admin' %}active{% endif %}">🛡️ Platform Admin</a>
+          {% else %}
+            <a href="{{ url_for('index') }}" class="nav-link {% if request.endpoint == 'roster_month' %}active{% endif %}">📅 Roster</a>
+            <a href="{{ url_for('requests_page') }}" class="nav-link {% if request.endpoint == 'requests_page' %}active{% endif %}">📝 Requests</a>
+            <a href="{{ url_for('staff_profile', sid=current_user.id) }}" class="nav-link {% if request.endpoint == 'staff_profile' %}active{% endif %}">👤 Profile</a>
+            {% if is_admin or is_editor %}
+              <a href="{{ url_for('overtime') }}" class="nav-link {% if request.endpoint == 'overtime' %}active{% endif %}">🛰️ Overtime Finder</a>
+              <a href="{{ url_for('leave') }}" class="nav-link {% if request.endpoint == 'leave' %}active{% endif %}">📝 Leave / Sickness</a>
+              <a href="{{ url_for('reports_index') }}" class="nav-link {% if request.endpoint in ('reports_index','report_leave','report_fatigue','report_leave_year','report_leave_month','report_sickness') %}active{% endif %}">📑 Reports</a>
+            {% endif %}
+            {% if is_admin %}
+              <a href="{{ url_for('unit_accounts') }}" class="nav-link {% if request.endpoint == 'unit_accounts' %}active{% endif %}">👥 Accounts</a>
+              <a href="{{ url_for('admin') }}" class="nav-link {% if request.endpoint == 'admin' %}active{% endif %}">⚙️ Admin</a>
+            {% endif %}
           {% endif %}
-          {% if is_admin %}
-            <a href="{{ url_for('admin') }}" class="nav-link {% if request.endpoint == 'admin' %}active{% endif %}">⚙️ Admin</a>
-          {% endif %}
-
           <a href="{{ url_for('logout') }}" class="nav-link">🚪 Logout</a>
         {% else %}
           <a href="{{ url_for('login') }}" class="nav-link {% if request.endpoint == 'login' %}active{% endif %}">🔐 Login</a>

--- a/templates/platform_admin.html
+++ b/templates/platform_admin.html
@@ -3,20 +3,51 @@
 {% block content %}
 <div class="container my-4">
   <h2>Platform Administration</h2>
-  <p class="text-muted">Privacy-safe airport account and service-health aggregates. Personnel and roster data are intentionally unavailable.</p>
+  <p class="text-muted">Create and operate airport accounts using privacy-safe metadata. Personnel and roster data are not available here.</p>
+
+  <section class="card card-body mb-4">
+    <h3>Create airport account</h3>
+    <form method="post" class="row g-3">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+      <input type="hidden" name="action" value="create_unit">
+      <div class="col-md-2"><label>Airport code<input class="form-control" name="code" maxlength="12" required placeholder="LBA"></label></div>
+      <div class="col-md-4"><label>Airport name<input class="form-control" name="name" required></label></div>
+      <div class="col-md-3"><label>Plan<select class="form-select" name="plan"><option>starter</option><option>standard</option><option>professional</option><option>enterprise</option></select></label></div>
+      <div class="col-md-3"><label>Active-user limit<input class="form-control" type="number" name="active_user_limit" min="1" max="10000" value="10" required></label></div>
+      <div class="col-md-4"><label>Initial Unit Admin name<input class="form-control" name="admin_name" required></label></div>
+      <div class="col-md-4"><label>Initial Unit Admin username<input class="form-control" name="admin_username" required></label></div>
+      <div class="col-md-4"><label>Temporary password<input class="form-control" type="password" name="admin_password" minlength="12" required autocomplete="new-password"></label></div>
+      <div class="col-12"><button class="btn btn-primary" type="submit">Create airport and Unit Admin</button></div>
+    </form>
+  </section>
+
   <div class="table-responsive">
     <table class="table">
-      <thead><tr><th>Airport</th><th>Status / plan</th><th>Accounts</th><th>Features</th><th>Database</th><th>Usage</th><th>Dates</th></tr></thead>
+      <thead><tr><th>Airport</th><th>Status / plan</th><th>Active accounts</th><th>Features</th><th>Database</th><th>Usage</th><th>Account controls</th></tr></thead>
       <tbody>
       {% for row in rows %}
         <tr>
-          <td>{{ row.unit.name }} ({{ row.unit.code }})</td>
+          <td><strong>{{ row.unit.name }}</strong><br><code>{{ row.unit.code }}</code></td>
           <td>{{ row.unit.status }} / {{ row.unit.plan }}</td>
           <td>{{ row.active_accounts }} / {{ row.unit.active_user_limit }}</td>
-          <td>{% for key, enabled in row.flags.items() if enabled %}<span class="badge bg-secondary">{{ key }}</span> {% endfor %}</td>
-          <td>{{ row.database_health }} · {{ row.migration_version or "unreported" }} · {{ row.storage_bytes }} bytes</td>
+          <td>{% for key, enabled in row.flags.items() if enabled %}<span class="badge bg-secondary">{{ key }}</span> {% else %}—{% endfor %}</td>
+          <td>{{ row.database_health }} · {{ row.migration_version or "unreported" }}<br>{{ row.storage_bytes }} bytes</td>
           <td>{{ row.activity_count }} aggregate events</td>
-          <td>Created {{ row.unit.created_at }}<br>Trial {{ row.unit.trial_ends_at or "—" }}<br>Renewal {{ row.unit.renews_at or "—" }}<br>Last active {{ row.unit.last_active_at or "—" }}</td>
+          <td>
+            <form method="post" class="d-flex gap-2 mb-2">
+              <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+              <input type="hidden" name="action" value="update_limit">
+              <input type="hidden" name="unit_id" value="{{ row.unit.id }}">
+              <input class="form-control form-control-sm" type="number" name="active_user_limit" min="{{ row.active_accounts }}" max="10000" value="{{ row.unit.active_user_limit }}" aria-label="Active-user limit for {{ row.unit.code }}">
+              <button class="btn btn-sm" type="submit">Update limit</button>
+            </form>
+            <form method="post">
+              <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+              <input type="hidden" name="action" value="toggle_suspension">
+              <input type="hidden" name="unit_id" value="{{ row.unit.id }}">
+              <button class="btn btn-sm" type="submit">{{ "Restore" if row.unit.status == "suspended" else "Suspend" }}</button>
+            </form>
+          </td>
         </tr>
       {% else %}
         <tr><td colspan="7">No airport accounts.</td></tr>

--- a/templates/unit_accounts.html
+++ b/templates/unit_accounts.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+{% block title %}Account Management{% endblock %}
+{% block content %}
+<div class="container my-4">
+  <h2>Account management</h2>
+  <div class="alert {{ 'alert-danger' if active_count >= unit.active_user_limit else 'alert-info' }}" role="status">
+    <strong>{{ active_count }} of {{ unit.active_user_limit }}</strong> active accounts used.
+    {% if active_count >= unit.active_user_limit %}Deactivate an account before adding another.{% endif %}
+  </div>
+
+  <section class="card card-body mb-4">
+    <h3>Create and activate account</h3>
+    <form method="post" class="row g-3">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+      <input type="hidden" name="action" value="create_account">
+      <div class="col-md-4"><label>Name<input class="form-control" name="name" required></label></div>
+      <div class="col-md-4"><label>Username<input class="form-control" name="username" required></label></div>
+      <div class="col-md-4"><label>Temporary password<input class="form-control" type="password" name="password" minlength="12" required autocomplete="new-password"></label></div>
+      <div class="col-12"><button class="btn btn-primary" type="submit" {% if active_count >= unit.active_user_limit %}disabled{% endif %}>Activate account</button></div>
+    </form>
+  </section>
+
+  <table class="table">
+    <thead><tr><th>Account reference</th><th>Role</th><th>Status</th><th>Action</th></tr></thead>
+    <tbody>
+    {% for membership in memberships %}
+      <tr>
+        <td>#{{ membership.id }}</td>
+        <td>{{ membership.role }}</td>
+        <td>{{ membership.status }}</td>
+        <td>
+          {% if membership.status == "active" and membership.person_id != current_user.id %}
+          <form method="post">
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+            <input type="hidden" name="action" value="deactivate">
+            <input type="hidden" name="membership_id" value="{{ membership.id }}">
+            <button class="btn btn-sm" type="submit">Deactivate</button>
+          </form>
+          {% else %}—{% endif %}
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/tests/test_platform_admin.py
+++ b/tests/test_platform_admin.py
@@ -1,0 +1,114 @@
+import app
+from app import (
+    PlatformIdentity, Staff, Unit, UnitMembership, Watch, db,
+)
+
+
+def _csrf(client, path):
+    response = client.get(path)
+    assert response.status_code == 200
+    with client.session_transaction() as session:
+        return session["_csrf_token"]
+
+
+def _login(client, username, password):
+    response = client.post(
+        "/login", data={"username": username, "password": password}
+    )
+    assert response.status_code == 302
+
+
+def test_super_admin_provisions_airport_and_account_limit_is_transactional():
+    with app.app.app_context():
+        db.drop_all()
+        db.create_all()
+        control = Unit(
+            code="CTRL", name="Platform Control", status="platform_control",
+            active_user_limit=1,
+        )
+        db.session.add(control)
+        db.session.flush()
+        platform_user = Staff(
+            unit_id=control.id, username="platform.admin",
+            name="Platform Administrator", staff_no="CTRL-1",
+            role="superadmin", is_operational=False,
+        )
+        platform_user.set_password("Platform-Test-2026!")
+        db.session.add(platform_user)
+        db.session.flush()
+        db.session.add(PlatformIdentity(
+            public_id="platform-admin-test",
+            username=platform_user.username,
+            password_hash=platform_user.password_hash,
+        ))
+        db.session.commit()
+        app.migrate_add_role_and_calendar_token()
+        assert db.session.get(Staff, platform_user.id).role == "superadmin"
+
+    super_client = app.app.test_client()
+    _login(super_client, "platform.admin", "Platform-Test-2026!")
+    token = _csrf(super_client, "/platform/admin")
+    created = super_client.post(
+        "/platform/admin",
+        data={
+            "_csrf_token": token,
+            "action": "create_unit",
+            "code": "TST",
+            "name": "Test Airport",
+            "plan": "starter",
+            "active_user_limit": "2",
+            "admin_name": "Initial Unit Admin",
+            "admin_username": "tst.admin",
+            "admin_password": "UnitAdmin-Test-2026!",
+        },
+        follow_redirects=True,
+    )
+    assert created.status_code == 200
+    assert b"Test Airport created" in created.data
+    # The control-plane listing does not display personnel details.
+    assert b"tst.admin" not in created.data
+
+    with app.app.app_context():
+        unit = Unit.query.filter_by(code="TST").one()
+        assert unit.active_user_limit == 2
+        memberships = UnitMembership.query.filter_by(unit_id=unit.id).all()
+        assert len(memberships) == 1
+        assert memberships[0].status == "active"
+
+    unit_client = app.app.test_client()
+    _login(unit_client, "tst.admin", "UnitAdmin-Test-2026!")
+    unit_token = _csrf(unit_client, "/unit/accounts")
+    second = unit_client.post(
+        "/unit/accounts",
+        data={
+            "_csrf_token": unit_token,
+            "action": "create_account",
+            "name": "Second Account",
+            "username": "tst.user2",
+            "password": "Second-Test-2026!",
+        },
+        follow_redirects=True,
+    )
+    assert b"Account activated" in second.data
+    assert b"2 of 2" in second.data
+
+    blocked = unit_client.post(
+        "/unit/accounts",
+        data={
+            "_csrf_token": unit_token,
+            "action": "create_account",
+            "name": "Blocked Account",
+            "username": "tst.user3",
+            "password": "Blocked-Test-2026!",
+        },
+        follow_redirects=True,
+    )
+    assert b"Active account limit reached" in blocked.data
+    with app.app.app_context():
+        assert db.session.query(Staff).execution_options(
+            skip_tenant_scope=True
+        ).filter_by(username="tst.user3").first() is None
+        unit = Unit.query.filter_by(code="TST").one()
+        assert UnitMembership.query.filter_by(
+            unit_id=unit.id, status="active"
+        ).count() == 2

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -99,6 +99,12 @@ def test_login_page_loads(client):
     assert b"Login" in resp.data
 
 
+def test_favicon_is_served(client):
+    resp = client.get("/favicon.ico")
+    assert resp.status_code == 200
+    assert resp.mimetype == "image/svg+xml"
+
+
 def test_index_redirects_to_roster(client):
     login(client)
     resp = client.get("/")
@@ -130,6 +136,63 @@ def test_admin_pages_accessible(client):
     for url in endpoints:
         resp = client.get(url)
         assert resp.status_code == 200, f"Endpoint {url} returned {resp.status_code}"
+
+
+def test_admin_can_configure_requestable_shift(client):
+    login(client)
+    with app.app.app_context():
+        shift = ShiftType.query.filter_by(code="M").one()
+        shift_id = shift.id
+
+    response = client.post(
+        "/admin",
+        data={
+            "form": "shift_edit",
+            "shift_id": shift_id,
+            "name": "Morning",
+            "start": "07:00",
+            "end": "15:00",
+            "is_working": "on",
+            "is_active": "on",
+            "is_requestable": "on",
+            "required_qualification": "medical",
+        },
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert b"Shift updated" in response.data
+    assert b"Requestable" in response.data
+    assert b"Required qualification" in response.data
+
+    with app.app.app_context():
+        shift = db.session.get(ShiftType, shift_id)
+        assert shift.is_active is True
+        assert shift.is_requestable is True
+        assert shift.required_qualification == "medical"
+
+
+def test_non_working_shift_cannot_be_requestable(client):
+    login(client)
+    with app.app.app_context():
+        shift = ShiftType.query.filter_by(code="OFF").one()
+        shift_id = shift.id
+
+    response = client.post(
+        "/admin",
+        data={
+            "form": "shift_edit",
+            "shift_id": shift_id,
+            "name": "Off",
+            "is_active": "on",
+            "is_requestable": "on",
+        },
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert b"Only active working shifts can be requestable" in response.data
+
+    with app.app.app_context():
+        assert db.session.get(ShiftType, shift_id).is_requestable is False
 
 
 def test_admin_staff_edit_handles_missing_watch_history(client):

--- a/tests/test_shift_request_security.py
+++ b/tests/test_shift_request_security.py
@@ -141,6 +141,38 @@ def test_invalid_status_and_cross_unit_isolation(secured_client):
     assert b"UNIT-B-SECRET" not in page.data
 
 
+def test_sequential_tenant_sessions_do_not_reuse_first_unit_filter(secured_client):
+    with app.app.app_context():
+        user_a = Staff.query.filter_by(username="user-a").one()
+        user_b = Staff.query.filter_by(username="user-b").one()
+        db.session.add_all([
+            ShiftRequest(
+                unit_id=1, staff_id=user_a.id, day=request_day(), code="REQ",
+                requester_comment="AIRPORT-A-ONLY",
+            ),
+            ShiftRequest(
+                unit_id=2, staff_id=user_b.id, day=request_day(), code="REQ",
+                requester_comment="AIRPORT-B-ONLY",
+            ),
+        ])
+        db.session.commit()
+
+    login(secured_client, "user-a")
+    airport_a = secured_client.get("/requests")
+    assert b"AIRPORT-A-ONLY" in airport_a.data
+    assert b"AIRPORT-B-ONLY" not in airport_a.data
+    assert b"Airport A" in airport_a.data
+    assert b">AAA<" in airport_a.data
+
+    second_client = app.app.test_client()
+    login(second_client, "user-b")
+    airport_b = second_client.get("/requests")
+    assert b"AIRPORT-B-ONLY" in airport_b.data
+    assert b"AIRPORT-A-ONLY" not in airport_b.data
+    assert b"Airport B" in airport_b.data
+    assert b">BBB<" in airport_b.data
+
+
 def test_approve_only_then_apply_and_notify(secured_client):
     with app.app.app_context():
         user = Staff.query.filter_by(username="user-a").one()


### PR DESCRIPTION
## What changed
- adds platform super-admin airport setup and per-airport user limits
- adds airport account management and clearer airport identity in the header
- reorganises the airport admin page into focused, searchable sections
- adds regression coverage for platform administration, account limits, and shift-request security

## Why
Makes multi-airport administration easier to operate while enforcing tenant account limits and retaining airport isolation.

## Validation
- 27 automated tests pass
- git diff --check passes
- admin section navigation, staff search, and add-shift panel smoke-tested in the browser