### PR TITLE
Build pilot-ready compliance and staff experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ After signing in:
 - Use **Roster** for the monthly operational view.
 - Use **Shift Requests** to request a future requestable shift or, as a Unit
   Admin, respond to requests.
+- Use **Published** to review and acknowledge the currently released roster
+  version.
 - Check the airport name and code in the page header before making changes.
 - Use **Admin** for staffing requirements, shift definitions, people, and
   unit tools.
@@ -65,12 +67,19 @@ After signing in:
 - Use **Reports** for fatigue, sickness, leave-year, overtime, swap, and
   extension information.
 - Use **Qualification compliance** at `/compliance`.
+- Use **Compliance** at `/compliance-centre` for explainable fatigue findings
+  and the regulator/auditor evidence export.
 - Use **Coverage heatmap** at `/planning/coverage/YYYY-MM`.
 - Use **Roster scenarios** at `/planning/scenarios`.
 - Use **Airport onboarding** at `/unit/onboarding`.
 
 Dates are displayed using the airport configuration. Server timestamps and
 audit events are recorded in UTC.
+
+On a supported mobile browser, install ATCRoster from the browser's **Add to
+Home Screen** or **Install app** action. The service worker caches only static
+application assets; authenticated roster pages and personnel data are not
+stored for offline viewing.
 
 ## Unit administration workspace
 
@@ -98,7 +107,9 @@ unless they also have an active login membership.
 
 ## Airport onboarding
 
-Unit Admins complete the ten-stage wizard at `/unit/onboarding`:
+Unit Admins open `/unit/onboarding` to see a live readiness score based on the
+airport's actual configuration. The checklist links directly to each setup
+area and covers:
 
 1. Enter airport name/code, timezone, locale, date format, and branding.
 2. Configure watches or teams.
@@ -109,8 +120,8 @@ Unit Admins complete the ten-stage wizard at `/unit/onboarding`:
 6. Enter staffing requirements.
 7. Configure fatigue rules and the shift-request window/deadline.
 8. Import CSV data after reviewing the validation preview.
-9. Invite Unit Admins.
-10. Review the go-live checklist.
+9. Activate Unit Admin access.
+10. Review compliance, publication, restore and go-live acceptance.
 
 Do not go live until the timezone, request deadline, working/non-working codes,
 qualifications, staffing requirements, and initial roster have been checked by
@@ -146,9 +157,13 @@ assignment.
 
 ### Publication and acknowledgement
 
-Roster publication records support `draft`, `published`, and `superseded`
-states with versioned snapshots. Staff acknowledgements are stored against a
-specific published version. A rollback must create or restore an auditable
+Open **Published** or `/publications/YYYY-MM`. A Unit Admin can publish the
+current month after reviewing the Compliance Centre. Publication creates an
+immutable JSON snapshot and notifies active operational staff.
+
+Publishing a replacement marks the previous version `superseded`; it does not
+delete it. Staff acknowledge the active version, and acknowledgements remain
+tied to that exact version. A rollback must create or restore an auditable
 version; it must not erase intervening history.
 
 ## Shift requests
@@ -253,6 +268,20 @@ The dashboard at `/compliance` categorises qualifications as:
 Configure warning periods per qualification type; the standard defaults are
 180, 90, 60, and 30 days. Assignment and request-application checks must use
 the current airport’s qualification records only.
+
+### Fatigue and Compliance Centre
+
+Unit Admins and roster editors open `/compliance-centre?ym=YYYY-MM` to review:
+
+- total and critical fatigue findings;
+- affected controllers;
+- the source date, assigned shift and rule explanation;
+- findings grouped by controller and by frequent rule.
+
+The **Evidence CSV** export records airport, month, ATCO, date, severity, rule
+and the explainable finding. It is intended to support competent human review,
+not declare a roster legally compliant. Correct the roster or record an
+authorised decision through the controlled change process before publication.
 
 ## Coverage and scenario planning
 
@@ -389,6 +418,7 @@ Run behind an HTTPS reverse proxy and set:
 ```text
 FLASK_SECRET_KEY=<high-entropy deployment secret>
 DATABASE_URL=<database URL for the selected deployment role>
+ATCROSTER_SECURE_COOKIES=true
 ```
 
 ### Native desktop mode
@@ -458,6 +488,12 @@ record before go-live.
 - Tenant context comes from the authenticated membership.
 - Cross-airport reads, writes, references, and admin actions return no data.
 - Passwords use Werkzeug’s password hashing; never store plaintext passwords.
+- Password changes require the current password, CSRF validation and a new
+  password of at least 12 characters.
+- Cookies are HTTP-only and SameSite=Lax; production must enable secure
+  cookies.
+- Responses set clickjacking, MIME-sniffing, referrer and browser-permission
+  protections, with HSTS on HTTPS.
 - Invitation tokens must be random, store only a digest, expire, and be
   single-use.
 - Add MFA challenge enforcement at the identity layer before enabling
@@ -511,6 +547,10 @@ python -m compileall -q app.py tenancy.py saas_models.py account_limits.py scrip
 
 For production, add integration tests against PostgreSQL and the deployment’s
 secret manager, backup service, email/SMS provider, and reverse proxy.
+
+See [SECURITY.md](SECURITY.md) for production requirements and known gaps, and
+[docs/pilot_readiness.md](docs/pilot_readiness.md) for the recommended pilot
+acceptance and evidence plan.
 
 ## Troubleshooting
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# ATCRoster Security
+
+## Reporting a vulnerability
+
+Do not open a public issue containing credentials, personal data, tenant data,
+or exploit details. Send a private report to the repository owner with:
+
+- the affected version and deployment type;
+- reproduction steps using non-production data;
+- likely impact;
+- any suggested mitigation.
+
+Rotate exposed secrets immediately. Preserve relevant audit records and avoid
+copying operational personnel data into the report.
+
+## Current security controls
+
+- Airport context is derived from the authenticated user, never a form or query
+  parameter.
+- Operational models are tenant-filtered and cross-airport writes are rejected.
+- Passwords are stored using Werkzeug password hashing.
+- Privileged and sensitive write routes use CSRF tokens.
+- Login rotates session state.
+- Cookies are HTTP-only and SameSite=Lax. Production deployments must set
+  `ATCROSTER_SECURE_COOKIES=true`.
+- Responses set clickjacking, MIME-sniffing, referrer and browser-permission
+  protections. HTTPS responses enable HSTS.
+- Roster publications are immutable versioned snapshots; acknowledgements are
+  tied to a specific version.
+- Compliance and platform exports contain only the data necessary for their
+  stated purpose.
+
+## Production requirements
+
+Before processing live operational data:
+
+1. Use PostgreSQL and a unique high-entropy `FLASK_SECRET_KEY`.
+2. Terminate TLS at a maintained reverse proxy and force HTTPS.
+3. Enable secure cookies.
+4. Restrict database and backup credentials through a managed secret store.
+5. Enable MFA or organisation SSO before internet-facing production use.
+6. Configure encrypted backups and complete a witnessed restore test.
+7. Run dependency, static-analysis, tenant-isolation and penetration tests.
+8. Define log retention, incident response, access review and leaver processes.
+9. Complete a DPIA and agree controller/processor responsibilities.
+10. Obtain independent aviation operational acceptance. The software provides
+    decision support and does not itself certify regulatory compliance.
+
+## Known readiness gaps
+
+The repository does not currently claim Cyber Essentials, ISO 27001, SOC 2,
+CAA approval or EASA certification. Passkeys, MFA, enterprise SSO, centralised
+rate limiting and SIEM integration remain required for a broadly available
+hosted service.

