### PR TITLE
Add accountable manager roster assurance

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,13 +158,29 @@ assignment.
 ### Publication and acknowledgement
 
 Open **Published** or `/publications/YYYY-MM`. A Unit Admin can publish the
-current month after reviewing the Compliance Centre. Publication creates an
-immutable JSON snapshot and notifies active operational staff.
+current month after completing the pre-publication assurance gate. The gate
+checks:
+
+- every operational controller has an explicit assignment for every day;
+- working shifts do not violate their configured required qualification;
+- Morning, Day, Afternoon and Night staffing meet the configured requirement;
+- all explainable fatigue findings have been reviewed.
+
+Missing assignments and required-qualification failures block publication.
+Remaining fatigue findings or staffing shortfalls require an accountable
+manager rationale of at least 20 characters. The manager must also confirm the
+release declaration covering competence, coverage, fatigue, breaks and
+operational contingencies.
+
+Publication creates an immutable JSON snapshot containing the roster and its
+release-assurance summary, records the declaration in the change log, and
+notifies active operational staff.
 
 Publishing a replacement marks the previous version `superseded`; it does not
 delete it. Staff acknowledge the active version, and acknowledgements remain
-tied to that exact version. A rollback must create or restore an auditable
-version; it must not erase intervening history.
+tied to that exact version. The publication screen lists staff still awaiting
+acknowledgement. A rollback must create or restore an auditable version; it
+must not erase intervening history.
 
 ## Shift requests
 
@@ -551,6 +567,9 @@ secret manager, backup service, email/SMS provider, and reverse proxy.
 See [SECURITY.md](SECURITY.md) for production requirements and known gaps, and
 [docs/pilot_readiness.md](docs/pilot_readiness.md) for the recommended pilot
 acceptance and evidence plan.
+
+The accountable-manager product assessment and remaining operational roadmap
+are recorded in [docs/atc_manager_review.md](docs/atc_manager_review.md).
 
 ## Troubleshooting
 

--- a/app.py
+++ b/app.py
@@ -2834,6 +2834,66 @@ def _roster_snapshot(year: int, month: int) -> dict:
     }
 
 
+def _publication_preflight(year: int, month: int) -> dict:
+    _, days = month_range(year, month)
+    staff = Staff.query.filter_by(is_operational=True).order_by(Staff.name).all()
+    assignments = Assignment.query.filter(
+        Assignment.day >= days[0], Assignment.day <= days[-1]
+    ).all()
+    assignment_map = {(row.staff_id, row.day): row for row in assignments}
+    requirement = Requirement.query.filter_by(year=year, month=month).first()
+    counts = {day: Counter() for day in days}
+    qualification_gaps = []
+    unassigned = []
+
+    for person in staff:
+        for day in days:
+            assignment = assignment_map.get((person.id, day))
+            if not assignment:
+                unassigned.append({"staff": person, "day": day})
+                continue
+            shift = get_shift(assignment.code)
+            if (
+                shift and shift.is_working and shift.required_qualification
+                and not _staff_has_shift_qualification(person, shift)
+            ):
+                qualification_gaps.append({
+                    "staff": person, "day": day, "shift": shift,
+                    "qualification": shift.required_qualification,
+                })
+            if (
+                shift and shift.is_working and not shift.is_training
+                and assignment.code not in get_exclude_from_counters()
+            ):
+                group = assignment.code[:1].upper()
+                if group in ("M", "D", "A", "N"):
+                    counts[day][group] += 1
+
+    coverage_gaps = []
+    for day in days:
+        for group in ("M", "D", "A", "N"):
+            needed = int(getattr(requirement, f"req_{group.lower()}", 0) or 0)
+            available = counts[day][group]
+            if available < needed:
+                coverage_gaps.append({
+                    "day": day, "group": group,
+                    "available": available, "needed": needed,
+                    "shortfall": needed - available,
+                })
+
+    fatigue = _compliance_findings(year, month)
+    return {
+        "fatigue_total": fatigue["total"],
+        "fatigue_critical": fatigue["critical"],
+        "coverage_gaps": coverage_gaps,
+        "qualification_gaps": qualification_gaps,
+        "unassigned": unassigned,
+        "hard_blocks": len(qualification_gaps) + len(unassigned),
+        "exceptions": fatigue["total"] + len(coverage_gaps),
+        "ready": not qualification_gaps and not unassigned,
+    }
+
+
 @app.route("/publications")
 @login_required
 def publication_index():
@@ -2853,6 +2913,31 @@ def publication_centre(ym):
         if action == "publish":
             if not is_admin_user(current_user):
                 abort(403)
+            preflight = _publication_preflight(year, month)
+            declaration = request.form.get("release_declaration") == "yes"
+            exception_reason = (
+                request.form.get("exception_reason") or ""
+            ).strip()
+            if preflight["hard_blocks"]:
+                flash(
+                    "Publication blocked: resolve all missing assignments and "
+                    "required-qualification failures first.",
+                    "error",
+                )
+                return redirect(url_for("publication_centre", ym=ym))
+            if not declaration:
+                flash(
+                    "Confirm the accountable manager release declaration before publishing.",
+                    "error",
+                )
+                return redirect(url_for("publication_centre", ym=ym))
+            if preflight["exceptions"] and len(exception_reason) < 20:
+                flash(
+                    "Record an exception rationale of at least 20 characters "
+                    "for fatigue findings or staffing shortfalls.",
+                    "error",
+                )
+                return redirect(url_for("publication_centre", ym=ym))
             current = (
                 RosterPublication.query.filter_by(
                     year=year, month=month, state="published"
@@ -2873,12 +2958,27 @@ def publication_centre(ym):
             if current:
                 current.state = "superseded"
                 current.superseded_at = utcnow()
+            snapshot = _roster_snapshot(year, month)
+            snapshot["release_assurance"] = {
+                "declared_by_id": current_user.id,
+                "declared_at": utcnow().isoformat(),
+                "declaration": (
+                    "Coverage, competence, fatigue findings and operational "
+                    "contingencies reviewed by the accountable roster manager."
+                ),
+                "exception_reason": exception_reason,
+                "fatigue_findings": preflight["fatigue_total"],
+                "critical_fatigue_findings": preflight["fatigue_critical"],
+                "coverage_shortfalls": len(preflight["coverage_gaps"]),
+                "qualification_failures": len(preflight["qualification_gaps"]),
+                "unassigned_cells": len(preflight["unassigned"]),
+            }
             publication = RosterPublication(
                 unit_id=_current_unit_id(),
                 year=year, month=month,
                 version=latest_version + 1,
                 state="published",
-                snapshot_json=json.dumps(_roster_snapshot(year, month)),
+                snapshot_json=json.dumps(snapshot),
                 published_at=utcnow(),
             )
             db.session.add(publication)
@@ -2897,7 +2997,10 @@ def publication_centre(ym):
             db.session.commit()
             log_change(
                 "RosterPublication", publication.id, "state", "draft",
-                "published", context_day=date(year, month, 1),
+                "published", note=(
+                    f"Manager declaration recorded. Exceptions: "
+                    f"{exception_reason or 'none'}"
+                ), context_day=date(year, month, 1),
             )
             flash(f"Roster version {publication.version} published.", "ok")
             return redirect(url_for("publication_centre", ym=ym))
@@ -2926,8 +3029,14 @@ def publication_centre(ym):
         .all()
     )
     active = next((row for row in publications if row.state == "published"), None)
+    preflight = _publication_preflight(year, month)
     acknowledged = False
     acknowledgements = []
+    expected_staff = Staff.query.filter_by(
+        is_operational=True, membership_status="active"
+    ).order_by(Staff.name).all()
+    unacknowledged_staff = []
+    release_assurance = {}
     if active:
         acknowledgements = RosterAcknowledgement.query.filter_by(
             publication_id=active.id
@@ -2935,6 +3044,16 @@ def publication_centre(ym):
         acknowledged = any(
             row.person_id == current_user.id for row in acknowledgements
         )
+        acknowledged_ids = {row.person_id for row in acknowledgements}
+        unacknowledged_staff = [
+            person for person in expected_staff if person.id not in acknowledged_ids
+        ]
+        try:
+            release_assurance = json.loads(
+                active.snapshot_json or "{}"
+            ).get("release_assurance", {})
+        except (TypeError, json.JSONDecodeError):
+            release_assurance = {}
     py, pm = _month_add(year, month, -1)
     ny, nm = _month_add(year, month, 1)
     return render_template(
@@ -2943,7 +3062,10 @@ def publication_centre(ym):
         month_title=date(year, month, 1).strftime("%B %Y"),
         publications=publications, active=active,
         acknowledgements=acknowledgements, acknowledged=acknowledged,
-        operational_count=Staff.query.filter_by(is_operational=True).count(),
+        operational_count=len(expected_staff),
+        unacknowledged_staff=unacknowledged_staff,
+        release_assurance=release_assurance,
+        preflight=preflight,
         prev_ym=f"{py:04d}-{pm:02d}", next_ym=f"{ny:04d}-{nm:02d}",
     )
 

--- a/docs/atc_manager_review.md
+++ b/docs/atc_manager_review.md
@@ -1,0 +1,72 @@
+# ATC unit manager product review
+
+Review perspective: the manager accountable for issuing a safe, workable unit
+roster. This is a product assessment, not regulatory approval.
+
+## What now meets the core planning need
+
+- Airport-separated people, accounts and operational data
+- Watches, shift definitions and monthly staffing requirements
+- Leave, sickness, shift requests, overtime and qualification visibility
+- Explainable duty/rest fatigue-rule findings
+- Daily staffing-shortfall detection before publication
+- Required-qualification validation before publication
+- Explicit assignment-completeness check
+- Accountable-manager declaration and exception rationale
+- Immutable publication versions, supersession and change history
+- Staff notification, calendar access and version acknowledgement
+- Evidence export and a usable mobile staff dashboard
+
+These functions support a controlled pilot in which the existing approved unit
+rostering system and competent human decisions remain authoritative.
+
+## Operational capabilities still required
+
+### Position and endorsement demand
+
+Requirements currently operate at Morning, Day, Afternoon and Night group
+level. A mature unit product should model operational positions, sector/tower
+endorsements, supervisor roles, traffic opening schemes and time-specific
+demand. Two controllers on the same shift are not interchangeable merely
+because the headcount matches.
+
+### Break and time-on-position planning
+
+The roster records duty periods, not operational position sessions. Add a
+daily deployment/break plan that records position, start/end, relief,
+maximum continuous operational time and the applicable duty-to-break ratio.
+
+### Planned versus achieved duty
+
+Record actual sign-on/off, extensions, call-outs, swaps and changes to duty
+nature. Compare achieved duty with the published roster and feed exceedances
+back into fatigue monitoring.
+
+### Fatigue reporting and SMS integration
+
+Provide a confidential controller fatigue self-report and manager assessment
+workflow linked to the organisation's Safety Management System. Trend roster
+patterns, sickness and reported fatigue without turning reports into punitive
+performance measures.
+
+### Formal rule governance
+
+Version the unit's approved rostering-system rule set with effective dates,
+consultation evidence, competent approver and change-management reference.
+Software defaults must never silently replace approved local arrangements.
+
+### Disruption and resilience
+
+Add minimum resilient staffing, contingency roles, temporary endorsement
+restrictions, equipment/position closures and short-notice operational
+revalidation before the watch begins.
+
+## Management conclusion
+
+ATCRoster now meets the needs of a roster-construction and controlled
+publication pilot better than a spreadsheet workflow. It does not yet replace
+the full approved unit rostering system or Safety Management System.
+
+The recommended next product increment is **position-based demand and
+competence coverage**, followed by **break/time-on-position planning** and
+**planned-versus-achieved duty monitoring**.

--- a/static/styles.css
+++ b/static/styles.css
@@ -1392,6 +1392,25 @@ table.roster { transform-origin: top left; transform: scale(var(--ui-scale)); }
   .profile-stats { grid-template-columns:1fr 1fr; }
 }
 .publication-grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:1rem; }