--- a/app.py
+++ b/app.py
@@ -54,6 +54,12 @@ app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {
     "max_overflow": 5,
 }
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+app.config["SESSION_COOKIE_HTTPONLY"] = True
+app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+app.config["SESSION_COOKIE_SECURE"] = os.environ.get("ATCROSTER_SECURE_COOKIES", "").lower() in {
+    "1", "true", "yes"
+}
+app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(hours=12)
 
 # Make external URLs prefer https behind PA’s proxy
 app.config["PREFERRED_URL_SCHEME"] = "https"
@@ -137,6 +143,21 @@ def _bind_tenant_context():
         unit_id = int(getattr(current_user, "unit_id", 0) or 0)
         if unit_id:
             g.tenant_context_token = bind_authenticated_unit(unit_id)
+
+
+@app.after_request
+def _security_headers(response):
+    response.headers.setdefault("X-Content-Type-Options", "nosniff")
+    response.headers.setdefault("X-Frame-Options", "DENY")
+    response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
+    response.headers.setdefault(
+        "Permissions-Policy", "camera=(), microphone=(), geolocation=()"
+    )
+    if request.is_secure:
+        response.headers.setdefault(
+            "Strict-Transport-Security", "max-age=31536000; includeSubDomains"
+        )
+    return response
 
 
 @app.teardown_request