+.publication-assurance { grid-column:1 / -1; }
+.assurance-grid { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:.65rem; }
+.assurance-grid article { padding:.8rem; border:1px solid rgba(255,255,255,.1); border-radius:10px; background:rgba(255,255,255,.035); }
+.assurance-grid article.warning { border-color:rgba(216,155,50,.55); }
+.assurance-grid article.danger { border-color:rgba(228,100,100,.65); }
+.assurance-grid article.success { border-color:rgba(97,213,154,.4); }
+.assurance-grid span { display:block; color:var(--muted,#aab7c4); font-size:.78rem; }
+.assurance-grid strong { font-size:1.35rem; }
+.publication-block,.publication-warning { margin:1rem 0 .4rem; padding:.8rem; border-radius:9px; }
+.publication-block { color:#ffaaaa; background:rgba(228,100,100,.1); }
+.publication-warning { color:#f5c979; background:rgba(216,155,50,.1); }
+.assurance-exceptions { display:flex; flex-wrap:wrap; gap:.45rem; margin-top:.7rem; }
+.assurance-exceptions span { padding:.35rem .55rem; border-radius:999px; background:rgba(255,255,255,.06); font-size:.8rem; }
+.publication-release-form { display:grid; gap:.8rem; }
+.publication-release-form textarea { width:100%; }
+.release-declaration { align-items:flex-start; line-height:1.4; }
+.release-record { display:grid; grid-template-columns:max-content 1fr; gap:.35rem .8rem; margin:.7rem 0 0; }
+.release-record dt { color:var(--muted,#aab7c4); }
+.release-record dd { margin:0; }
 .publication-current h3 { margin:.7rem 0 .25rem; }
 .publication-history { display:grid; gap:.65rem; }
 .publication-history article { display:flex; align-items:center; justify-content:space-between; gap:1rem; padding:.75rem; border:1px solid rgba(255,255,255,.08); border-radius:10px; }
@@ -1399,6 +1418,7 @@ table.roster { transform-origin: top left; transform: scale(var(--ui-scale)); }
 .publication-history small { color:var(--muted,#aab7c4); text-align:right; }
 @media (max-width:760px) {
   .publication-grid { grid-template-columns:1fr; }
+  .assurance-grid { grid-template-columns:repeat(2,minmax(0,1fr)); }
   .publication-history article { align-items:flex-start; flex-direction:column; }
   .publication-history small { text-align:left; }
 }

--- a/templates/publication_centre.html
+++ b/templates/publication_centre.html
@@ -15,6 +15,46 @@
 </section>
 
 <div class="publication-grid">
+  <section class="card publication-assurance">
+    <div class="card-hd">Pre-publication assurance</div>
+    <div class="card-bd">
+      <div class="assurance-grid">
+        <article class="{{ 'danger' if preflight.unassigned else 'success' }}"><span>Unassigned cells</span><strong>{{ preflight.unassigned|length }}</strong></article>
+        <article class="{{ 'danger' if preflight.qualification_gaps else 'success' }}"><span>Competence failures</span><strong>{{ preflight.qualification_gaps|length }}</strong></article>
+        <article class="{{ 'warning' if preflight.coverage_gaps else 'success' }}"><span>Coverage shortfalls</span><strong>{{ preflight.coverage_gaps|length }}</strong></article>
+        <article class="{{ 'warning' if preflight.fatigue_total else 'success' }}"><span>Fatigue findings</span><strong>{{ preflight.fatigue_total }}</strong></article>
+      </div>
+      {% if preflight.hard_blocks %}
+        <p class="publication-block"><i class="fa-solid fa-ban"></i> Publication is blocked until every assignment and required qualification is valid.</p>
+      {% elif preflight.exceptions %}
+        <p class="publication-warning"><i class="fa-solid fa-triangle-exclamation"></i> Publication requires an accountable-manager exception rationale.</p>
+      {% else %}
+        <p class="compliance-clear"><i class="fa-solid fa-circle-check"></i> No automated release exceptions found.</p>
+      {% endif %}
+      {% if preflight.coverage_gaps %}
+        <details>
+          <summary>Review staffing shortfalls</summary>
+          <div class="assurance-exceptions">
+            {% for gap in preflight.coverage_gaps[:20] %}
+              <span>{{ gap.day.strftime('%d %b') }} · {{ gap.group }}: {{ gap.available }}/{{ gap.needed }}</span>
+            {% endfor %}
+            {% if preflight.coverage_gaps|length > 20 %}<span>+ {{ preflight.coverage_gaps|length - 20 }} more</span>{% endif %}
+          </div>
+        </details>
+      {% endif %}
+      {% if preflight.qualification_gaps %}
+        <details>
+          <summary>Review competence failures</summary>
+          <div class="assurance-exceptions">
+            {% for gap in preflight.qualification_gaps %}
+              <span>{{ gap.day.strftime('%d %b') }} · {{ gap.staff.name }} · {{ gap.shift.code }} requires {{ gap.qualification }}</span>
+            {% endfor %}
+          </div>
+        </details>
+      {% endif %}
+    </div>
+  </section>
+
   <section class="card">
     <div class="card-hd">Current status</div>
     <div class="card-bd">
@@ -24,6 +64,23 @@
           <h3>Version {{ active.version }}</h3>
           <p>Published {{ active.published_at.strftime('%d %b %Y at %H:%M') }}</p>
           <p><strong>{{ acknowledgements|length }}</strong> of <strong>{{ operational_count }}</strong> operational staff acknowledged.</p>
+          {% if release_assurance %}
+            <details>
+              <summary>Release assurance record</summary>
+              <dl class="release-record">
+                <dt>Fatigue findings</dt><dd>{{ release_assurance.fatigue_findings }}</dd>
+                <dt>Coverage shortfalls</dt><dd>{{ release_assurance.coverage_shortfalls }}</dd>
+                <dt>Competence failures</dt><dd>{{ release_assurance.qualification_failures }}</dd>
+                <dt>Manager rationale</dt><dd>{{ release_assurance.exception_reason or 'No exceptions recorded' }}</dd>
+              </dl>
+            </details>
+          {% endif %}
+          {% if unacknowledged_staff %}
+            <details>
+              <summary>{{ unacknowledged_staff|length }} awaiting acknowledgement</summary>
+              <p>{{ unacknowledged_staff|map(attribute='name')|join(', ') }}</p>
+            </details>
+          {% endif %}
           {% if acknowledged %}
             <p class="compliance-clear"><i class="fa-solid fa-circle-check"></i> You acknowledged this version.</p>
           {% else %}
@@ -45,15 +102,22 @@
   <section class="card">
     <div class="card-hd">Unit Admin action</div>
     <div class="card-bd">
-      <p>Run the compliance review before publishing. This creates a permanent snapshot and notifies active operational staff.</p>
-      <div class="compliance-actions">
+      <p>Run the compliance review, resolve all hard blocks, and record your accountable-manager declaration. Publishing creates a permanent snapshot and notifies active operational staff.</p>
+      <form method="post" class="publication-release-form">
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+        <input type="hidden" name="action" value="publish">
+        <label>Exception rationale
+          <textarea name="exception_reason" rows="3" maxlength="1000" placeholder="Required when fatigue findings or staffing shortfalls remain. Record the operational assessment and mitigations."></textarea>
+        </label>
+        <label class="checkbox release-declaration">
+          <input type="checkbox" name="release_declaration" value="yes" required>
+          I confirm that coverage, competence, fatigue findings, breaks and operational contingencies have been reviewed under the unit’s approved rostering system.
+        </label>
+        <div class="compliance-actions">
         <a class="btn" href="{{ url_for('compliance_centre', ym=ym) }}">Review compliance</a>
-        <form method="post">
-          <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
-          <input type="hidden" name="action" value="publish">
-          <button class="btn btn-primary" type="submit">{{ 'Publish replacement' if active else 'Publish roster' }}</button>
-        </form>
-      </div>
+          <button class="btn btn-primary" type="submit" {% if preflight.hard_blocks %}disabled aria-disabled="true"{% endif %}>{{ 'Publish replacement' if active else 'Publish roster' }}</button>
+        </div>
+      </form>
     </div>
   </section>
   {% endif %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -125,9 +125,23 @@ def test_compliance_centre_and_evidence_export(client):
 def test_roster_publication_and_acknowledgement(client):
     login(client)
     token = csrf(client)
-    published = client.post(
+    rejected = client.post(
         "/publications/2025-04",
         data={"_csrf_token": token, "action": "publish"},
+        follow_redirects=True,
+    )
+    assert b"release declaration" in rejected.data
+    published = client.post(
+        "/publications/2025-04",
+        data={
+            "_csrf_token": token,
+            "action": "publish",
+            "release_declaration": "yes",
+            "exception_reason": (
+                "Operational manager reviewed staffing and fatigue exceptions "
+                "with mitigations in place."
+            ),
+        },
         follow_redirects=True,
     )
     assert published.status_code == 200
@@ -137,6 +151,9 @@ def test_roster_publication_and_acknowledgement(client):
             year=2025, month=4, state="published"
         ).first()
         assert publication is not None
+        snapshot = app.json.loads(publication.snapshot_json)
+        assert snapshot["release_assurance"]["declared_by_id"]
+        assert snapshot["release_assurance"]["exception_reason"]
         publication_id = publication.id
     acknowledged = client.post(
         "/publications/2025-04",


### PR DESCRIPTION
## What changed
- adds a pre-publication gate for assignment completeness, competence, staffing coverage and fatigue findings
- blocks publication for missing assignments or required-qualification failures
- requires an accountable-manager declaration and rationale for remaining exceptions
- stores the assurance summary inside the immutable publication snapshot and change log
- shows staffing shortfalls, competence failures and staff awaiting acknowledgement
- adds an ATC unit manager product assessment and updates the user manual

## Why
The previous workflow allowed publication after merely linking to the compliance screen. An accountable unit manager needs a recorded, evidence-based release decision with hard safety blocks and visible operational exceptions.

## Validation
- 30 automated tests pass
- Python compilation and git diff checks pass
- browser-tested against the populated Leeds demo, including 99 staffing shortfalls, 96 fatigue findings, exception declaration, version supersession and persisted assurance rationale