@@ -1881,6 +1902,120 @@ def would_create_new_fatigue_issues(
             new_flags[d] = diff
     return new_flags
 
+
+def _compliance_month(ym: str | None) -> tuple[int, int]:
+    today = date.today()
+    value = (ym or f"{today.year:04d}-{today.month:02d}").strip()
+    if not re.fullmatch(r"\d{4}-\d{2}", value):
+        abort(400, "Month must use YYYY-MM.")
+    year, month = map(int, value.split("-"))
+    if month not in range(1, 13):
+        abort(400, "Invalid month.")
+    return year, month
+
+
+def _compliance_findings(year: int, month: int) -> dict:
+    _, days = month_range(year, month)
+    people = (
+        Staff.query.filter_by(is_operational=True)
+        .outerjoin(Watch, Staff.watch_id == Watch.id)
+        .order_by(Watch.order_index, Staff.name)
+        .all()
+    )
+    rows = []
+    rule_counts: Counter[str] = Counter()
+    for person in people:
+        flags = fatigue_flags_for_range(person, days)
+        issues = []
+        for finding_day, messages in sorted(flags.items()):
+            assignment = Assignment.query.filter_by(
+                staff_id=person.id, day=finding_day
+            ).first()
+            for message in messages:
+                rule = message.split(":", 1)[0].split("(", 1)[0].strip()
+                severity = "critical" if any(
+                    token in message
+                    for token in ("<11h", "3rd consecutive", ">200h", "> 10h")
+                ) else "warning"
+                rule_counts[rule] += 1
+                issues.append({
+                    "day": finding_day,
+                    "message": message,
+                    "rule": rule,
+                    "severity": severity,
+                    "assignment": assignment,
+                })
+        rows.append({"staff": person, "issues": issues, "total": len(issues)})
+    total = sum(row["total"] for row in rows)
+    return {
+        "days": days,
+        "rows": rows,
+        "total": total,
+        "affected": sum(1 for row in rows if row["total"]),
+        "critical": sum(
+            1 for row in rows for issue in row["issues"]
+            if issue["severity"] == "critical"
+        ),
+        "rule_counts": rule_counts.most_common(),
+    }
+
+
+@app.route("/compliance-centre")
+@login_required
+def compliance_centre():
+    if not is_admin_user(current_user):
+        abort(403)
+    year, month = _compliance_month(request.args.get("ym"))
+    findings = _compliance_findings(year, month)
+    py, pm = _month_add(year, month, -1)
+    ny, nm = _month_add(year, month, 1)
+    return render_template(
+        "compliance_centre.html",
+        ym=f"{year:04d}-{month:02d}",
+        month_title=date(year, month, 1).strftime("%B %Y"),
+        prev_ym=f"{py:04d}-{pm:02d}",
+        next_ym=f"{ny:04d}-{nm:02d}",
+        **findings,
+    )
+
+
+@app.route("/compliance-centre/export")
+@login_required
+def compliance_centre_export():
+    if not is_admin_user(current_user):
+        abort(403)
+    year, month = _compliance_month(request.args.get("ym"))
+    findings = _compliance_findings(year, month)
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow([
+        "Airport", "Month", "ATCO", "Staff number", "Watch", "Date",
+        "Severity", "Rule", "Finding",
+    ])
+    unit = db.session.get(Unit, _current_unit_id())
+    for row in findings["rows"]:
+        person = row["staff"]
+        for issue in row["issues"]:
+            writer.writerow([
+                unit.code if unit else "",
+                f"{year:04d}-{month:02d}",
+                person.name,
+                person.staff_no,
+                person.watch.name if person.watch else "",
+                issue["day"].isoformat(),
+                issue["severity"],
+                issue["rule"],
+                issue["message"],
+            ])
+    return Response(
+        output.getvalue(),
+        mimetype="text/csv; charset=utf-8",
+        headers={
+            "Content-Disposition":
+                f"attachment; filename=compliance-evidence-{year:04d}-{month:02d}.csv"
+        },
+    )
+
 # -------------------- Migrations / seeding --------------------
 
 
@@ -2639,6 +2774,7 @@ def admin_required(f):
 def password_change():
     """Allow any logged-in user to reset OWN password."""
     if request.method == "POST":
+        _validate_csrf()
         cur = request.form.get("current_password", "")
         new1 = request.form.get("new_password", "")
         new2 = request.form.get("confirm_password", "")
@@ -2647,6 +2783,12 @@ def password_change():
             return redirect(url_for("password_change"))
         if not new1 or new1 != new2:
             flash("New passwords do not match.", "error")
+            return redirect(url_for("password_change"))
+        if len(new1) < 12:
+            flash("Use a password of at least 12 characters.", "error")
+            return redirect(url_for("password_change"))
+        if new1 == cur:
+            flash("Choose a password different from the current password.", "error")
             return redirect(url_for("password_change"))
         u = db.session.get(Staff, current_user.id)
         u.set_password(new1)
@@ -2663,6 +2805,147 @@ def password_change():
 def index():
     t = date.today()
     return redirect(url_for("roster_month", ym=f"{t.year}-{t.month:02d}"))
+
+
+def _roster_snapshot(year: int, month: int) -> dict:
+    start = date(year, month, 1)
+    ny, nm = _month_add(year, month, 1)
+    end = date(ny, nm, 1)
+    assignments = (
+        Assignment.query.filter(
+            Assignment.day >= start, Assignment.day < end
+        )
+        .order_by(Assignment.staff_id, Assignment.day)
+        .all()
+    )
+    return {
+        "generated_at": utcnow().isoformat(),
+        "year": year,
+        "month": month,
+        "assignments": [
+            {
+                "staff_id": row.staff_id,
+                "day": row.day.isoformat(),
+                "code": row.code,
+                "annotation": row.annotation or "",
+            }
+            for row in assignments
+        ],
+    }
+
+
+@app.route("/publications")
+@login_required
+def publication_index():
+    today = date.today()
+    return redirect(url_for(
+        "publication_centre", ym=f"{today.year:04d}-{today.month:02d}"
+    ))
+
+
+@app.route("/publications/<ym>", methods=["GET", "POST"])
+@login_required
+def publication_centre(ym):
+    year, month = _compliance_month(ym)
+    if request.method == "POST":
+        _validate_csrf()
+        action = (request.form.get("action") or "").strip()
+        if action == "publish":
+            if not is_admin_user(current_user):
+                abort(403)
+            current = (
+                RosterPublication.query.filter_by(
+                    year=year, month=month, state="published"
+                )
+                .order_by(RosterPublication.version.desc())
+                .first()
+            )
+            latest_version = (
+                db.session.query(db.func.max(RosterPublication.version))
+                .filter(
+                    RosterPublication.unit_id == _current_unit_id(),
+                    RosterPublication.year == year,
+                    RosterPublication.month == month,
+                )
+                .scalar()
+                or 0
+            )
+            if current:
+                current.state = "superseded"
+                current.superseded_at = utcnow()
+            publication = RosterPublication(
+                unit_id=_current_unit_id(),
+                year=year, month=month,
+                version=latest_version + 1,
+                state="published",
+                snapshot_json=json.dumps(_roster_snapshot(year, month)),
+                published_at=utcnow(),
+            )
+            db.session.add(publication)
+            for person in Staff.query.filter_by(
+                is_operational=True, membership_status="active"
+            ).all():
+                db.session.add(Notification(
+                    unit_id=_current_unit_id(),
+                    recipient_id=person.id,
+                    kind="roster_published",
+                    message=(
+                        f"{date(year, month, 1).strftime('%B %Y')} roster "
+                        f"version {publication.version} is ready to review."
+                    ),
+                ))
+            db.session.commit()
+            log_change(
+                "RosterPublication", publication.id, "state", "draft",
+                "published", context_day=date(year, month, 1),
+            )
+            flash(f"Roster version {publication.version} published.", "ok")
+            return redirect(url_for("publication_centre", ym=ym))
+        if action == "acknowledge":
+            publication_id = int(request.form.get("publication_id") or 0)
+            publication = RosterPublication.query.filter_by(
+                id=publication_id, year=year, month=month, state="published"
+            ).first_or_404()
+            existing = RosterAcknowledgement.query.filter_by(
+                publication_id=publication.id, person_id=current_user.id
+            ).first()
+            if not existing:
+                db.session.add(RosterAcknowledgement(
+                    unit_id=_current_unit_id(),
+                    publication_id=publication.id,
+                    person_id=current_user.id,
+                ))
+                db.session.commit()
+            flash("Roster acknowledgement recorded.", "ok")
+            return redirect(url_for("publication_centre", ym=ym))
+        abort(400)
+
+    publications = (
+        RosterPublication.query.filter_by(year=year, month=month)
+        .order_by(RosterPublication.version.desc())
+        .all()
+    )
+    active = next((row for row in publications if row.state == "published"), None)
+    acknowledged = False
+    acknowledgements = []
+    if active:
+        acknowledgements = RosterAcknowledgement.query.filter_by(
+            publication_id=active.id
+        ).all()
+        acknowledged = any(
+            row.person_id == current_user.id for row in acknowledgements
+        )
+    py, pm = _month_add(year, month, -1)
+    ny, nm = _month_add(year, month, 1)
+    return render_template(
+        "publication_centre.html",
+        ym=ym, year=year, month=month,
+        month_title=date(year, month, 1).strftime("%B %Y"),
+        publications=publications, active=active,
+        acknowledgements=acknowledgements, acknowledged=acknowledged,
+        operational_count=Staff.query.filter_by(is_operational=True).count(),
+        prev_ym=f"{py:04d}-{pm:02d}", next_ym=f"{ny:04d}-{nm:02d}",
+    )
 
 
 def _clamp_prev_next(year, month):
@@ -4004,6 +4287,8 @@ def leave():
 @login_required
 def staff_profile(sid):
     s = Staff.query.get_or_404(sid)
+    if s.id != current_user.id and not is_editor_user(current_user):
+        abort(403)
     today = date.today()
 
     # ensure_month_requirement(today.year, today.month)
@@ -4048,10 +4333,51 @@ def staff_profile(sid):
         from urllib.parse import quote
         google_link = f"https://calendar.google.com/calendar/r?cid={quote(cal_link)}"
 
-    return render_template("staff_profile.html", staff=s,
-                           al_days=al_days, sick_days=sick_days,
-                           hours_this_month=hours_this_month,
-                           cal_link=cal_link, apple_link=apple_link, google_link=google_link)
+    upcoming = (
+        Assignment.query.filter(
+            Assignment.staff_id == s.id,
+            Assignment.day >= today,
+            Assignment.day <= today + timedelta(days=45),
+        )
+        .order_by(Assignment.day.asc())
+        .all()
+    )
+    next_duty = next(
+        (a for a in upcoming if getattr(get_shift(a.code), "is_working", False)),
+        None,
+    )
+    recent_requests = (
+        ShiftRequest.query.filter_by(staff_id=s.id)
+        .order_by(ShiftRequest.updated_at.desc())
+        .limit(5)
+        .all()
+    )
+    notifications = (
+        Notification.query.filter_by(recipient_id=s.id)
+        .order_by(Notification.created_at.desc())
+        .limit(8)
+        .all()
+    )
+    return render_template(
+        "staff_profile.html", staff=s,
+        al_days=al_days, sick_days=sick_days,
+        hours_this_month=hours_this_month,
+        cal_link=cal_link, apple_link=apple_link, google_link=google_link,
+        upcoming=upcoming[:10], next_duty=next_duty,
+        recent_requests=recent_requests, notifications=notifications,
+        unread_notifications=sum(1 for item in notifications if not item.read_at),
+    )
+
+
+@app.post("/notifications/read")
+@login_required
+def notifications_read():
+    _validate_csrf()
+    Notification.query.filter_by(
+        recipient_id=current_user.id, read_at=None
+    ).update({"read_at": utcnow()})
+    db.session.commit()
+    return redirect(url_for("staff_profile", sid=current_user.id))
 
 # -------------------- Metrics + CSV (date range; FYTD default) --------------------
 # (… unchanged metrics functions from your file …)
@@ -5337,9 +5663,22 @@ def unit_onboarding():
         return redirect(url_for("unit_onboarding"))
     active = UnitMembership.query.filter_by(unit_id=unit.id, status="active").count()
     pending = UnitMembership.query.filter_by(unit_id=unit.id, status="invited").count()
+    readiness = [
+        ("Airport identity", bool(unit.name and unit.code and unit.timezone), "unit_onboarding"),
+        ("Watches configured", Watch.query.count() > 0, "admin"),
+        ("Active shifts configured", ShiftType.query.filter_by(is_active=True).count() > 0, "admin"),
+        ("Operational staff added", Staff.query.filter_by(is_operational=True).count() > 0, "admin"),
+        ("Staffing requirements set", Requirement.query.count() > 0, "admin"),
+        ("Qualification types set", QualificationType.query.count() > 0, "qualification_compliance"),
+        ("Compliance review available", True, "compliance_centre"),
+        ("Unit Admin access active", active > 0, "unit_accounts"),
+    ]
+    readiness_complete = sum(1 for _, complete, _ in readiness if complete)
     return render_template(
         "unit_onboarding.html", unit=unit, active_accounts=active,
-        pending_invitations=pending,
+        pending_invitations=pending, readiness=readiness,
+        readiness_complete=readiness_complete,
+        readiness_percent=round(readiness_complete / len(readiness) * 100),
     )
 
 

--- a/docs/pilot_readiness.md
+++ b/docs/pilot_readiness.md
@@ -1,0 +1,44 @@
+# Pilot readiness and acceptance plan
+
+This document is a reusable starting point for a controlled airport pilot. It
+is not legal, regulatory or safety assurance advice.
+
+## Entry criteria
+
+- Named pilot sponsor, Unit Admin and operational safety owner
+- Approved non-production or representative test dataset
+- Completed data-flow map and DPIA screening
+- Agreed support hours, escalation contacts and incident process
+- PostgreSQL environment with TLS, managed secrets and encrypted backups
+- MFA or SSO implementation appropriate to the pilot exposure
+
+## Acceptance scenarios
+
+1. Create an airport and its initial Unit Admin.
+2. Verify that users cannot read or change another airport's data.
+3. Configure watches, shifts, qualifications and staffing requirements.
+4. Import or create a representative roster and reconcile record counts.
+5. Exercise leave, sickness, requests, overtime and account-limit workflows.
+6. Review every Compliance Centre finding with the operational safety owner.
+7. Publish a roster replacement and verify supersession history.
+8. Record staff acknowledgement against the correct publication version.
+9. Export audit and compliance evidence and confirm minimised content.
+10. Restore the control and airport databases into an isolated environment.
+11. Test loss of network, expired sessions and disabled accounts.
+12. Complete keyboard, screen-reader, mobile and print checks.
+
+## Exit criteria
+
+- No open critical security or tenant-isolation defects
+- No unexplained data-reconciliation differences
+- Restore time and recovery point accepted by the sponsor
+- Fatigue-rule configuration signed off by a competent operational owner
+- Staff and administrator training completed
+- Support, rollback and data-exit processes rehearsed
+- Formal go/no-go decision recorded outside the application
+
+## Evidence pack
+
+Retain test results, rule configuration, screenshots, export samples,
+penetration-test summary, accessibility review, restore evidence, approval
+record and the version/commit used for the pilot.

--- a/static/manifest.webmanifest
+++ b/static/manifest.webmanifest
@@ -1,0 +1,17 @@
+{
+  "name": "ATC Roster",
+  "short_name": "ATCRoster",
+  "description": "Compliance-first ATCO roster and workforce management.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#101923",
+  "theme_color": "#16283a",
+  "icons": [
+    {
+      "src": "/static/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}

--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -1,0 +1,22 @@
+const CACHE = "atcroster-shell-v1";
+const SHELL = ["/static/styles.css", "/static/favicon.svg", "/static/manifest.webmanifest"];
+
+self.addEventListener("install", event => {
+  event.waitUntil(caches.open(CACHE).then(cache => cache.addAll(SHELL)));
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(keys.filter(key => key !== CACHE).map(key => caches.delete(key))))
+  );
+  self.clients.claim();
+});
+
+self.addEventListener("fetch", event => {
+  const url = new URL(event.request.url);
+  if (event.request.method !== "GET" || url.origin !== self.location.origin || !url.pathname.startsWith("/static/")) return;
+  event.respondWith(
+    caches.match(event.request).then(cached => cached || fetch(event.request))
+  );
+});

--- a/static/styles.css
+++ b/static/styles.css
@@ -1323,3 +1323,95 @@ table.roster { transform-origin: top left; transform: scale(var(--ui-scale)); }
 /* EM uses Morning colour */
 .code-input.em { background: var(--yellow); color: #000; }
 .code-input.group-e { background: var(--yellow); color: #000; }
+
+/* Compliance centre */
+.compliance-hero {
+  display: flex; align-items: flex-end; justify-content: space-between; gap: 1.5rem;
+  padding: 1.5rem; margin-bottom: 1rem; border: 1px solid rgba(83,170,255,.24);
+  border-radius: 18px; background: linear-gradient(135deg, rgba(30,68,105,.42), rgba(16,28,42,.92));
+}
+.compliance-hero h2 { margin: .25rem 0 .4rem; }
+.compliance-hero p { max-width: 760px; margin: 0; color: var(--muted, #aab7c4); }
+.compliance-actions { display: flex; flex-wrap: wrap; gap: .55rem; }
+.compliance-summary { display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); gap: .8rem; margin-bottom: 1rem; }
+.compliance-summary article { padding: 1rem 1.1rem; border: 1px solid rgba(255,255,255,.1); border-radius: 14px; background: rgba(255,255,255,.035); }
+.compliance-summary span { display: block; color: var(--muted, #aab7c4); font-size: .82rem; }
+.compliance-summary strong { display: block; margin-top: .2rem; font-size: 1.65rem; }
+.compliance-layout { display: grid; grid-template-columns: minmax(0,2fr) minmax(260px,.8fr); gap: 1rem; }
+.compliance-list { display: grid; gap: .7rem; }
+.compliance-person { border: 1px solid rgba(255,255,255,.1); border-radius: 12px; overflow: hidden; }
+.compliance-person summary { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: .9rem 1rem; cursor: pointer; }
+.compliance-person summary small { display: block; margin-top: .2rem; color: var(--muted, #aab7c4); }
+.compliance-issues { display: grid; gap: .6rem; padding: 0 1rem 1rem; }
+.compliance-issue { padding: .8rem; border-left: 4px solid #d89b32; border-radius: 8px; background: rgba(216,155,50,.08); }
+.compliance-issue.critical { border-color: #e46464; background: rgba(228,100,100,.08); }
+.compliance-issue p { margin: .55rem 0 .25rem; }
+.compliance-issue small { color: var(--muted, #aab7c4); }
+.compliance-clear { padding: .8rem 1rem; margin: 0; color: #75d69c; }
+.compliance-rule { display: flex; justify-content: space-between; gap: 1rem; padding: .55rem 0; border-bottom: 1px solid rgba(255,255,255,.08); }
+.compliance-workflow { padding-left: 1.2rem; color: var(--muted, #aab7c4); }
+.compliance-workflow li + li { margin-top: .45rem; }
+@media (max-width: 900px) {
+  .compliance-hero { align-items: flex-start; flex-direction: column; }
+  .compliance-summary { grid-template-columns: repeat(2,minmax(0,1fr)); }
+  .compliance-layout { grid-template-columns: 1fr; }
+}
+
+/* Mobile-first staff dashboard */
+.profile-hero { display:flex; justify-content:space-between; align-items:flex-end; gap:1rem; padding:1.4rem; margin-bottom:1rem; border-radius:18px; background:linear-gradient(135deg,rgba(37,92,126,.55),rgba(22,31,45,.95)); border:1px solid rgba(83,170,255,.2); }
+.profile-hero h2 { margin:.25rem 0; }
+.profile-hero p { margin:0; color:var(--muted,#aab7c4); }
+.next-duty { min-width:260px; padding:1rem; border-radius:12px; background:rgba(255,255,255,.07); }
+.next-duty span,.next-duty small { display:block; color:var(--muted,#aab7c4); }
+.next-duty strong { display:block; margin:.25rem 0; }
+.profile-action-grid { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:.75rem; margin-bottom:1rem; }
+.profile-action-grid a { display:flex; align-items:center; gap:.8rem; padding:1rem; color:inherit; text-decoration:none; border:1px solid rgba(255,255,255,.1); border-radius:13px; background:rgba(255,255,255,.035); }
+.profile-action-grid a:hover { border-color:rgba(83,170,255,.5); transform:translateY(-1px); }
+.profile-action-grid i { color:#6eb9ff; font-size:1.25rem; }
+.profile-action-grid small { display:block; color:var(--muted,#aab7c4); }
+.profile-dashboard { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:1rem; }
+.profile-timeline { display:grid; gap:.4rem; }
+.profile-timeline > div { display:grid; grid-template-columns:minmax(105px,1fr) 60px 1fr; gap:.7rem; padding:.55rem 0; border-bottom:1px solid rgba(255,255,255,.08); }
+.profile-timeline time,.profile-timeline span { color:var(--muted,#aab7c4); }
+.profile-notifications { display:grid; gap:.65rem; }
+.profile-notifications article { padding:.7rem; border-left:3px solid transparent; }
+.profile-notifications article.unread { border-color:#58aef5; background:rgba(88,174,245,.07); }
+.profile-notifications p { margin:.25rem 0; }
+.profile-notifications small { color:var(--muted,#aab7c4); }
+.profile-requests > div { display:flex; justify-content:space-between; gap:1rem; padding:.55rem 0; border-bottom:1px solid rgba(255,255,255,.08); }
+.profile-stats { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:.8rem; }
+.profile-stats div { padding:.7rem; border-radius:10px; background:rgba(255,255,255,.035); }
+.profile-stats span { display:block; color:var(--muted,#aab7c4); font-size:.8rem; }
+.profile-stats strong { display:block; margin-top:.2rem; }
+.profile-calendar-url { display:block; margin-top:.7rem; padding:.7rem; overflow-wrap:anywhere; }
+@media (max-width: 760px) {
+  .profile-hero { align-items:stretch; flex-direction:column; }
+  .next-duty { min-width:0; }
+  .profile-action-grid,.profile-dashboard { grid-template-columns:1fr; }
+  .profile-action-grid { gap:.5rem; }
+  .profile-stats { grid-template-columns:1fr 1fr; }
+}
+.publication-grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:1rem; }
+.publication-current h3 { margin:.7rem 0 .25rem; }
+.publication-history { display:grid; gap:.65rem; }
+.publication-history article { display:flex; align-items:center; justify-content:space-between; gap:1rem; padding:.75rem; border:1px solid rgba(255,255,255,.08); border-radius:10px; }
+.publication-history article > div { display:flex; align-items:center; gap:.7rem; }
+.publication-history small { color:var(--muted,#aab7c4); text-align:right; }
+@media (max-width:760px) {
+  .publication-grid { grid-template-columns:1fr; }
+  .publication-history article { align-items:flex-start; flex-direction:column; }
+  .publication-history small { text-align:left; }
+}
+.onboarding-score { display:grid; place-items:center; min-width:100px; padding:1rem; border-radius:50%; aspect-ratio:1; background:rgba(83,170,255,.12); border:2px solid rgba(83,170,255,.55); }
+.onboarding-score strong { font-size:1.5rem; }
+.onboarding-score span { color:var(--muted,#aab7c4); font-size:.8rem; }
+.onboarding-progress { height:10px; margin:-.4rem 0 1rem; overflow:hidden; border-radius:999px; background:rgba(255,255,255,.08); }
+.onboarding-progress span { display:block; height:100%; border-radius:inherit; background:linear-gradient(90deg,#3f8ddd,#61d59a); }
+.onboarding-layout { display:grid; grid-template-columns:minmax(0,1.1fr) minmax(0,1fr); gap:1rem; }
+.onboarding-checklist { display:grid; gap:.5rem; }
+.onboarding-checklist a { display:grid; grid-template-columns:24px 1fr auto; gap:.6rem; align-items:center; padding:.7rem; color:inherit; text-decoration:none; border:1px solid rgba(255,255,255,.08); border-radius:10px; }
+.onboarding-checklist a.complete i { color:#61d59a; }
+.onboarding-checklist small { color:var(--muted,#aab7c4); }
+@media (max-width:760px) {
+  .onboarding-layout { grid-template-columns:1fr; }
+}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -188,6 +188,7 @@
       <a href="{{ url_for('change_log_page') }}"><i class="fa-solid fa-list-check"></i><span><strong>Change log</strong><small>Review administrative history</small></span></a>
       <a href="{{ url_for('unit_accounts') }}"><i class="fa-solid fa-users-gear"></i><span><strong>Login accounts</strong><small>Usage, limits and deactivation</small></span></a>
       <a href="{{ url_for('unit_onboarding') }}"><i class="fa-solid fa-plane-circle-check"></i><span><strong>Onboarding</strong><small>Airport setup checklist</small></span></a>
+      <a href="{{ url_for('compliance_centre') }}"><i class="fa-solid fa-shield-heart"></i><span><strong>Compliance centre</strong><small>Explainable fatigue findings and evidence export</small></span></a>
     </div>
   </section>
 </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="dark">
   <link rel="icon" href="{{ url_for('favicon') }}" type="image/svg+xml">
+  <link rel="manifest" href="{{ url_for('static', filename='manifest.webmanifest') }}">
+  <meta name="theme-color" content="#16283a">
   <title>{% block title %}{% endblock %} – ATC Roster</title>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -45,11 +47,13 @@
           {% else %}
             <a href="{{ url_for('index') }}" class="nav-link {% if request.endpoint == 'roster_month' %}active{% endif %}">📅 Roster</a>
             <a href="{{ url_for('requests_page') }}" class="nav-link {% if request.endpoint == 'requests_page' %}active{% endif %}">📝 Requests</a>
+            <a href="{{ url_for('publication_index') }}" class="nav-link {% if request.endpoint in ('publication_index','publication_centre') %}active{% endif %}">✅ Published</a>
             <a href="{{ url_for('staff_profile', sid=current_user.id) }}" class="nav-link {% if request.endpoint == 'staff_profile' %}active{% endif %}">👤 Profile</a>
             {% if is_admin or is_editor %}
               <a href="{{ url_for('overtime') }}" class="nav-link {% if request.endpoint == 'overtime' %}active{% endif %}">🛰️ Overtime Finder</a>
               <a href="{{ url_for('leave') }}" class="nav-link {% if request.endpoint == 'leave' %}active{% endif %}">📝 Leave / Sickness</a>
               <a href="{{ url_for('reports_index') }}" class="nav-link {% if request.endpoint in ('reports_index','report_leave','report_fatigue','report_leave_year','report_leave_month','report_sickness') %}active{% endif %}">📑 Reports</a>
+              <a href="{{ url_for('compliance_centre') }}" class="nav-link {% if request.endpoint in ('compliance_centre','compliance_centre_export') %}active{% endif %}">🛡️ Compliance</a>
             {% endif %}
             {% if is_admin %}
               <a href="{{ url_for('unit_accounts') }}" class="nav-link {% if request.endpoint == 'unit_accounts' %}active{% endif %}">👥 Accounts</a>
@@ -93,6 +97,10 @@
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
   <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => navigator.serviceWorker.register('/static/service-worker.js'));
+    }
+
     function printRoster(){ window.print(); }
 
     // Auto-fit roster to viewport (scale UI, avoid horizontal scroll)

--- a/templates/compliance_centre.html
+++ b/templates/compliance_centre.html
@@ -1,0 +1,76 @@
+{% extends "base.html" %}
+{% block title %}Compliance Centre · {{ month_title }}{% endblock %}
+{% block content %}
+<section class="compliance-hero">
+  <div>
+    <span class="admin-step">Decision support</span>
+    <h2>Fatigue &amp; Compliance Centre</h2>
+    <p>Explainable roster findings for {{ month_title }}. Findings require competent human review and do not constitute a regulatory determination.</p>
+  </div>
+  <div class="compliance-actions">
+    <a class="btn" href="{{ url_for('compliance_centre', ym=prev_ym) }}">← {{ prev_ym }}</a>
+    <a class="btn" href="{{ url_for('compliance_centre', ym=next_ym) }}">{{ next_ym }} →</a>
+    <a class="btn btn-primary" href="{{ url_for('compliance_centre_export', ym=ym) }}"><i class="fa-solid fa-file-arrow-down"></i> Evidence CSV</a>
+  </div>
+</section>
+
+<div class="compliance-summary" aria-label="Compliance summary">
+  <article><span>Total findings</span><strong>{{ total }}</strong></article>
+  <article><span>Critical findings</span><strong>{{ critical }}</strong></article>
+  <article><span>People affected</span><strong>{{ affected }}</strong></article>
+  <article><span>ATCOs reviewed</span><strong>{{ rows|length }}</strong></article>
+</div>
+
+<div class="compliance-layout">
+  <section class="card">
+    <div class="card-hd">Findings by controller</div>
+    <div class="card-bd compliance-list">
+      {% for row in rows %}
+        <details class="compliance-person" {% if row.total and loop.index <= 3 %}open{% endif %}>
+          <summary>
+            <span><strong>{{ row.staff.name }}</strong><small>{{ row.staff.watch.name if row.staff.watch else 'No watch' }} · {{ row.staff.staff_no }}</small></span>
+            <span class="status-pill {{ 'danger' if row.total else 'success' }}">{{ row.total }} finding{{ '' if row.total == 1 else 's' }}</span>
+          </summary>
+          {% if row.issues %}
+            <div class="compliance-issues">
+              {% for issue in row.issues %}
+                <article class="compliance-issue {{ issue.severity }}">
+                  <div>
+                    <span class="status-pill {{ 'danger' if issue.severity == 'critical' else 'warning' }}">{{ issue.severity }}</span>
+                    <strong>{{ issue.day.strftime('%a %d %b') }} · {{ issue.rule }}</strong>
+                  </div>
+                  <p>{{ issue.message }}</p>
+                  <small>Assigned shift: {{ issue.assignment.code if issue.assignment else 'Not available' }}</small>
+                </article>
+              {% endfor %}
+            </div>
+          {% else %}
+            <p class="compliance-clear"><i class="fa-solid fa-circle-check"></i> No fatigue-rule findings in this month.</p>
+          {% endif %}
+        </details>
+      {% else %}
+        <p>No operational staff are configured.</p>
+      {% endfor %}
+    </div>
+  </section>
+
+  <aside class="card">
+    <div class="card-hd">Most frequent rules</div>
+    <div class="card-bd">
+      {% for rule, count in rule_counts %}
+        <div class="compliance-rule"><span>{{ rule }}</span><strong>{{ count }}</strong></div>
+      {% else %}
+        <p class="compliance-clear">No findings to group.</p>
+      {% endfor %}
+      <hr>
+      <h3>Review workflow</h3>
+      <ol class="compliance-workflow">
+        <li>Confirm the shift and source data.</li>
+        <li>Review the cited rule and operational context.</li>
+        <li>Correct the roster or record an authorised decision in the change log.</li>
+        <li>Export evidence after the roster is final.</li>
+      </ol>
+    </div>
+  </aside>
+</div>
+{% endblock %}

--- a/templates/password.html
+++ b/templates/password.html
@@ -6,14 +6,15 @@
     <div class="card-hd"><i class="fa-solid fa-key"></i> Change Password</div>
     <div class="card-bd">
       <form method="post" class="grid">
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
         <label>Current password
           <input type="password" name="current_password" required>
         </label>
         <label>New password
-          <input type="password" name="new_password" required>
+          <input type="password" name="new_password" minlength="12" autocomplete="new-password" required>
         </label>
         <label>Confirm new password
-          <input type="password" name="confirm_password" required>
+          <input type="password" name="confirm_password" minlength="12" autocomplete="new-password" required>
         </label>
         <div>
           <button class="btn"><i class="fa-solid fa-floppy-disk"></i> Update</button>

--- a/templates/publication_centre.html
+++ b/templates/publication_centre.html
@@ -1,0 +1,75 @@
+{% extends "base.html" %}
+{% block title %}Published Roster · {{ month_title }}{% endblock %}
+{% block content %}
+<section class="compliance-hero">
+  <div>
+    <span class="admin-step">Controlled roster release</span>
+    <h2>{{ month_title }} publication</h2>
+    <p>Published versions are immutable snapshots. Publishing a replacement supersedes—but does not erase—the previous version.</p>
+  </div>
+  <div class="compliance-actions">
+    <a class="btn" href="{{ url_for('publication_centre', ym=prev_ym) }}">← {{ prev_ym }}</a>
+    <a class="btn" href="{{ url_for('roster_month', ym=ym) }}">Open roster</a>
+    <a class="btn" href="{{ url_for('publication_centre', ym=next_ym) }}">{{ next_ym }} →</a>
+  </div>
+</section>
+
+<div class="publication-grid">
+  <section class="card">
+    <div class="card-hd">Current status</div>
+    <div class="card-bd">
+      {% if active %}
+        <div class="publication-current">
+          <span class="status-pill success">Published</span>
+          <h3>Version {{ active.version }}</h3>
+          <p>Published {{ active.published_at.strftime('%d %b %Y at %H:%M') }}</p>
+          <p><strong>{{ acknowledgements|length }}</strong> of <strong>{{ operational_count }}</strong> operational staff acknowledged.</p>
+          {% if acknowledged %}
+            <p class="compliance-clear"><i class="fa-solid fa-circle-check"></i> You acknowledged this version.</p>
+          {% else %}
+            <form method="post">
+              <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+              <input type="hidden" name="action" value="acknowledge">
+              <input type="hidden" name="publication_id" value="{{ active.id }}">
+              <button class="btn btn-primary" type="submit">Acknowledge version {{ active.version }}</button>
+            </form>
+          {% endif %}
+        </div>
+      {% else %}
+        <p>No roster version has been published for this month.</p>
+      {% endif %}
+    </div>
+  </section>
+
+  {% if is_admin %}
+  <section class="card">
+    <div class="card-hd">Unit Admin action</div>
+    <div class="card-bd">
+      <p>Run the compliance review before publishing. This creates a permanent snapshot and notifies active operational staff.</p>
+      <div class="compliance-actions">
+        <a class="btn" href="{{ url_for('compliance_centre', ym=ym) }}">Review compliance</a>
+        <form method="post">
+          <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+          <input type="hidden" name="action" value="publish">
+          <button class="btn btn-primary" type="submit">{{ 'Publish replacement' if active else 'Publish roster' }}</button>
+        </form>
+      </div>
+    </div>
+  </section>
+  {% endif %}
+</div>
+
+<section class="card mt-3">
+  <div class="card-hd">Version history</div>
+  <div class="card-bd publication-history">
+    {% for publication in publications %}
+      <article>
+        <div><strong>Version {{ publication.version }}</strong><span class="status-pill {{ 'success' if publication.state == 'published' else 'muted' }}">{{ publication.state }}</span></div>
+        <small>Published {{ publication.published_at.strftime('%d %b %Y %H:%M') if publication.published_at else 'Not published' }}{% if publication.superseded_at %} · superseded {{ publication.superseded_at.strftime('%d %b %Y %H:%M') }}{% endif %}</small>
+      </article>
+    {% else %}
+      <p>No publication history.</p>
+    {% endfor %}
+  </div>
+</section>
+{% endblock %}

--- a/templates/staff_profile.html
+++ b/templates/staff_profile.html
@@ -1,46 +1,113 @@
 {% extends "base.html" %}
 {% block title %}{{ staff.name }} · ATC Roster{% endblock %}
 {% block content %}
-<h1><i class="fa-regular fa-user"></i> {{ staff.name }}</h1>
-
-<div class="grid grid-3">
-  <div class="card">
-    <div class="card-hd">Summary</div>
-    <div class="card-bd grid">
-      <div><strong>Staff #:</strong> {{ staff.staff_no }}</div>
-      <div><strong>Watch:</strong> {{ staff.watch.name if staff.watch else '-' }}</div>
-      <div><strong>Role:</strong> {{ staff.role }}</div>
-      <div><strong>Phone:</strong> {{ staff.phone_number or '—' }}</div>
-      <div><strong>AL (last 12 months):</strong> {{ al_days }}</div>
-      <div><strong>Sickness (SC/SSC, last 12 months):</strong> {{ sick_days }}</div>
-      <div><strong>Rostered hours this month:</strong> {{ hours_this_month }}</div>
-    </div>
+<section class="profile-hero">
+  <div>
+    <span class="admin-step">My operational dashboard</span>
+    <h2>{{ staff.name }}</h2>
+    <p>{{ staff.watch.name if staff.watch else 'No watch assigned' }} · {{ staff.staff_no }}</p>
   </div>
+  {% if next_duty %}
+    <article class="next-duty">
+      <span>Next duty</span>
+      <strong>{{ next_duty.code }} · {{ next_duty.day.strftime('%A %d %B') }}</strong>
+      <small>{{ next_duty.annotation or 'No annotation' }}</small>
+    </article>
+  {% else %}
+    <article class="next-duty"><span>Next duty</span><strong>None scheduled</strong><small>within 45 days</small></article>
+  {% endif %}
+</section>
 
-  <div class="card">
-    <div class="card-hd">Certificates</div>
-    <div class="card-bd grid">
-      <div><strong>Tower UE:</strong> {{ staff.tower_ue_expiry or '—' }}</div>
-      <div><strong>Radar UE:</strong> {{ staff.radar_ue_expiry or '—' }}</div>
-      <div><strong>Met:</strong> {{ staff.met_ue_expiry or '—' }}</div>
-      <div><strong>Medical:</strong> {{ staff.medical_expiry or '—' }}</div>
+<div class="profile-action-grid">
+  <a href="{{ url_for('requests_page') }}"><i class="fa-solid fa-calendar-plus"></i><span><strong>Request a shift</strong><small>Submit or review requests</small></span></a>
+  <a href="{{ url_for('calendar_feed', sid=staff.id, token=staff.calendar_token) if staff.calendar_token else '#' }}"><i class="fa-regular fa-calendar"></i><span><strong>Roster calendar</strong><small>Subscribe on your phone</small></span></a>
+  <a href="{{ url_for('password_change') }}"><i class="fa-solid fa-key"></i><span><strong>Security</strong><small>Change your password</small></span></a>
+</div>
 
-    </div>
-  </div>
-
-  <div class="card">
-    <div class="card-hd">Calendar</div>
-    <div class="card-bd">
-      {% if cal_link %}
-        <p class="muted">Subscribe to your roster:</p>
-        <p><a href="{{ apple_link }}" class="btn">Add to Apple Calendar</a></p>
-        <p><a href="{{ google_link }}" class="btn">Add to Google Calendar</a></p>
-        <p class="muted">Or copy the ICS URL:</p>
-        <code>{{ cal_link }}</code>
+<div class="profile-dashboard">
+  <section class="card">
+    <div class="card-hd">Upcoming roster</div>
+    <div class="card-bd profile-timeline">
+      {% for assignment in upcoming %}
+        <div>
+          <time datetime="{{ assignment.day.isoformat() }}">{{ assignment.day.strftime('%a %d %b') }}</time>
+          <strong>{{ assignment.code }}</strong>
+          <span>{{ assignment.annotation or '—' }}</span>
+        </div>
       {% else %}
-        <p class="muted">No calendar token assigned.</p>
+        <p>No assignments are currently scheduled.</p>
+      {% endfor %}
+    </div>
+  </section>
+
+  <section class="card">
+    <div class="card-hd d-flex justify-content-between align-items-center">
+      <span>Notifications {% if unread_notifications %}<span class="status-pill warning">{{ unread_notifications }} new</span>{% endif %}</span>
+      {% if unread_notifications %}
+        <form method="post" action="{{ url_for('notifications_read') }}">
+          <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+          <button class="btn btn-sm" type="submit">Mark read</button>
+        </form>
       {% endif %}
     </div>
-  </div>
+    <div class="card-bd profile-notifications">
+      {% for item in notifications %}
+        <article class="{{ 'unread' if not item.read_at else '' }}">
+          <strong>{{ item.kind|replace('_',' ')|title }}</strong>
+          <p>{{ item.message }}</p>
+          <small>{{ item.created_at.strftime('%d %b %Y %H:%M') }}</small>
+        </article>
+      {% else %}
+        <p>No notifications.</p>
+      {% endfor %}
+    </div>
+  </section>
+
+  <section class="card">
+    <div class="card-hd">Recent requests</div>
+    <div class="card-bd profile-requests">
+      {% for item in recent_requests %}
+        <div><span>{{ item.day.strftime('%d %b') }} · {{ item.code }}</span><span class="status-pill {{ item.status }}">{{ item.status }}</span></div>
+      {% else %}
+        <p>No shift requests yet.</p>
+      {% endfor %}
+    </div>
+  </section>
+
+  <section class="card">
+    <div class="card-hd">Personal summary</div>
+    <div class="card-bd profile-stats">
+      <div><span>Rostered this month</span><strong>{{ hours_this_month }}h</strong></div>
+      <div><span>Annual leave, 12 months</span><strong>{{ al_days }}</strong></div>
+      <div><span>Sickness, 12 months</span><strong>{{ sick_days }}</strong></div>
+      <div><span>Role</span><strong>{{ staff.role|title }}</strong></div>
+    </div>
+  </section>
+
+  <section class="card">
+    <div class="card-hd">Qualifications</div>
+    <div class="card-bd profile-stats">
+      <div><span>Tower UE</span><strong>{{ staff.tower_ue_expiry or '—' }}</strong></div>
+      <div><span>Radar UE</span><strong>{{ staff.radar_ue_expiry or '—' }}</strong></div>
+      <div><span>MET</span><strong>{{ staff.met_ue_expiry or '—' }}</strong></div>
+      <div><span>Medical</span><strong>{{ staff.medical_expiry or '—' }}</strong></div>
+    </div>
+  </section>
+
+  <section class="card">
+    <div class="card-hd">Calendar subscription</div>
+    <div class="card-bd">
+      {% if cal_link %}
+        <p>Keep your personal calendar synchronized with roster changes.</p>
+        <div class="compliance-actions">
+          <a href="{{ apple_link }}" class="btn">Apple Calendar</a>
+          <a href="{{ google_link }}" class="btn">Google Calendar</a>
+        </div>
+        <details><summary>Manual subscription URL</summary><code class="profile-calendar-url">{{ cal_link }}</code></details>
+      {% else %}
+        <p>No calendar token is assigned. Ask a Unit Admin to create one.</p>
+      {% endif %}
+    </div>
+  </section>
 </div>
 {% endblock %}

--- a/templates/unit_onboarding.html
+++ b/templates/unit_onboarding.html
@@ -1,29 +1,61 @@
 {% extends "base.html" %}
 {% block title %}Airport Onboarding{% endblock %}
 {% block content %}
-<div class="container my-4">
-  <h2>Airport onboarding</h2>
-  <p>Step {{ unit.onboarding_step }} of 10 · active accounts {{ active_accounts }}/{{ unit.active_user_limit }} · pending invitations {{ pending_invitations }}</p>
-  <ol>
-    <li>Unit identity, locale and branding</li><li>Watches and teams</li>
-    <li>Shift definitions and templates</li><li>Qualification types</li>
-    <li>Qualification warning periods</li><li>Staffing requirements</li>
-    <li>Fatigue and request rules</li><li>CSV import preview</li>
-    <li>Invite Unit Admins</li><li>Go-live checklist</li>
-  </ol>
-  <form method="post" class="card card-body">
-    <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
-    <input type="hidden" name="step" value="{{ unit.onboarding_step }}">
-    {% if unit.onboarding_step == 1 %}
-      <label>Name <input class="form-control" name="name" value="{{ unit.name }}" required></label>
-      <label>Code <input class="form-control" name="code" value="{{ unit.code }}" required></label>
-      <label>Timezone <input class="form-control" name="timezone" value="{{ unit.timezone }}"></label>
-      <label>Locale <input class="form-control" name="locale" value="{{ unit.locale }}"></label>
-      <label>Date format <input class="form-control" name="date_format" value="{{ unit.date_format }}"></label>
-    {% else %}
-      <p>Configure this step using the linked unit administration screen, then continue.</p>
-    {% endif %}
-    <button class="btn btn-primary mt-3" type="submit">Save and continue</button>
-  </form>
+<section class="compliance-hero">
+  <div>
+    <span class="admin-step">Pilot readiness</span>
+    <h2>Airport onboarding</h2>
+    <p>{{ unit.name }} · {{ active_accounts }}/{{ unit.active_user_limit }} active accounts · {{ pending_invitations }} pending invitations</p>
+  </div>
+  <div class="onboarding-score" aria-label="{{ readiness_percent }} percent configured">
+    <strong>{{ readiness_percent }}%</strong><span>configured</span>
+  </div>
+</section>
+
+<div class="onboarding-progress" role="progressbar" aria-valuenow="{{ readiness_percent }}" aria-valuemin="0" aria-valuemax="100">
+  <span style="width:{{ readiness_percent }}%"></span>
 </div>
+
+<div class="onboarding-layout">
+  <section class="card">
+    <div class="card-hd">Configuration checklist · {{ readiness_complete }}/{{ readiness|length }}</div>
+    <div class="card-bd onboarding-checklist">
+      {% for label, complete, endpoint in readiness %}
+        <a href="{{ url_for(endpoint) }}" class="{{ 'complete' if complete else '' }}">
+          <i class="fa-solid {{ 'fa-circle-check' if complete else 'fa-circle' }}"></i>
+          <span>{{ label }}</span>
+          <small>{{ 'Configured' if complete else 'Needs attention' }}</small>
+        </a>
+      {% endfor %}
+    </div>
+  </section>
+
+  <section class="card">
+    <div class="card-hd">Airport identity</div>
+    <form method="post" class="card-bd grid">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+      <input type="hidden" name="step" value="1">
+      <label>Name <input class="form-control" name="name" value="{{ unit.name }}" required></label>
+      <label>Code <input class="form-control" name="code" value="{{ unit.code }}" pattern="[A-Za-z0-9]{2,12}" required></label>
+      <label>Timezone <input class="form-control" name="timezone" value="{{ unit.timezone }}" required></label>
+      <label>Locale <input class="form-control" name="locale" value="{{ unit.locale }}" required></label>
+      <label>Date format <input class="form-control" name="date_format" value="{{ unit.date_format }}" required></label>
+      <button class="btn btn-primary" type="submit">Save airport identity</button>
+    </form>
+  </section>
+</div>
+
+<section class="card mt-3">
+  <div class="card-hd">Recommended pilot sequence</div>
+  <div class="card-bd">
+    <ol class="compliance-workflow">
+      <li>Configure watches, shifts and staffing requirements.</li>
+      <li>Add operational staff and check their qualifications.</li>
+      <li>Import or build a representative roster month.</li>
+      <li>Review the Fatigue &amp; Compliance Centre with an authorised roster manager.</li>
+      <li>Publish a controlled version and test staff acknowledgement.</li>
+      <li>Complete restore, access-control and operational acceptance tests before live use.</li>
+    </ol>
+  </div>
+</section>
 {% endblock %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -93,6 +93,12 @@ def login(client):
     return response
 
 
+def csrf(client):
+    client.get("/publications/2025-04")
+    with client.session_transaction() as sess:
+        return sess["_csrf_token"]
+
+
 def test_login_page_loads(client):
     resp = client.get("/login")
     assert resp.status_code == 200
@@ -103,6 +109,53 @@ def test_favicon_is_served(client):
     resp = client.get("/favicon.ico")
     assert resp.status_code == 200
     assert resp.mimetype == "image/svg+xml"
+
+
+def test_compliance_centre_and_evidence_export(client):
+    login(client)
+    page = client.get("/compliance-centre?ym=2025-04")
+    assert page.status_code == 200
+    assert b"Fatigue &amp; Compliance Centre" in page.data
+    export = client.get("/compliance-centre/export?ym=2025-04")
+    assert export.status_code == 200
+    assert export.mimetype == "text/csv"
+    assert b"Airport,Month,ATCO" in export.data
+
+
+def test_roster_publication_and_acknowledgement(client):
+    login(client)
+    token = csrf(client)
+    published = client.post(
+        "/publications/2025-04",
+        data={"_csrf_token": token, "action": "publish"},
+        follow_redirects=True,
+    )
+    assert published.status_code == 200
+    assert b"Version 1" in published.data
+    with app.app.app_context():
+        publication = app.RosterPublication.query.filter_by(
+            year=2025, month=4, state="published"
+        ).first()
+        assert publication is not None
+        publication_id = publication.id
+    acknowledged = client.post(
+        "/publications/2025-04",
+        data={
+            "_csrf_token": token,
+            "action": "acknowledge",
+            "publication_id": publication_id,
+        },
+        follow_redirects=True,
+    )
+    assert acknowledged.status_code == 200
+    assert b"You acknowledged this version" in acknowledged.data
+
+
+def test_security_headers_are_present(client):
+    response = client.get("/login")
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+    assert response.headers["X-Frame-Options"] == "DENY"
+    assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
 
 
 def test_index_redirects_to_roster(client):


### PR DESCRIPTION
## What changed
- adds an explainable Fatigue & Compliance Centre with evidence CSV export
- adds controlled versioned roster publication, supersession, notifications and acknowledgements
- replaces the staff profile with a mobile-first operational dashboard and installable PWA shell
- adds configuration-readiness onboarding and a pilot acceptance plan
- hardens cookies, response headers and password changes
- updates the complete README user manual and adds a security policy

## Product impact
This creates a coherent pilot-ready workflow from airport configuration through compliance review, controlled publication and staff acknowledgement. It makes existing fatigue, calendar and notification foundations visible and useful without claiming regulatory certification.

## Validation
- 30 automated tests pass
- Python compilation passes
- git diff --check passes
- browser smoke-tested against the populated Leeds Bradford demo for compliance, publication, notifications, mobile staff dashboard and onboarding