### PR TITLE
Harden acceptance testing and role permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 __pycache__/
 *.pyc
 instance/roster.db
+instance/*.manifest.json
+instance/*.db-shm
+instance/*.db-wal
 env/
 .pytest_cache/
 *.sqlite3

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ aggregates only.
 | `RosterEditor` | Roster editing and permitted annotation application. Cannot edit annotation definitions. |
 | `WatchManager` | Explicitly granted watch and annotation actions only. |
 | `StaffUser` | Their own roster, requests, notifications, and permitted self-service functions. |
-| `ReadOnlyAuditor` | Read-only unit records and reports explicitly exposed for audit. |
+| `ReadOnlyAuditor` | Product target only; not currently provisionable. Do not offer until its read-only route/export contract is implemented and tested. |
 
 An operational `Person` does not need a login. Authentication belongs to a
 `PlatformIdentity`; airport access belongs to `UnitMembership`, which may link
@@ -76,6 +76,20 @@ After signing in:
 - Use **Coverage heatmap** at `/planning/coverage/YYYY-MM`.
 - Use **Roster scenarios** at `/planning/scenarios`.
 - Use **Airport onboarding** at `/unit/onboarding`.
+
+The shared interface includes:
+
+- a compact mobile **Menu** that keeps the current page and airport context
+  visible;
+- keyboard skip navigation, visible focus states and reduced-motion support;
+- persistent roster zoom presets at 75%, 90%, 100% and **Fit width**;
+- clear success/error announcements and purpose-built 400, 403, 404 and 500
+  recovery pages;
+- duplicate-submit protection on write forms;
+- confirmation before deleting requests, leave/sickness records or
+  deactivating accounts;
+- CSRF protection on leave/sickness, overtime, requests, publication,
+  operational assurance, accounts and platform administration workflows.
 
 Dates are displayed using the airport configuration. Server timestamps and
 audit events are recorded in UTC.
@@ -598,12 +612,47 @@ Install dependencies and run:
 python -m pytest -q
 ```
 
-The suite covers legacy helpers/routes plus platform airport creation,
+The suite covers legacy helpers/routes plus shared UX/error recovery, roster
+zoom controls, overtime empty states, platform airport creation,
 account-limit enforcement, unit account management, request persistence,
 request windows and lock boundaries, requestable shifts,
 one-request-per-date, pending updates, forged deletion, status validation,
 approve-only, approve-and-apply, qualification conflicts, CSRF,
 audit/notifications, and cross-unit read/write isolation.
+
+### Repeatable acceptance dataset
+
+Create a clean, date-relative test platform with Leeds Bradford, East
+Midlands and Inverness airports:
+
+```bash
+python scripts/seed_acceptance_data.py --reset
+export DATABASE_URL="sqlite:///instance/acceptance.db"
+export FLASK_SECRET_KEY="local-acceptance-secret"
+flask --app app.py run --port 5001
+```
+
+The generated `instance/acceptance.manifest.json` lists the local test
+credentials and rolling month values. It is ignored by Git and must never be
+used in production. The seed command creates:
+
+- three isolated airport tenants and a platform-control account;
+- 42 operational ATCOs across four watches;
+- Unit Admin, Roster Editor and Staff User accounts;
+- four complete rolling roster months;
+- leave, sickness, requests, notifications, qualifications, annotations and
+  TOIL examples;
+- operational positions, endorsements, position requirements, break plans,
+  achieved duty, fatigue reports and governed rules;
+- scenarios, a previous published roster and an acknowledgement;
+- exactly one spare account at each airport for a quick account-limit test.
+
+The full ordered acceptance procedure and result sheets are in
+[docs/manual_acceptance_test.md](docs/manual_acceptance_test.md). Re-run the
+seed command to return to a known baseline between test cycles.
+
+The latest implemented-role access and isolation evidence is recorded in
+[docs/permission_test_report_2026-07-24.md](docs/permission_test_report_2026-07-24.md).
 
 Before release also run:
 

--- a/app.py
+++ b/app.py
@@ -209,6 +209,58 @@ def _internal_error(error):
     )
     return render_template("error.html", request_id=getattr(g, "request_id", "")), 500
 
+
+@app.errorhandler(400)
+def _bad_request(error):
+    description = getattr(error, "description", "") or ""
+    if "CSRF" in description:
+        message = (
+            "This page or form has expired. Reload the page and try the action "
+            "once more."
+        )
+    elif description and not description.startswith(
+        "The browser (or proxy) sent a request"
+    ):
+        message = description
+    else:
+        message = (
+            "The request was not valid. Check the entered values and try again."
+        )
+    return render_template(
+        "error.html",
+        status_code=400,
+        error_title="We could not validate that request",
+        error_message=message,
+        request_id=getattr(g, "request_id", ""),
+    ), 400
+
+
+@app.errorhandler(403)
+def _forbidden(_error):
+    return render_template(
+        "error.html",
+        status_code=403,
+        error_title="You do not have access to this area",
+        error_message=(
+            "Your account role does not permit this action. Return to the "
+            "roster or ask your Unit Administrator for access."
+        ),
+        request_id=getattr(g, "request_id", ""),
+    ), 403
+
+
+@app.errorhandler(404)
+def _not_found(_error):
+    return render_template(
+        "error.html",
+        status_code=404,
+        error_title="That page or record was not found",
+        error_message=(
+            "It may have moved, been removed, or belong to a different airport."
+        ),
+        request_id=getattr(g, "request_id", ""),
+    ), 404
+
 # Database & login
 db = SQLAlchemy(app, session_options={"expire_on_commit": False})
 login_manager = LoginManager(app)
@@ -221,6 +273,18 @@ from tenancy import bind_authenticated_unit, reset_authenticated_unit
 def _bind_tenant_context():
     g.request_id = request.headers.get("X-Request-ID") or secrets.token_hex(12)
     g.tenant_context_token = None
+    if (
+        current_user.is_authenticated
+        and getattr(current_user, "role", "") == "superadmin"
+    ):
+        allowed_platform_endpoints = {
+            "platform_admin", "logout", "password_change", "mfa_setup",
+            "static", "favicon", "health_live", "health_ready",
+        }
+        if request.endpoint == "index":
+            return redirect(url_for("platform_admin"))
+        if request.endpoint not in allowed_platform_endpoints:
+            abort(403)
     if current_user.is_authenticated and getattr(current_user, "role", "") != "superadmin":
         unit_id = int(getattr(current_user, "unit_id", 0) or 0)
         if unit_id:
@@ -3477,6 +3541,7 @@ def __can():
 def admin_ai_generate(ym):
     if not is_admin_user(current_user):
         abort(403)
+    _validate_csrf()
     y, m = parse_ym(ym)
     try:
         res = generate_month_roster(y, m, current_user) or {}
@@ -3513,6 +3578,7 @@ def admin_ai_generate(ym):
 @login_required
 @roster_edit_required
 def assign_cell(staff_id, ym, day):
+    _validate_csrf()
     # parse inputs
     d = date.fromisoformat(day)
     st = db.session.get(Staff, staff_id) or Staff.query.get_or_404(staff_id)
@@ -4349,8 +4415,7 @@ def change_log_page():
 def leave():
     # Page visibility: editors & admins only
     if not (is_admin_user(current_user) or getattr(current_user, "role", "") in ("editor", "admin")):
-        flash("Editors or Admins only.", "error")
-        return redirect(url_for("index"))
+        abort(403)
 
     staff = Staff.query.order_by(Staff.name).all()
 
@@ -4364,6 +4429,7 @@ def leave():
     prev_ym, next_ym = _clamp_prev_next(year, month)
 
     if request.method == "POST":
+        _validate_csrf()
         # (still restrict POST actions too)
         if not (is_admin_user(current_user) or getattr(current_user, "role", "") in ("editor", "admin")):
             flash("Editors or Admins only.", "error")
@@ -4762,8 +4828,7 @@ def _fy_start_for(d: date) -> date:
 @login_required
 def metrics():
     if not (is_admin_user(current_user) or getattr(current_user, "role", "") in ("editor", "admin")):
-        flash("Editors or Admins only.", "error")
-        return redirect(url_for("index"))
+        abort(403)
     # ... existing body unchanged ...
     today = date.today()
     default_start = _fy_start_for(today)
@@ -4846,8 +4911,7 @@ def _has_in_date_ue(s: Staff, ref_day: date) -> bool:
 @login_required
 def metrics_export():
     if not is_admin_user(current_user):
-        flash("Admins only!", "error")
-        return redirect(url_for("index"))
+        abort(403)
     today = date.today()
     default_start = _fy_start_for(today)
     start_day = date.fromisoformat(
@@ -4913,9 +4977,16 @@ def _compute_overtime_candidates(chosen_date: date | None, chosen_shift_code: st
     ensure_assignments_for_range(chosen_date - timedelta(days=30),
                                  chosen_date + timedelta(days=lookahead_days))
 
-    staff_members = (Staff.query
-                     .outerjoin(Watch, Staff.watch_id == Watch.id)
-                     .order_by(Watch.order_index, Staff.name).all())
+    staff_members = (
+        Staff.query
+        .outerjoin(Watch, Staff.watch_id == Watch.id)
+        .filter(
+            Staff.is_operational.is_(True),
+            Staff.membership_status == "active",
+        )
+        .order_by(Watch.order_index, Staff.name)
+        .all()
+    )
 
     soal_codes = annotation_codes_for_tag("soal", active_only=False)
     soal_display = "SOAL"
@@ -4927,6 +4998,9 @@ def _compute_overtime_candidates(chosen_date: date | None, chosen_shift_code: st
     results = []
     for s in staff_members:
         if s.exclude_from_ot:
+            continue
+
+        if not _staff_has_shift_qualification(s, sh):
             continue
 
         a_today = Assignment.query.filter_by(
@@ -4996,8 +5070,7 @@ def _compute_overtime_candidates(chosen_date: date | None, chosen_shift_code: st
 @login_required
 def overtime():
     if not (is_admin_user(current_user) or getattr(current_user, "role", "") in ("editor", "admin")):
-        flash("Editors or Admins only.", "error")
-        return redirect(url_for("index"))
+        abort(403)
 
     shifts = ShiftType.query.filter_by(
         is_working=True).order_by(ShiftType.code).all()
@@ -5006,8 +5079,10 @@ def overtime():
     chosen_shift = None
     selected_staff_ids: set[str] = set()
     sms_body = ""
+    searched = request.method == "POST"
 
     if request.method == "POST":
+        _validate_csrf()
         action = request.form.get("action", "find")
         chosen_date = _parse_date(request.form.get("date"))
         chosen_shift = (request.form.get("shift_code") or "").upper().strip()
@@ -5062,7 +5137,8 @@ def overtime():
                            shifts=shifts, results=results,
                            chosen_date=chosen_date, chosen_shift=chosen_shift,
                            sms_body=sms_body, sms_ready=sms_ready,
-                           selected_staff_ids=selected_staff_ids)
+                           selected_staff_ids=selected_staff_ids,
+                           searched=searched)
 
 # -------------------- Calendar subscription --------------------
 
@@ -5171,8 +5247,7 @@ def _leave_summary_for_month(year: int, month: int):
 @login_required
 def report_leave(ym):
     if not is_admin_user(current_user):
-        flash("Admins only!", "error")
-        return redirect(url_for("index"))
+        abort(403)
     year, month = parse_ym(ym)
     ensure_month_requirement(year, month)
     generate_month(year, month)
@@ -5189,8 +5264,7 @@ def report_leave(ym):
 @login_required
 def report_leave_csv():
     if not is_admin_user(current_user):
-        flash("Admins only!", "error")
-        return redirect(url_for("index"))
+        abort(403)
     ym = request.args.get("ym")
     if not ym:
         abort(400)
@@ -5277,8 +5351,7 @@ def _toil_accrued_used_in_range_half_days(staff_id: int, start_day: date, end_da
 @login_required
 def report_leave_year():
     if not is_admin_user(current_user):
-        flash("Admins only!", "error")
-        return redirect(url_for("index"))
+        abort(403)
     today = date.today()
     people = (Staff.query
               .outerjoin(Watch, Staff.watch_id == Watch.id)
@@ -5334,8 +5407,7 @@ def _group_consecutive_days(days_set):
 @login_required
 def report_sickness():
     if not is_admin_user(current_user):
-        flash("Admins only!", "error")
-        return redirect(url_for("index"))
+        abort(403)
     today = date.today()
     start = today - timedelta(days=365)
     people = (Staff.query
@@ -5963,6 +6035,8 @@ def unit_onboarding():
 @app.route("/compliance")
 @login_required
 def qualification_compliance():
+    if not is_editor_user(current_user):
+        abort(403)
     unit_id = _current_unit_id()
     today = date.today()
     qualifications = (
@@ -6264,6 +6338,8 @@ def fatigue_self_report():
 @app.route("/planning/coverage/<ym>")
 @login_required
 def coverage_heatmap(ym):
+    if not can_edit_roster(current_user):
+        abort(403)
     year, month = parse_ym(ym)
     start, days = month_range(year, month)
     end = days[-1]
@@ -6364,8 +6440,7 @@ def reports_index():
         return redirect(url_for("metrics"))
 
     # Everyone else: no access
-    flash("Admins only.", "error")
-    return redirect(url_for("index"))
+    abort(403)
 
 
 @app.route("/login", methods=["GET", "POST"], endpoint="login")

--- a/docs/manual_acceptance_test.md
+++ b/docs/manual_acceptance_test.md
@@ -1,0 +1,260 @@
+# ATCRoster manual acceptance test
+
+Use this script to test a release from the perspective of platform support,
+unit management, roster editors and operational ATCOs. It is deliberately
+ordered so later tests can rely on changes made earlier.
+
+## Test record
+
+| Field | Record |
+| --- | --- |
+| Tester | |
+| Application version / commit | |
+| Browser and version | |
+| Device / operating system | |
+| Dataset generation date | |
+| Test started | |
+| Test completed | |
+| Overall result | Pass / Fail / Blocked |
+
+For every failure, record the test ID, what happened, what was expected, a
+screenshot, the account used and the time. Do not include passwords, MFA
+secrets, medical details or free-text fatigue content in defect reports.
+
+## Prepare the acceptance environment
+
+These commands create a dedicated SQLite acceptance database. The command
+refuses to overwrite an existing database unless `--reset` is present.
+
+```bash
+python -m pip install -r requirements.txt
+python scripts/seed_acceptance_data.py --reset
+export DATABASE_URL="sqlite:///instance/acceptance.db"
+export FLASK_SECRET_KEY="local-acceptance-secret"
+flask --app app.py run --port 5001
+```
+
+Open `http://127.0.0.1:5001`. The generated credentials and current test
+months are in `instance/acceptance.manifest.json`. This manifest is local test
+material and must not be committed or used in production.
+
+The dataset contains:
+
+- Leeds Bradford (`LBA`): 16 ATCOs, 17-account limit;
+- East Midlands (`EMA`): 14 ATCOs, 15-account limit;
+- Inverness (`INV`): 12 ATCOs, 13-account limit;
+- a Platform Super Admin, Unit Admin, Roster Editor and Staff User login;
+- four rolling months of complete assignments (previous, current, next and
+  two months ahead);
+- watches, shifts, leave, sickness, TOIL, overtime annotations, requirements,
+  qualifications, position endorsements, break plans, achieved duty, fatigue
+  reports, scenarios, requests, notifications and a previous publication.
+
+Re-run the seed command whenever a clean baseline is needed. Use the month
+values in the manifest rather than fixed dates.
+
+## Result key
+
+- **Pass**: behaviour and stored result match the expected outcome.
+- **Fail**: behaviour is incorrect or data is lost, disclosed or corrupted.
+- **Blocked**: an earlier defect prevents the test.
+- **Not run**: test has not yet been attempted.
+
+## A. Service and authentication
+
+| ID | Action | Expected result | Result |
+| --- | --- | --- | --- |
+| A01 | Open `/health/live`. | HTTP 200 and JSON status `ok`. | |
+| A02 | Open `/health/ready`. | HTTP 200 and JSON status `ready`. | |
+| A03 | Open `/login` in a private browser window. | Login page loads over the expected origin with no authenticated data visible. | |
+| A04 | Submit an invalid username and password. | Generic invalid-credentials message; no account details disclosed. | |
+| A05 | Sign in as the LBA Staff User from the manifest. | Roster opens and the header clearly says Leeds Bradford Airport and `LBA`. | |
+| A06 | Sign out, then use the Back button. | Protected content is not usable; navigation returns to login. | |
+| A07 | Sign in as the LBA Unit Admin and open `/security/mfa`. Enrol an authenticator and save the recovery codes. | Setup succeeds and the recovery codes are shown once. | |
+| A08 | Sign out and sign in again using the authenticator code. | MFA challenge succeeds and the code cannot be replayed. | |
+| A09 | Sign out and use one recovery code. Repeat with the same recovery code. | First use succeeds; second use is rejected. | |
+| A10 | Resize to a narrow/mobile viewport and navigate the main pages. | Header, airport context, navigation and forms remain readable without hiding critical actions. | |
+| A11 | At a narrow viewport, open and close Menu; press Escape while it is open. | Menu is keyboard accessible, closes on Escape and returns focus to its button. | |
+| A12 | Tab from the top of a page and activate “Skip to main content”. | Focus moves directly to the page content. | |
+
+Reset the dataset after A07–A09 if later testers need an unenrolled account.
+
+## B. Tenant isolation and role access
+
+| ID | Action | Expected result | Result |
+| --- | --- | --- | --- |
+| B01 | As LBA Staff User, inspect roster, profile, requests, fatigue and published pages. | Only LBA people and records are visible. | |
+| B02 | Copy an LBA staff-profile URL. Sign out, sign in as EMA Staff User and open it. | LBA personnel data is not disclosed; access is denied or not found. | |
+| B03 | As EMA Staff User, attempt `/admin`, `/unit/accounts`, `/operations/<current-month>` and `/reports`. | Administrative areas are denied or safely redirected. | |
+| B04 | As EMA Roster Editor, open roster, overtime, leave/sickness, reports and compliance. | Editor tools are available; account and Unit Admin configuration remain unavailable. | |
+| B05 | As EMA Unit Admin, open all unit areas. | Full EMA unit administration is available; no LBA/INV data appears. | |
+| B06 | As Platform Super Admin, open `/platform/admin`. | Only airport/service aggregates appear; no names, rosters, requests, fatigue or medical records are exposed. | |
+| B07 | As Platform Super Admin, try operational URLs. | Operational personnel and roster functions are unavailable. | |
+| B08 | In each airport account, verify the airport name/code in the header before editing. | Context always matches the login’s airport and cannot be changed by URL parameters. | |
+
+## C. Platform administration and account limits
+
+| ID | Action | Expected result | Result |
+| --- | --- | --- | --- |
+| C01 | As Platform Super Admin, review LBA, EMA and INV cards. | Plan, limit, status, health, migration and aggregate usage display correctly. | |
+| C02 | Change INV’s account limit, plan or status, then reload. | Change persists and a safe platform audit event is recorded. | |
+| C03 | Create a new test airport with a unique code, initial admin and a 12+ character password. | Airport and initial Unit Admin are created atomically. No password is displayed afterward. | |
+| C04 | Attempt to create an airport using an existing code. | Validation rejects the duplicate without partial records. | |
+| C05 | As LBA Unit Admin, open Accounts. | Usage reads `16 of 17`. | |
+| C06 | Create one LBA account with a unique username and 12+ character password. | Account activates and usage reads `17 of 17`. | |
+| C07 | Attempt to create one more LBA account. | Creation is blocked by the active-account limit and no partial account remains. | |
+| C08 | Deactivate the account created in C06, then create another. | Capacity returns and replacement creation succeeds. | |
+| C09 | Attempt to deactivate the account currently signed in. | Self-deactivation is refused. | |
+| C10 | Reset the dataset. | All airports return to the documented baseline. | |
+
+## D. Airport onboarding and reference data
+
+| ID | Action | Expected result | Result |
+| --- | --- | --- | --- |
+| D01 | As LBA Unit Admin, open Airport onboarding. | Readiness is complete and links open the correct setup areas. | |
+| D02 | Edit LBA identity fields and save, then restore them. | Header and onboarding reflect saved values; other airports are unchanged. | |
+| D03 | Open Admin and switch between Overview, Requirements, Shifts, Staff and Tools. | Sections are clear, retain selection and do not submit hidden forms. | |
+| D04 | Add a shift `TST`, then edit its times/requestable state. | Shift appears once and saved values are used by relevant forms. | |
+| D05 | Try a duplicate shift code and malformed times. | Clear validation; no duplicate or partial shift. | |
+| D06 | Add an operational test ATCO, edit their profile and move them to another watch with an effective date. | Person and dated watch history persist. | |
+| D07 | Edit and then delete the watch-history record created in D06. | Roster/watch view follows the current valid history; audit remains available. | |
+| D08 | Open Reference Data and inspect A6, OT, TOAI and TOA8. | Labels, categories, colours, suffix and TOIL behaviour match the seed definitions. | |
+| D09 | Add a note-required annotation and use it on a roster cell without a note, then with a note. | Missing note is rejected; valid use succeeds and is audited. | |
+| D10 | Attempt to deactivate an annotation after it has been used. | Historical meaning is preserved and the UI explains the permitted action. | |
+
+## E. Monthly roster and editing
+
+Use the manifest’s `test_month`.
+
+| ID | Action | Expected result | Result |
+| --- | --- | --- | --- |
+| E01 | Open the LBA current-month roster. | All 16 people and every day have explicit assignments; watch grouping and M/D/A/N coverage appear. | |
+| E02 | Navigate previous/next months. | Month boundaries, weekdays and data remain correct. | |
+| E03 | Search/inspect several people and compare their profile assignments. | Names, watches and shifts agree across views. | |
+| E04 | As LBA Roster Editor, change an unprotected future cell to a valid shift. Reload. | Change persists with manual source/audit and only the chosen cell changes. | |
+| E05 | Apply an OT annotation and valid A6 suffix. | Badge/colour and annotation totals update correctly. | |
+| E06 | Enter an invalid shift or annotation through a modified request. | Server rejects the value; roster is unchanged. | |
+| E07 | Attempt direct overwrite of annual leave, sickness or TOIL-protected data. | Protected workflow prevents an unsafe overwrite or requires the authorised path. | |
+| E08 | Create a fatigue-producing sequence and review the warning. Cancel, then repeat with an authorised override/reason if offered. | Warning is explainable; cancel preserves data; authorised override is recorded. | |
+| E09 | Export roster CSV. | File downloads, contains LBA only, correct month/dates and no HTML. | |
+| E10 | Open print view / print preview. | Landscape output is legible and includes airport/month context. | |
+| E11 | Open the public calendar URL from a staff profile in a signed-out window. | Valid token returns only that person’s permitted roster window; altered token fails. | |
+| E12 | Select 75%, 90%, 100% and Fit width, then revisit the roster. | Each preset is applied, the grid can scroll at larger sizes and the chosen preset persists. | |
+
+## F. Shift requests
+
+Use the manifest’s `request_month`.
+
+| ID | Action | Expected result | Result |
+| --- | --- | --- | --- |
+| F01 | As LBA Staff User, open Requests. | Seeded pending/approved/rejected examples display with clear status and manager response where applicable. | |
+| F02 | Submit a valid requestable shift on an eligible date. | One pending request is stored with the comment and confirmation. | |
+| F03 | Edit the pending request’s shift/comment. | Existing request updates; no duplicate is created. | |
+| F04 | Try a second request on the same date. | One-request-per-person/date rule is enforced. | |
+| F05 | Try a non-requestable/unknown shift, past date and date outside the window. | Each is rejected server-side with no stored request. | |
+| F06 | Cancel the request. | Status becomes cancelled, audit is retained and active badge disappears. | |
+| F07 | As LBA Unit Admin, approve a pending request without applying it. | Status becomes approved, response/audit/notification are recorded, assignment is unchanged. | |
+| F08 | Approve and apply another request. | Matching assignment is created/updated, request becomes fulfilled and links to it. | |
+| F09 | Attempt approve-and-apply where leave, sickness, qualification or fatigue conflicts. | Unsafe application is blocked and original data remains intact. | |
+| F10 | Sign in as the requester and inspect notifications/roster. | Outcome is visible only to the correct user and airport. | |
+
+## G. Leave, sickness, TOIL and overtime
+
+| ID | Action | Expected result | Result |
+| --- | --- | --- | --- |
+| G01 | Open Leave / Sickness for LBA. | Seeded leave and sickness periods appear with correct people/dates. | |
+| G02 | Add, edit and remove a future annual-leave period. | Assignments update safely; reports and profile agree; removal restores expected roster behaviour. | |
+| G03 | Add sickness with self-cert/certified code and inspect the sickness report. | Period, roster code and report agree without affecting other staff. | |
+| G04 | Attempt overlapping or end-before-start leave/sickness. | Validation rejects invalid range with no partial changes. | |
+| G05 | Add half-day and full-day TOIL through the dedicated workflow. | Balance changes by the correct half-day units and audit/report reflect it. | |
+| G06 | Inspect the seeded OT annotation in metrics. | Overtime total includes the seeded entry exactly once. | |
+| G07 | Run Overtime Finder for an operational shift. | Candidates exclude unavailable, opted-out, unqualified or fatigue-conflicted people as applicable. | |
+| G08 | If SMS is unconfigured, attempt notification. | Clear safe configuration message; no false success and no secret disclosure. | |
+
+## H. Qualifications and compliance
+
+| ID | Action | Expected result | Result |
+| --- | --- | --- | --- |
+| H01 | Open Qualification compliance. | MED, ADI and OJTI rows show; one medical is within 30 days and states are clear. | |
+| H02 | Inspect the seeded expired legacy radar validation on a profile. | Expired state is prominent and does not appear valid. | |
+| H03 | Add/edit a qualification expiry and reload. | New state and warning band calculate from the actual date. | |
+| H04 | Open Compliance Centre for current month. | Fatigue findings are grouped/explained and scoped to LBA. | |
+| H05 | Export compliance evidence CSV. | Correct airport/month, headers and findings; no other airport data. | |
+| H06 | Compare a finding against the person’s roster sequence. | Dates and duties support the explanation. | |
+
+## I. Operational assurance and fatigue
+
+| ID | Action | Expected result | Result |
+| --- | --- | --- | --- |
+| I01 | Open Operations for current month. | TWR/GMC/APP, endorsements, position requirements, break, achieved duty, reports and rule v1 display. | |
+| I02 | Add a position and grant an endorsement with valid dates. | Both persist and are airport-scoped. | |
+| I03 | Add/update a position requirement for a date/shift. | Assurance recalculates eligible count and shortfall. | |
+| I04 | Set a requirement above endorsed staffing. | Shortfall becomes visible and blocks publication. Restore the original value. | |
+| I05 | Add a break with end before start, then a valid break. | Invalid period is rejected; valid period persists. | |
+| I06 | Record achieved duty with a variance reason. | Actual times and variance persist; invalid negative duration is rejected. | |
+| I07 | As Staff User, submit low, high and unfit fatigue reports. | Reports are stored with clear immediate-reporting guidance. | |
+| I08 | As Unit Admin, review/close the reports with a meaningful response. | Reviewer/time/status persist; high/unfit remains a publication blocker until closed. | |
+| I09 | Create draft rule v2 with valid JSON and governance evidence. | Draft is created without changing approved v1. | |
+| I10 | Try malformed JSON and approval without evidence. | Both are rejected safely. | |
+| I11 | Approve rule v2 with effective date. | v2 is approved, v1 superseded and audit evidence retained. | |
+
+## J. Coverage, scenarios and publication
+
+| ID | Action | Expected result | Result |
+| --- | --- | --- | --- |
+| J01 | Open Coverage heatmap for the current month. | M/D/A/N coverage and shortfall colours agree with roster requirements. | |
+| J02 | Open Scenarios and inspect “Summer traffic uplift”. | Scenario changes display without modifying the live roster. | |
+| J03 | Create a scenario with two changes, then apply/approve only if the UI supports the required authority. | Preview is isolated; authorised application is audited and explicit. | |
+| J04 | Open Published for the previous month. | Version 1 and release information display; one seeded acknowledgement exists. | |
+| J05 | As an unacknowledged Staff User, acknowledge previous version. | Acknowledgement records once; repeat does not duplicate it. | |
+| J06 | Open current-month publication centre. | Preflight reports configuration, competence, coverage, position, break, fatigue and acknowledgement information. | |
+| J07 | Introduce an unassigned cell, position shortfall or open high fatigue report and attempt publication. | Publication is hard-blocked. Restore the baseline. | |
+| J08 | Attempt publication without release declaration. | Publication is refused. | |
+| J09 | If only soft exceptions remain, use a short rationale then a 20+ character rationale. | Short rationale is refused; adequate rationale plus declaration publishes version 1. | |
+| J10 | Change a roster cell and publish again. | Prior version becomes superseded; version 2 is immutable and current. | |
+| J11 | As Staff User, acknowledge current version and inspect notification. | Acknowledgement and notification state persist for that person only. | |
+
+## K. Reports, audit and data quality
+
+| ID | Action | Expected result | Result |
+| --- | --- | --- | --- |
+| K01 | Open Reports, leave-year, sickness and metrics as LBA Unit Admin. | Totals reconcile with seeded roster, leave, sickness, TOIL and OT records. | |
+| K02 | Compare one person’s profile, calendar, roster and leave-year report. | Identity and dates agree in every view. | |
+| K03 | Open the change log after the preceding edits. | Actor, entity, change, month and reason are clear and correctly ordered. | |
+| K04 | Mark notifications read and reload. | Read state persists and another user’s notifications are unchanged. | |
+| K05 | Repeat selected report/export checks in EMA and INV. | Counts differ as expected (14 and 12 people) and tenant data never mixes. | |
+| K06 | Enter text containing `<script>`, quotes and a very long value in safe test fields. | Output is escaped, lengths enforced and the page remains functional. | |
+| K07 | Submit a stale/missing CSRF token on a state-changing form. | Request is rejected and no data changes. | |
+
+## L. Resilience and release checks
+
+| ID | Action | Expected result | Result |
+| --- | --- | --- | --- |
+| L01 | Restart the server and sign in again. | All committed test changes persist; sessions behave safely. | |
+| L02 | Open two different airport sessions in separate browser profiles and make independent edits. | Each remains bound to its own airport. | |
+| L03 | Rapidly double-submit a request/account/annotation form. | No duplicate business records or 500 error. | |
+| L04 | Test a 28/29/30/31-day month and year boundary using roster navigation. | All days and month links are correct. | |
+| L05 | Run `python -m pytest -q`. | Entire automated suite passes. | |
+| L06 | Run `python -m compileall -q app.py tenancy.py saas_models.py account_limits.py scripts`. | No compile errors. | |
+| L07 | Rebuild a fresh acceptance database and compare manifest counts. | 3 airports, 42 operational staff, 9 requests and four rolling assignment months are recreated. | |
+| L08 | Review browser console and server log during the script. | No uncaught errors, secrets, passwords or sensitive free text in logs. | |
+| L09 | Verify backup/restore and HTTPS/reverse-proxy procedures in a production-like environment. | Runbook evidence is captured; restored service passes health, login and isolation smoke tests. | |
+
+## Exit criteria
+
+Release only when:
+
+- every priority safety, security, tenant-isolation and data-integrity test
+  passes;
+- no open defect can create an incorrect published roster, conceal a
+  competence/fatigue/coverage issue or disclose another airport’s data;
+- all automated tests and production migration checks pass;
+- Unit Manager, operational safety representative and technical owner sign
+  the test record;
+- remaining lower-priority defects have an owner, risk decision and target
+  date.
+
+Acceptance of this script is product validation, not regulatory approval. The
+unit remains responsible for its approved rostering rules, fatigue risk
+management, competence scheme, operational change process and local safety
+assurance.

--- a/docs/permission_test_report_2026-07-24.md
+++ b/docs/permission_test_report_2026-07-24.md
@@ -1,0 +1,140 @@
+# Permission test report — 24 July 2026
+
+## Outcome
+
+**Pass with one documented product limitation.**
+
+All currently implemented runtime permission levels passed the read, write,
+tenant-isolation and denial tests after remediation:
+
+- Platform Super Admin;
+- Unit Admin;
+- Roster Editor;
+- Watch Manager;
+- Duty Watch Manager;
+- Staff User.
+
+The `ReadOnlyAuditor` name in the product vision is not currently
+provisionable by the account workflow and therefore was not represented as a
+runtime role in this test. It must not be offered commercially until a
+separate read-only permission contract, account option and regression matrix
+are implemented.
+
+## Test environment
+
+| Item | Value |
+| --- | --- |
+| Database | Local rolling acceptance database |
+| Airports | Leeds Bradford, East Midlands, Inverness |
+| Automated suite | 38 passed |
+| Role-matrix personas | 6 |
+| Permission routes per persona | 18 |
+| Tenant-isolation airports | 3 |
+| Test date | 24 July 2026 |
+
+## Permission matrix
+
+`R` means readable/self-service, `W` means permitted write authority, and `—`
+means server-side 403 denial.
+
+| Capability | Super Admin | Unit Admin | Editor | WM / DWM | Staff |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Platform administration | W | — | — | — | — |
+| Monthly roster | — | W | W | W | R |
+| Shift requests | — | W | R | R | R |
+| Published rosters / acknowledgement | — | W | R | R | R |
+| Personal fatigue reporting | — | R | R | R | R |
+| Overtime finder | — | W | W | — | — |
+| Leave / sickness management | — | W | W | — | — |
+| Metrics | — | R | R | — | — |
+| Qualification compliance | — | R | R | — | — |
+| Fatigue compliance centre/export | — | R | — | — | — |
+| Operational assurance | — | W | — | — | — |
+| Coverage heatmap | — | R | R | R | — |
+| Scenario planning | — | W | W | W | — |
+| Account management | — | W | — | — | — |
+| Airport onboarding | — | W | — | — | — |
+| Unit administration/reference data | — | W | — | — | — |
+
+## Remediated findings
+
+### P1 — Platform control-plane escape
+
+The Platform Super Admin could reach roster, requests, publications,
+qualification and coverage URLs by typing them directly, despite those links
+being hidden.
+
+**Fix:** a central server-side control-plane allowlist now restricts the
+Platform Super Admin to platform administration, own-password/MFA, logout,
+static assets and health endpoints. `/` redirects to Platform Admin.
+
+### P1 — Unit personnel-data exposure
+
+An ordinary Staff User could directly open the unit-wide qualification
+compliance page. They could also open the coverage heatmap even though it was
+not part of their self-service role.
+
+**Fix:** qualification data now requires Unit Admin or Roster Editor.
+Coverage requires roster-edit authority (Admin, Editor, WM or DWM).
+
+### P2 — Ambiguous permission denial
+
+Restricted overtime, leave, reports and metrics URLs silently redirected an
+unauthorised user to the roster, making access denial appear to be a broken
+link.
+
+**Fix:** restricted direct access now returns the consistent, recoverable 403
+screen.
+
+### P1 — Roster write CSRF gap
+
+Direct roster-cell and monthly AI-generation posts did not validate CSRF
+tokens.
+
+**Fix:** both endpoints now require a valid token, and every roster write form
+includes it.
+
+## Write and isolation evidence
+
+The regression suite verifies:
+
+- Staff User cannot write roster cells;
+- Watch Manager and Duty Watch Manager can write roster cells;
+- Roster Editor can write roster cells and scenarios but cannot administer;
+- Unit Admin can perform unit configuration, publication, operational
+  assurance and account actions;
+- Platform Super Admin can administer airport accounts but cannot read
+  operational pages;
+- Staff User can view only their own profile;
+- Unit Admin can view another person in the same airport;
+- an ID belonging to another airport returns 404 rather than disclosing its
+  existence;
+- forged cross-airport request and operational-position writes fail;
+- account limits remain transactional;
+- request approval/application, qualification conflicts, notifications and
+  audit records remain enforced;
+- missing CSRF tokens fail without changing data.
+
+## Manual test accounts
+
+The acceptance database uses the password recorded in
+`instance/acceptance.manifest.json`.
+
+| Permission | Leeds account |
+| --- | --- |
+| Platform Super Admin | `platform.admin` |
+| Unit Admin | `lba.admin` |
+| Roster Editor | `lba.editor` |
+| Watch Manager | `lba.atco03` |
+| Duty Watch Manager | `lba.atco04` |
+| Staff User | `lba.atco01` |
+
+Repeat the same checks with `ema.*` and `inv.*` accounts when conducting a
+formal release acceptance cycle.
+
+## Release decision
+
+The implemented permission model is suitable for continued acceptance
+testing. Do not enable a ReadOnly Auditor account or advertise that role until
+its explicit read-only routes, export policy, privacy scope and tests have
+been delivered.

--- a/scripts/seed_acceptance_data.py
+++ b/scripts/seed_acceptance_data.py
@@ -1,0 +1,619 @@
+#!/usr/bin/env python3
+"""Create a deterministic, non-production ATCRoster acceptance database.
+
+The dataset is intentionally rebuilt from scratch. It uses dates relative to
+the day it is generated so request windows, expiry warnings and current-month
+views remain useful whenever the script is run.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from calendar import monthrange
+from datetime import date, datetime, time, timedelta
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+PASSWORD = "Test-ATCRoster-2026!"
+AIRPORTS = (
+    # Each unit has exactly one spare account, making the limit test quick.
+    ("LBA", "Leeds Bradford Airport", 16, 17),
+    ("EMA", "East Midlands Airport", 14, 15),
+    ("INV", "Inverness Airport", 12, 13),
+)
+FIRST_NAMES = (
+    "Alex", "Beth", "Callum", "Deepa", "Euan", "Fiona", "Gareth", "Hannah",
+    "Imran", "Jenny", "Kieran", "Lucy", "Martin", "Nadia", "Owen", "Priya",
+)
+SURNAMES = (
+    "Taylor", "Singh", "Murray", "Campbell", "Roberts", "Wilson", "Fraser",
+    "Ahmed", "Davies", "Brown", "Khan", "Evans", "Reid", "Morgan", "Clark",
+    "Stewart",
+)
+
+
+def add_months(day: date, count: int) -> date:
+    total = day.year * 12 + day.month - 1 + count
+    return date(total // 12, total % 12 + 1, 1)
+
+
+def month_days(first: date) -> list[date]:
+    return [
+        date(first.year, first.month, day)
+        for day in range(1, monthrange(first.year, first.month)[1] + 1)
+    ]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--database",
+        default=str(REPO_ROOT / "instance" / "acceptance.db"),
+        help="SQLite file to create (default: instance/acceptance.db)",
+    )
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        help="Replace the target database if it already exists.",
+    )
+    parser.add_argument(
+        "--as-of",
+        type=date.fromisoformat,
+        default=date.today(),
+        help="Dataset reference date in YYYY-MM-DD format (default: today).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    db_path = Path(args.database).expanduser().resolve()
+    if db_path.suffix.lower() not in {".db", ".sqlite", ".sqlite3"}:
+        raise SystemExit("Acceptance data must target an explicit SQLite database file.")
+    if db_path.exists() and not args.reset:
+        raise SystemExit(f"{db_path} already exists; use --reset to replace it.")
+    if db_path.exists():
+        db_path.unlink()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+    os.environ["ATCROSTER_ENV"] = "development"
+    os.environ["ATCROSTER_SKIP_RUNTIME_SCHEMA"] = "1"
+    os.environ.setdefault("FLASK_SECRET_KEY", "acceptance-only-secret-never-deploy")
+
+    import app as roster
+
+    current_month = args.as_of.replace(day=1)
+    previous_month = add_months(current_month, -1)
+    next_month = add_months(current_month, 1)
+    request_month = add_months(current_month, 2)
+    months = (previous_month, current_month, next_month, request_month)
+
+    with roster.app.app_context():
+        roster.db.drop_all()
+        roster.db.create_all()
+
+        control = roster.Unit(
+            code="PLATFORM",
+            name="ATCRoster Platform Control",
+            status="platform_control",
+            plan="internal",
+            active_user_limit=5,
+        )
+        roster.db.session.add(control)
+        roster.db.session.flush()
+        platform_user = roster.Staff(
+            unit_id=control.id,
+            username="platform.admin",
+            name="Platform Super Administrator",
+            staff_no="PLATFORM-001",
+            role="superadmin",
+            is_operational=False,
+        )
+        platform_user.set_password(PASSWORD)
+        roster.db.session.add(platform_user)
+        roster.db.session.flush()
+        platform_identity = roster.PlatformIdentity(
+            public_id="acceptance-platform-admin",
+            username=platform_user.username,
+            password_hash=platform_user.password_hash,
+        )
+        roster.db.session.add(platform_identity)
+        roster.db.session.flush()
+
+        credentials = [{
+            "airport": "Platform control",
+            "role": "Super Admin",
+            "username": platform_user.username,
+            "password": PASSWORD,
+        }]
+        summaries = []
+
+        for airport_index, (code, name, staff_count, account_limit) in enumerate(AIRPORTS):
+            unit = roster.Unit(
+                code=code,
+                name=name,
+                status="active",
+                plan="professional",
+                active_user_limit=account_limit,
+                request_months_ahead=3,
+                request_lock_day=20,
+                onboarding_step=10,
+                branding_json=json.dumps({"short_name": code}),
+                last_active_at=roster.utcnow(),
+            )
+            roster.db.session.add(unit)
+            roster.db.session.flush()
+
+            watches = []
+            for watch_index, watch_name in enumerate(("Blue", "Red", "Green", "Gold"), 1):
+                watch = roster.Watch(
+                    unit_id=unit.id,
+                    name=f"{watch_name} Watch",
+                    order_index=watch_index,
+                )
+                roster.db.session.add(watch)
+                watches.append(watch)
+            roster.db.session.flush()
+
+            shift_specs = (
+                ("M", "Morning", time(6), time(14), True, True),
+                ("D", "Day", time(8), time(16), True, True),
+                ("A", "Afternoon", time(14), time(22), True, True),
+                ("N", "Night", time(22), time(6), True, True),
+                ("SBY", "Standby", time(8), time(16), True, True),
+                ("TRG", "Training", time(9), time(17), True, False),
+                ("OFF", "Rest day", None, None, False, False),
+                ("AL", "Annual leave", None, None, False, False),
+                ("SC", "Sickness", None, None, False, False),
+                ("TOUI", "TOIL half day", None, None, False, False),
+                ("TOU8", "TOIL full day", None, None, False, False),
+            )
+            for shift_code, label, start, end, working, requestable in shift_specs:
+                roster.db.session.add(roster.ShiftType(
+                    unit_id=unit.id,
+                    code=shift_code,
+                    name=label,
+                    start_time=start,
+                    end_time=end,
+                    is_working=working,
+                    is_training=shift_code == "TRG",
+                    is_requestable=requestable,
+                    required_qualification="medical" if working else "",
+                ))
+
+            for order, (annotation_code, label, category, colour) in enumerate((
+                ("A6", "Six-hour extension", "Extension", "#7c3aed"),
+                ("OT", "Overtime", "Overtime", "#b45309"),
+                ("TOAI", "TOIL accrued half day", "TOIL Accrual", "#047857"),
+                ("TOA8", "TOIL accrued full day", "TOIL Accrual", "#065f46"),
+            )):
+                roster.db.session.add(roster.AnnotationType(
+                    unit_id=unit.id,
+                    code=annotation_code,
+                    label=label,
+                    category=category,
+                    colour=colour,
+                    description=f"Acceptance-test {label.lower()} annotation.",
+                    allow_suffix=annotation_code == "A6",
+                    suffixes="M,D,A,N" if annotation_code == "A6" else "",
+                    toil_half_days={"TOAI": 1, "TOA8": 2}.get(annotation_code, 0),
+                    tags="acceptance",
+                    sort_order=order,
+                ))
+
+            qualification_types = {}
+            for qual_code, label in (
+                ("MED", "Class 3 Medical"),
+                ("ADI", "Aerodrome Control Instrument"),
+                ("OJTI", "On-the-job Training Instructor"),
+            ):
+                qtype = roster.QualificationType(
+                    unit_id=unit.id,
+                    code=qual_code,
+                    label=label,
+                    warning_days_csv="180,90,60,30",
+                )
+                roster.db.session.add(qtype)
+                qualification_types[qual_code] = qtype
+            roster.db.session.flush()
+
+            people = []
+            for index in range(staff_count):
+                role = "admin" if index == 0 else "editor" if index == 1 else "user"
+                username = (
+                    f"{code.lower()}.admin" if index == 0
+                    else f"{code.lower()}.editor" if index == 1
+                    else f"{code.lower()}.atco{index - 1:02d}"
+                )
+                person = roster.Staff(
+                    unit_id=unit.id,
+                    username=username,
+                    name=f"{FIRST_NAMES[index]} {SURNAMES[(index + airport_index * 3) % len(SURNAMES)]}",
+                    staff_no=f"{code}-{100 + index}",
+                    role=role,
+                    membership_status="active",
+                    watch=watches[index % len(watches)],
+                    pattern_csv="M,M,A,A,N,N,OFF,OFF,OFF,OFF",
+                    pattern_anchor=current_month - timedelta(days=index % 10),
+                    medical_expiry=args.as_of + timedelta(days=(20 if index == 2 else 400)),
+                    tower_ue_expiry=args.as_of + timedelta(days=(80 if index == 3 else 500)),
+                    radar_ue_expiry=args.as_of - timedelta(days=5) if index == 4 else None,
+                    has_ojti=index % 4 == 0,
+                    has_assessor=index % 6 == 0,
+                    is_wm=index in (0, 4, 8),
+                    is_dwm=index in (1, 5, 9),
+                    is_trainee=index == staff_count - 1,
+                    is_operational=True,
+                    leave_entitlement_days=25,
+                    leave_public_holidays=8,
+                    leave_carryover_days=index % 3,
+                    toil_half_days=index % 5,
+                )
+                person.set_password(PASSWORD)
+                roster.db.session.add(person)
+                people.append(person)
+            roster.db.session.flush()
+
+            for person_index, person in enumerate(people):
+                identity = roster.PlatformIdentity(
+                    public_id=f"acceptance-{code.lower()}-{person_index:02d}",
+                    username=person.username,
+                    password_hash=person.password_hash,
+                )
+                roster.db.session.add(identity)
+                roster.db.session.flush()
+                roster.db.session.add(roster.UnitMembership(
+                    identity_id=identity.id,
+                    unit_id=unit.id,
+                    person_id=person.id,
+                    role={
+                        "admin": "UnitAdmin",
+                        "editor": "RosterEditor",
+                        "user": "StaffUser",
+                    }[person.role],
+                    status="active",
+                    activated_at=roster.utcnow(),
+                ))
+                for qual_code in ("MED", "ADI"):
+                    expires = args.as_of + timedelta(days=400 + person_index)
+                    if qual_code == "MED" and person_index == 2:
+                        expires = args.as_of + timedelta(days=20)
+                    roster.db.session.add(roster.PersonQualification(
+                        unit_id=unit.id,
+                        person_id=person.id,
+                        qualification_type_id=qualification_types[qual_code].id,
+                        expires_on=expires,
+                        status="valid",
+                    ))
+                if person.has_ojti:
+                    roster.db.session.add(roster.PersonQualification(
+                        unit_id=unit.id,
+                        person_id=person.id,
+                        qualification_type_id=qualification_types["OJTI"].id,
+                        expires_on=args.as_of + timedelta(days=500),
+                        status="valid",
+                    ))
+
+            positions = []
+            for position_code, label in (
+                ("TWR", "Aerodrome Control"),
+                ("GMC", "Ground Movement Control"),
+                ("APP", "Approach Control"),
+            ):
+                position = roster.OperationalPosition(
+                    unit_id=unit.id,
+                    code=position_code,
+                    label=label,
+                    description=f"{label} operational position for {code}.",
+                )
+                roster.db.session.add(position)
+                positions.append(position)
+            roster.db.session.flush()
+            for person in people:
+                for position in positions[:2]:
+                    roster.db.session.add(roster.PositionEndorsement(
+                        unit_id=unit.id,
+                        person_id=person.id,
+                        position_id=position.id,
+                        valid_from=previous_month,
+                        valid_until=args.as_of + timedelta(days=500),
+                        status="valid",
+                    ))
+            for person in people[::2]:
+                roster.db.session.add(roster.PositionEndorsement(
+                    unit_id=unit.id,
+                    person_id=person.id,
+                    position_id=positions[2].id,
+                    valid_from=previous_month,
+                    valid_until=args.as_of + timedelta(days=500),
+                    status="valid",
+                ))
+
+            for month in months:
+                roster.db.session.add(roster.Requirement(
+                    unit_id=unit.id,
+                    year=month.year,
+                    month=month.month,
+                    req_m=1,
+                    req_d=1,
+                    req_a=1,
+                    req_n=1,
+                ))
+                for day_index, duty_day in enumerate(month_days(month)):
+                    for person_index, person in enumerate(people):
+                        pattern = ("M", "M", "A", "A", "N", "N",
+                                   "OFF", "OFF", "OFF", "OFF")
+                        code_index = (
+                            duty_day - person.pattern_anchor
+                        ).days % len(pattern)
+                        duty_code = pattern[code_index]
+                        roster.db.session.add(roster.Assignment(
+                            unit_id=unit.id,
+                            staff_id=person.id,
+                            day=duty_day,
+                            code=duty_code,
+                            source="acceptance",
+                            annotation="OT" if day_index == 4 and person_index == 5 else "",
+                        ))
+                    for shift_code, position in (("M", positions[0]), ("A", positions[1])):
+                        roster.db.session.add(roster.PositionRequirement(
+                            unit_id=unit.id,
+                            day=duty_day,
+                            shift_code=shift_code,
+                            position_id=position.id,
+                            required_count=1,
+                            contingency_count=0,
+                        ))
+
+            leave_start = current_month + timedelta(days=9)
+            sickness_day = current_month + timedelta(days=4)
+            roster.db.session.add(roster.Leave(
+                unit_id=unit.id,
+                staff_id=people[6].id,
+                leave_type="AL",
+                start=leave_start,
+                end=leave_start + timedelta(days=2),
+            ))
+            roster.db.session.add(roster.Sickness(
+                unit_id=unit.id,
+                staff_id=people[7].id,
+                start=sickness_day,
+                end=sickness_day + timedelta(days=1),
+                code="SC",
+            ))
+            for person, duty_day, code_value in (
+                (people[6], leave_start, "AL"),
+                (people[6], leave_start + timedelta(days=1), "AL"),
+                (people[6], leave_start + timedelta(days=2), "AL"),
+                (people[7], sickness_day, "SC"),
+                (people[7], sickness_day + timedelta(days=1), "SC"),
+            ):
+                assignment = roster.Assignment.query.execution_options(
+                    skip_tenant_scope=True
+                ).filter_by(unit_id=unit.id, staff_id=person.id, day=duty_day).one()
+                assignment.code = code_value
+                assignment.source = "acceptance"
+
+            request_day = request_month + timedelta(days=6 + airport_index)
+            for request_index, status in enumerate(("pending", "approved", "rejected")):
+                roster.db.session.add(roster.ShiftRequest(
+                    unit_id=unit.id,
+                    staff_id=people[2 + request_index].id,
+                    day=request_day + timedelta(days=request_index),
+                    code=("D", "A", "M")[request_index],
+                    requester_comment=f"Acceptance {status} request example.",
+                    status=status,
+                    admin_response=(
+                        "" if status == "pending"
+                        else f"Acceptance manager response: {status}."
+                    ),
+                    responded_by_id=None if status == "pending" else people[0].id,
+                    responded_at=None if status == "pending" else roster.utcnow(),
+                ))
+
+            roster.db.session.add(roster.BreakPlan(
+                unit_id=unit.id,
+                day=args.as_of,
+                person_id=people[2].id,
+                position_id=positions[0].id,
+                start_time=time(10, 0),
+                end_time=time(10, 30),
+                recorded_by_id=people[0].id,
+            ))
+            roster.db.session.add(roster.AchievedDuty(
+                unit_id=unit.id,
+                person_id=people[3].id,
+                day=args.as_of - timedelta(days=1),
+                actual_start=datetime.combine(args.as_of - timedelta(days=1), time(6)),
+                actual_end=datetime.combine(args.as_of - timedelta(days=1), time(14, 15)),
+                duty_type="operational",
+                variance_reason="Handover extended by fifteen minutes.",
+                recorded_by_id=people[0].id,
+            ))
+            roster.db.session.add_all([
+                roster.FatigueReport(
+                    unit_id=unit.id,
+                    person_id=people[4].id,
+                    duty_day=args.as_of,
+                    severity="medium",
+                    summary="Reduced sleep following an unexpected domestic disturbance.",
+                    status="open",
+                ),
+                roster.FatigueReport(
+                    unit_id=unit.id,
+                    person_id=people[5].id,
+                    duty_day=args.as_of - timedelta(days=3),
+                    severity="low",
+                    summary="Tired near the end of a sequence; discussed with supervisor.",
+                    status="closed",
+                    manager_response="Reviewed; restorative rest confirmed before next duty.",
+                    reviewed_by_id=people[0].id,
+                    reviewed_at=roster.utcnow(),
+                    closed_at=roster.utcnow(),
+                ),
+            ])
+            roster.db.session.add(roster.RosterRuleVersion(
+                unit_id=unit.id,
+                version=1,
+                name="Acceptance rostering rules",
+                rules_json=json.dumps({
+                    "maximum_consecutive_duties": 6,
+                    "minimum_rest_hours": 12,
+                    "night_duty_limit": 3,
+                }),
+                state="approved",
+                effective_from=previous_month,
+                change_reference=f"{code}-ACCEPT-001",
+                consultation_summary=(
+                    "Acceptance dataset rule version approved for repeatable "
+                    "workflow and publication testing."
+                ),
+                approved_by_id=people[0].id,
+                approved_at=roster.utcnow(),
+            ))
+            roster.db.session.add(roster.Scenario(
+                unit_id=unit.id,
+                name="Summer traffic uplift",
+                changes_json=json.dumps([
+                    {"date": next_month.isoformat(), "shift": "D", "delta": 1},
+                    {"date": (next_month + timedelta(days=1)).isoformat(), "shift": "A", "delta": 1},
+                ]),
+                created_by_id=people[1].id,
+            ))
+            publication = roster.RosterPublication(
+                unit_id=unit.id,
+                year=previous_month.year,
+                month=previous_month.month,
+                version=1,
+                state="published",
+                snapshot_json=json.dumps({
+                    "airport": code,
+                    "month": previous_month.strftime("%Y-%m"),
+                    "release_assurance": {"acceptance_dataset": True},
+                }),
+                published_at=roster.utcnow(),
+            )
+            roster.db.session.add(publication)
+            roster.db.session.flush()
+            roster.db.session.add(roster.RosterAcknowledgement(
+                unit_id=unit.id,
+                publication_id=publication.id,
+                person_id=people[2].id,
+            ))
+            roster.db.session.add_all([
+                roster.Notification(
+                    unit_id=unit.id,
+                    recipient_id=people[2].id,
+                    kind="roster_published",
+                    message="Previous-month roster version 1 is ready to review.",
+                ),
+                roster.Notification(
+                    unit_id=unit.id,
+                    recipient_id=people[3].id,
+                    kind="request_update",
+                    message="Your shift request has been approved.",
+                ),
+            ])
+            roster.db.session.add(roster.DatabaseRoutingMetadata(
+                unit_id=unit.id,
+                secret_name=f"ATCROSTER_UNIT_{unit.id}_DATABASE_URL",
+                health="healthy",
+                migration_version="20260724_02",
+                storage_bytes=2_000_000 + airport_index * 500_000,
+            ))
+            for feature in ("operational_assurance", "scenario_planning", "sms_notifications"):
+                roster.db.session.add(roster.FeatureFlag(
+                    unit_id=unit.id,
+                    key=feature,
+                    enabled=feature != "sms_notifications",
+                ))
+            roster.db.session.add(roster.PlanHistory(
+                unit_id=unit.id,
+                plan=unit.plan,
+                active_user_limit=unit.active_user_limit,
+                changed_by_identity_id=platform_identity.id,
+            ))
+            roster.db.session.add(roster.AggregateUsageEvent(
+                unit_id=unit.id,
+                event_type="monthly_active_users",
+                count=staff_count,
+            ))
+            roster.db.session.add(roster.SuperAdminAudit(
+                actor_identity_id=platform_identity.id,
+                unit_id=unit.id,
+                action="acceptance_dataset_created",
+                safe_summary=f"{code} acceptance account prepared.",
+            ))
+
+            credentials.extend([
+                {
+                    "airport": name,
+                    "role": "Unit Admin",
+                    "username": people[0].username,
+                    "password": PASSWORD,
+                },
+                {
+                    "airport": name,
+                    "role": "Roster Editor",
+                    "username": people[1].username,
+                    "password": PASSWORD,
+                },
+                {
+                    "airport": name,
+                    "role": "Staff User",
+                    "username": people[2].username,
+                    "password": PASSWORD,
+                },
+            ])
+            summaries.append({
+                "airport": code,
+                "staff": staff_count,
+                "account_limit": account_limit,
+                "test_month": current_month.strftime("%Y-%m"),
+                "request_month": request_month.strftime("%Y-%m"),
+            })
+
+        roster.db.session.commit()
+
+        manifest = {
+            "generated_as_of": args.as_of.isoformat(),
+            "database": str(db_path),
+            "password_notice": "Acceptance use only. Never deploy these credentials.",
+            "credentials": credentials,
+            "airports": summaries,
+        }
+        manifest_path = db_path.with_suffix(".manifest.json")
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+
+        counts = {
+            "airports": roster.Unit.query.filter(
+                roster.Unit.status != "platform_control"
+            ).count(),
+            "staff": roster.Staff.query.execution_options(
+                skip_tenant_scope=True
+            ).filter_by(is_operational=True).count(),
+            "assignments": roster.Assignment.query.execution_options(
+                skip_tenant_scope=True
+            ).count(),
+            "requests": roster.ShiftRequest.query.execution_options(
+                skip_tenant_scope=True
+            ).count(),
+        }
+        print(json.dumps({
+            "status": "created",
+            "database": str(db_path),
+            "manifest": str(manifest_path),
+            "months": [month.strftime("%Y-%m") for month in months],
+            "counts": counts,
+        }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/static/styles.css
+++ b/static/styles.css
@@ -30,6 +30,7 @@
 
   --red:#e74c3c;     /* SSC, SC */
   --blue:#3498db;    /* AL, PL, SPL, TOUI, TOU8 */
+  --off-blue:#bfe5ff; /* OFF / rest day */
 
   --ui-scale: 1;     /* dynamic scaling for roster */
 }
@@ -37,6 +38,21 @@
 *{box-sizing:border-box;}
 
 ::selection{background:var(--accent-strong); color:#fff;}
+
+.skip-link{
+  position:fixed;
+  left:1rem;
+  top:.75rem;
+  z-index:3000;
+  padding:.65rem 1rem;
+  border-radius:var(--radius-sm);
+  background:#fff;
+  color:#081426;
+  font-weight:700;
+  transform:translateY(-160%);
+  transition:transform .15s ease;
+}
+.skip-link:focus{transform:translateY(0); color:#081426;}
 
 /* Office/WFH/MTG: grey fill */
 .code-input.office, .code-input.wfh, .code-input.mtg {
@@ -232,6 +248,22 @@ textarea:focus,
 
 textarea{min-height:140px; resize:vertical;}
 
+.password-field{
+  display:flex;
+  align-items:stretch;
+  margin-top:.35rem;
+}
+.password-field input{
+  flex:1;
+  min-width:0;
+  border-radius:var(--radius-sm) 0 0 var(--radius-sm);
+}
+.password-toggle{
+  min-width:72px;
+  border-radius:0 var(--radius-sm) var(--radius-sm) 0;
+  box-shadow:none;
+}
+
 .simple-list{list-style:none; margin:0; padding:0; display:grid; gap:.45rem;}
 .simple-list li{padding:.55rem .75rem; border-radius:var(--radius-sm); border:1px solid rgba(116,138,178,.24); background:rgba(15,23,38,.78); box-shadow:inset 0 1px 0 rgba(255,255,255,.02);}
 
@@ -338,6 +370,11 @@ textarea{min-height:140px; resize:vertical;}
   justify-content:flex-end;
 }
 
+.nav-toggle{
+  display:none;
+  min-height:42px;
+}
+
 .nav-link {
   position:relative;
   display:inline-flex;
@@ -388,9 +425,19 @@ textarea{min-height:140px; resize:vertical;}
 }
 
 @media (max-width: 900px){
-  .nav-container{flex-direction:column; align-items:flex-start;}
+  .nav-container{align-items:center; flex-wrap:wrap;}
   .brand{align-items:flex-start;}
-  .main-nav{width:100%; justify-content:flex-start;}
+  .nav-toggle{display:inline-flex; margin-left:auto;}
+  .main-nav{
+    display:none;
+    width:100%;
+    max-height:calc(100vh - 150px);
+    overflow-y:auto;
+    padding:.75rem 0 .25rem;
+    justify-content:flex-start;
+    border-top:1px solid var(--line);
+  }
+  .main-nav.is-open{display:flex;}
   .nav-link{padding:.45rem .9rem;}
 }
 
@@ -440,6 +487,29 @@ textarea{min-height:140px; resize:vertical;}
   background:rgba(231,76,60,.16);
   color:#ffc4ba;
   border-color:rgba(231,76,60,.55);
+}
+
+.error-state{text-align:center;}
+.error-state__code{
+  color:var(--accent);
+  font-family:var(--font-mono);
+  font-size:clamp(2.5rem, 8vw, 5rem);
+  font-weight:700;
+  line-height:1;
+  margin-bottom:1rem;
+}
+.error-state .card-hd{justify-content:center;}
+.error-state .action-buttons{justify-content:center;}
+
+form[aria-busy="true"]{opacity:.82;}
+
+@media (prefers-reduced-motion: reduce){
+  *, *::before, *::after{
+    scroll-behavior:auto !important;
+    animation-duration:.01ms !important;
+    animation-iteration-count:1 !important;
+    transition-duration:.01ms !important;
+  }
 }
 
 /* ==============================
@@ -588,6 +658,35 @@ th.sticky.left{left:0; z-index:3; background:var(--head);}
 
 .roster .cell form{ margin:0; }
 
+.roster-zoom-controls{
+  display:inline-flex;
+  align-items:center;
+  gap:.35rem;
+  margin-left:1rem;
+  padding:.25rem;
+  border:1px solid var(--line);
+  border-radius:var(--radius-sm);
+  background:rgba(9,16,33,.55);
+}
+.roster-zoom-label{
+  padding:0 .35rem;
+  color:var(--text-muted);
+  font-size:.78rem;
+  font-weight:700;
+  text-transform:uppercase;
+  letter-spacing:.05em;
+}
+.roster-zoom-controls .btn{
+  min-height:30px;
+  padding:.3rem .55rem;
+}
+.roster-zoom-controls .roster-zoom-btn.is-active{
+  color:#fff;
+  border-color:var(--accent);
+  background:var(--accent-soft);
+}
+#roster{overflow-x:auto; overflow-y:hidden;}
+
 .roster .cell select.code-input{
   width:100%;
   height:34px;
@@ -614,6 +713,7 @@ select.code-input{
 .code-input.group-d{ background: var(--purple); color:#fff; }
 .code-input.group-a{ background: var(--orange); color:#000; }
 .code-input.group-n{ background: var(--yellow); color:#000; }
+.code-input.off{ background: var(--off-blue); color:#10243a; }
 
 .code-input.sc, .code-input.ssc{ background: var(--red); color:#fff; }
 .code-input.al, .code-input.pl, .code-input.spl,
@@ -1299,6 +1399,7 @@ table.roster { transform-origin: top left; transform: scale(var(--ui-scale)); }
   .code-input.group-d{ background: var(--purple) !important; color:#fff !important; }
   .code-input.group-a{ background: var(--orange) !important; color:#000 !important; }
   .code-input.group-n{ background: var(--yellow) !important; color:#000 !important; }
+  .code-input.off{ background: var(--off-blue) !important; color:#10243a !important; }
   .code-input.al, .code-input.pl, .code-input.spl,
   .code-input.toui, .code-input.tou8{ background: var(--blue) !important; color:#000 !important; }
   .code-input.sc, .code-input.ssc{ background: var(--red) !important; color:#000 !important; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -26,6 +26,7 @@
   {% block extra_head %}{% endblock %}
 </head>
 <body class="app-body">
+  <a class="skip-link" href="#main">Skip to main content</a>
   <header class="site-header">
     <div class="nav-container">
       <div class="brand">
@@ -40,12 +41,17 @@
           </div>
         {% endif %}
       </div>
-      <nav class="main-nav" aria-label="Primary">
+      <button class="nav-toggle" type="button" aria-expanded="false"
+              aria-controls="primary-navigation">
+        <span aria-hidden="true">☰</span>
+        <span>Menu</span>
+      </button>
+      <nav class="main-nav" id="primary-navigation" aria-label="Primary">
         {% if current_user.is_authenticated %}
           {% if current_user.role == 'superadmin' %}
-            <a href="{{ url_for('platform_admin') }}" class="nav-link {% if request.endpoint == 'platform_admin' %}active{% endif %}">🛡️ Platform Admin</a>
+            <a href="{{ url_for('platform_admin') }}" {% if request.endpoint == 'platform_admin' %}aria-current="page"{% endif %} class="nav-link {% if request.endpoint == 'platform_admin' %}active{% endif %}">🛡️ Platform Admin</a>
           {% else %}
-            <a href="{{ url_for('index') }}" class="nav-link {% if request.endpoint == 'roster_month' %}active{% endif %}">📅 Roster</a>
+            <a href="{{ url_for('index') }}" {% if request.endpoint == 'roster_month' %}aria-current="page"{% endif %} class="nav-link {% if request.endpoint == 'roster_month' %}active{% endif %}">📅 Roster</a>
             <a href="{{ url_for('requests_page') }}" class="nav-link {% if request.endpoint == 'requests_page' %}active{% endif %}">📝 Requests</a>
             <a href="{{ url_for('publication_index') }}" class="nav-link {% if request.endpoint in ('publication_index','publication_centre') %}active{% endif %}">✅ Published</a>
             <a href="{{ url_for('staff_profile', sid=current_user.id) }}" class="nav-link {% if request.endpoint == 'staff_profile' %}active{% endif %}">👤 Profile</a>
@@ -70,11 +76,11 @@
     </div>
   </header>
 
-  <main id="main" class="app-main">
+  <main id="main" class="app-main" tabindex="-1">
     {% with messages = get_flashed_messages(with_categories=true) %}
       {% if messages %}
         <div class="container-xl">
-          <ul class="flashes">
+          <ul class="flashes" role="status" aria-live="polite" aria-atomic="true">
             {% for category, message in messages %}
               <li class="flash {{ category }}">{{ message }}</li>
             {% endfor %}
@@ -105,10 +111,128 @@
 
     function printRoster(){ window.print(); }
 
+    const navToggle = document.querySelector('.nav-toggle');
+    const primaryNavigation = document.querySelector('#primary-navigation');
+    if (navToggle && primaryNavigation) {
+      navToggle.addEventListener('click', () => {
+        const open = navToggle.getAttribute('aria-expanded') === 'true';
+        navToggle.setAttribute('aria-expanded', open ? 'false' : 'true');
+        primaryNavigation.classList.toggle('is-open', !open);
+      });
+      primaryNavigation.addEventListener('click', (event) => {
+        if (event.target.closest('a') && window.innerWidth <= 900) {
+          navToggle.setAttribute('aria-expanded', 'false');
+          primaryNavigation.classList.remove('is-open');
+        }
+      });
+    }
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && navToggle && primaryNavigation) {
+        navToggle.setAttribute('aria-expanded', 'false');
+        primaryNavigation.classList.remove('is-open');
+        navToggle.focus();
+      }
+    });
+
+    document.querySelectorAll('[data-password-toggle]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const input = document.getElementById(button.dataset.passwordToggle);
+        if (!input) return;
+        const reveal = input.type === 'password';
+        input.type = reveal ? 'text' : 'password';
+        button.textContent = reveal ? 'Hide' : 'Show';
+        button.setAttribute('aria-label', reveal ? 'Hide password' : 'Show password');
+        button.setAttribute('aria-pressed', reveal ? 'true' : 'false');
+        input.focus();
+      });
+    });
+
+    document.querySelectorAll('.nav-link.active').forEach((link) => {
+      link.setAttribute('aria-current', 'page');
+    });
+
+    // Prevent accidental duplicate writes while preserving the clicked
+    // submit button's action/name in the submitted payload.
+    document.querySelectorAll('form[method="post"], form[method="POST"]').forEach((form) => {
+      form.addEventListener('submit', (event) => {
+        if (form.dataset.submitting === 'true') {
+          event.preventDefault();
+          return;
+        }
+        if (!form.checkValidity()) return;
+        form.dataset.submitting = 'true';
+        form.setAttribute('aria-busy', 'true');
+        const submitter = event.submitter;
+        if (submitter && submitter.name) {
+          const actionValue = document.createElement('input');
+          actionValue.type = 'hidden';
+          actionValue.name = submitter.name;
+          actionValue.value = submitter.value;
+          form.appendChild(actionValue);
+        }
+        window.setTimeout(() => {
+          form.querySelectorAll('button[type="submit"], input[type="submit"], button:not([type])')
+            .forEach((button) => {
+              button.disabled = true;
+              button.setAttribute('aria-disabled', 'true');
+            });
+        }, 0);
+      });
+    });
+
+    const rosterZoomStorageKey = 'atcroster-roster-zoom';
+    let rosterZoomPreference = 'fit';
+    try {
+      const savedRosterZoom = window.localStorage.getItem(rosterZoomStorageKey);
+      if (['fit', '0.75', '0.90', '1'].includes(savedRosterZoom)) {
+        rosterZoomPreference = savedRosterZoom;
+      }
+    } catch (_error) {
+      rosterZoomPreference = 'fit';
+    }
+
+    function markRosterZoomPreset(value) {
+      document.querySelectorAll('[data-roster-zoom]').forEach((button) => {
+        const active = button.dataset.rosterZoom === value;
+        button.classList.toggle('is-active', active);
+        button.setAttribute('aria-pressed', active ? 'true' : 'false');
+      });
+    }
+
+    function applyRosterZoom(scale, preference) {
+      const host = document.querySelector('#roster');
+      document.documentElement.style.setProperty('--ui-scale', scale.toFixed(3));
+      if (host) {
+        host.dataset.scale = scale.toFixed(3);
+        host.dataset.zoomMode = preference;
+      }
+      markRosterZoomPreset(preference);
+    }
+
+    function setRosterZoomPreset(value) {
+      rosterZoomPreference = ['fit', '0.75', '0.90', '1'].includes(value)
+        ? value : 'fit';
+      try {
+        window.localStorage.setItem(rosterZoomStorageKey, rosterZoomPreference);
+      } catch (_error) {
+        // Browser privacy settings may disable local storage.
+      }
+      if (rosterZoomPreference === 'fit') {
+        fitRoster(true);
+      } else {
+        applyRosterZoom(Number(rosterZoomPreference), rosterZoomPreference);
+      }
+    }
+
     // Auto-fit roster to viewport (scale UI, avoid horizontal scroll)
-    function fitRoster() {
+    function fitRoster(force = false) {
       const table = document.querySelector('#roster table.roster, table.roster');
       if (!table) return;
+
+      if (!force && rosterZoomPreference !== 'fit') {
+        applyRosterZoom(Number(rosterZoomPreference), rosterZoomPreference);
+        return;
+      }
 
       const host = table.closest('#roster') || table.parentElement;
       const hostRect = host ? host.getBoundingClientRect() : null;
@@ -142,10 +266,7 @@
       scale = Math.min(1, scale);
       if (scale < minScale) scale = minScale;
 
-      document.documentElement.style.setProperty('--ui-scale', scale.toFixed(3));
-      if (host) {
-        host.dataset.scale = scale.toFixed(3);
-      }
+      applyRosterZoom(scale, 'fit');
     }
 
     // Schedule layout work so rapid resize events don't thrash the layout engine
@@ -162,7 +283,11 @@
     let rosterResizeObserver = null;
 
     window.addEventListener('load', () => {
-      fitRoster();
+      if (rosterZoomPreference === 'fit') {
+        fitRoster(true);
+      } else {
+        applyRosterZoom(Number(rosterZoomPreference), rosterZoomPreference);
+      }
       window.addEventListener('resize', scheduleFit, { passive: true });
 
       const table = document.querySelector('#roster table.roster, table.roster');

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,11 +1,17 @@
 {% extends "base.html" %}
-{% block title %}Service error · ATC Roster{% endblock %}
+{% block title %}{{ error_title or 'Service error' }} · ATC Roster{% endblock %}
 {% block content %}
 <div class="container container--narrow py-5">
-  <section class="card"><div class="card-hd">We could not complete that request</div><div class="card-bd">
-    <p>The event has been recorded. Do not repeat safety-critical changes until you have confirmed whether the first attempt succeeded.</p>
-    <p>Reference: <code>{{ request_id }}</code></p>
-    <a class="btn" href="{{ url_for('index') }}">Return to roster</a>
+  <section class="card error-state">
+    <div class="error-state__code">{{ status_code or 500 }}</div>
+    <div class="card-hd">{{ error_title or 'We could not complete that request' }}</div>
+    <div class="card-bd">
+    <p>{{ error_message or 'The event has been recorded. Do not repeat safety-critical changes until you have confirmed whether the first attempt succeeded.' }}</p>
+    {% if request_id %}<p>Reference: <code>{{ request_id }}</code></p>{% endif %}
+    <div class="action-buttons">
+      <button class="btn ghost" type="button" onclick="history.back()">Go back</button>
+      <a class="btn btn-primary" href="{{ url_for('index') }}">Return to roster</a>
+    </div>
   </div></section>
 </div>
 {% endblock %}

--- a/templates/leave.html
+++ b/templates/leave.html
@@ -21,6 +21,7 @@
     <div class="card-header"><strong>Add Annual/Parental/Special Leave</strong></div>
     <div class="card-body">
       <form class="row g-3 align-items-end" method="post">
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
         <input type="hidden" name="form" value="leave_add">
         <div class="col-md-4">
           <label class="form-label">Staff</label>
@@ -60,6 +61,7 @@
     <div class="card-header"><strong>Add Sickness (SC/SSC)</strong></div>
     <div class="card-body">
       <form class="row g-3 align-items-end" method="post">
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
         <input type="hidden" name="form" value="sick_add">
         <div class="col-md-4">
           <label class="form-label">Staff</label>
@@ -123,6 +125,7 @@
             <td>{{ a.code }}</td>
             <td>
               <form class="d-inline" method="post">
+                <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
                 <input type="hidden" name="form" value="sick_edit">
                 <input type="hidden" name="staff_id" value="{{ a.staff_id }}">
                 <input type="hidden" name="start" value="{{ a.day }}">
@@ -133,7 +136,9 @@
                 </select>
                 <button class="btn btn-sm btn-secondary" type="submit">Save</button>
               </form>
-              <form class="d-inline ms-1" method="post">
+              <form class="d-inline ms-1" method="post"
+                    onsubmit="return confirm('Delete this sickness record?');">
+                <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
                 <input type="hidden" name="form" value="sick_delete">
                 <input type="hidden" name="staff_id" value="{{ a.staff_id }}">
                 <input type="hidden" name="start" value="{{ a.day }}">
@@ -173,6 +178,7 @@
             <td>{{ lv.end }}</td>
             <td>
               <form class="d-inline" method="post">
+                <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
                 <input type="hidden" name="form" value="leave_edit">
                 <input type="hidden" name="leave_id" value="{{ lv.id }}">
                 <input type="hidden" name="staff_id" value="{{ lv.staff_id }}">
@@ -181,7 +187,9 @@
                 <input type="date" class="form-control form-control-sm d-inline-block" style="width: 150px" name="end" value="{{ lv.end }}">
                 <button class="btn btn-sm btn-secondary" type="submit">Save</button>
               </form>
-              <form class="d-inline ms-1" method="post">
+              <form class="d-inline ms-1" method="post"
+                    onsubmit="return confirm('Delete this leave record?');">
+                <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
                 <input type="hidden" name="form" value="leave_delete">
                 <input type="hidden" name="leave_id" value="{{ lv.id }}">
                 <button class="btn btn-sm btn-danger" type="submit">Delete</button>

--- a/templates/login.html
+++ b/templates/login.html
@@ -7,13 +7,19 @@
     <div class="card-bd">
       <form method="post" class="grid">
         <label>Username
-          <input name="username" autocomplete="username" required>
+          <input name="username" autocomplete="username" required autofocus>
         </label>
         <label>Password
-          <input name="password" type="password" autocomplete="current-password" required>
+          <span class="password-field">
+            <input id="login-password" name="password" type="password"
+                   autocomplete="current-password" required>
+            <button class="password-toggle" type="button"
+                    data-password-toggle="login-password"
+                    aria-label="Show password" aria-pressed="false">Show</button>
+          </span>
         </label>
         <div>
-          <button class="btn"><i class="fa-solid fa-right-to-bracket"></i> Sign in</button>
+          <button class="btn btn-primary" type="submit"><i class="fa-solid fa-right-to-bracket"></i> Sign in</button>
         </div>
       </form>
     </div>

--- a/templates/overtime.html
+++ b/templates/overtime.html
@@ -6,6 +6,8 @@
 <div class="card" style="margin-bottom:1rem">
   <div class="card-bd">
     <form method="post" class="toolbar">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+      <input type="hidden" name="action" value="find">
       <label>Date <input type="date" name="date" value="{{ chosen_date }}"></label>
       <label>Shift
         <select name="shift_code">
@@ -19,12 +21,22 @@
   </div>
 </div>
 
-{% if results %}
+{% if searched %}
 <form method="post" class="card">
+  <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
   <input type="hidden" name="action" value="send_sms">
   <input type="hidden" name="date" value="{{ chosen_date }}">
   <input type="hidden" name="shift_code" value="{{ chosen_shift }}">
   <div class="card-bd">
+    <div class="section-heading">
+      <div>
+        <h2>Eligibility result</h2>
+        <p class="muted">
+          {{ results|length }} eligible ATCO{% if results|length != 1 %}s{% endif %}
+          for {{ chosen_shift }} on {{ chosen_date }}.
+        </p>
+      </div>
+    </div>
     <div class="table-scroll">
       <table class="table">
         <thead>
@@ -65,12 +77,23 @@
               </td>
             </tr>
           {% else %}
-            <tr><td colspan="7" class="muted">No eligible staff match the rules.</td></tr>
+            <tr>
+              <td colspan="7">
+                <strong>Nobody is eligible for overtime for this date and shift.</strong>
+                <div class="muted">
+                  Staff already working, opted out, without an in-date
+                  endorsement or required qualification, at six consecutive
+                  duties, or creating a blocking fatigue issue are excluded.
+                  Try another date or shift.
+                </div>
+              </td>
+            </tr>
           {% endfor %}
         </tbody>
       </table>
     </div>
 
+    {% if results %}
     <div class="grid grid-2" style="gap:1rem; margin-top:1rem; align-items:start">
       <label>Message
         <textarea name="message" rows="3" maxlength="480" placeholder="SMS body">{{ sms_body }}</textarea>
@@ -85,6 +108,7 @@
         </button>
       </div>
     </div>
+    {% endif %}
   </div>
 </form>
 {% endif %}

--- a/templates/requests.html
+++ b/templates/requests.html
@@ -92,7 +92,8 @@
                   </td>
                   <td>
                     {% if not is_locked(day.year, day.month) and (req.status or 'pending') == 'pending' %}
-                      <form method="post" class="d-inline">
+                      <form method="post" class="d-inline"
+                            onsubmit="return confirm('Cancel this pending shift request?');">
                         <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
                         <input type="hidden" name="form" value="del">
                         <input type="hidden" name="rid" value="{{ req.id }}">

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -73,11 +73,24 @@
   <a class="btn" href="{{ url_for('roster_export_csv', ym=ym) }}" style="margin-left:1rem">Export CSV</a>
   <button class="btn" onclick="printRoster()">Print</button>
 
+  <div class="roster-zoom-controls" role="group" aria-label="Roster zoom">
+    <span class="roster-zoom-label">Zoom</span>
+    <button type="button" class="btn ghost roster-zoom-btn" data-roster-zoom="0.75"
+            onclick="setRosterZoomPreset('0.75')">75%</button>
+    <button type="button" class="btn ghost roster-zoom-btn" data-roster-zoom="0.90"
+            onclick="setRosterZoomPreset('0.90')">90%</button>
+    <button type="button" class="btn ghost roster-zoom-btn" data-roster-zoom="1"
+            onclick="setRosterZoomPreset('1')">100%</button>
+    <button type="button" class="btn ghost roster-zoom-btn" data-roster-zoom="fit"
+            onclick="setRosterZoomPreset('fit')">Fit width</button>
+  </div>
+
   {# Admin-only: Run AI for Month (POST) #}
   {% if current_user.is_authenticated and is_admin %}
     <form method="post"
           action="{{ url_for('admin_ai_generate', ym=ym) }}"
           style="display:inline;">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
       <button class="btn" type="submit" style="margin-left:.5rem;"
               onclick="return confirm('Run AI for {{ month_title }} now?');">
         Run AI for Month
@@ -140,6 +153,7 @@
           <td class="cell {{ 'editable' if can_edit and not readonly else 'locked' }}{% if not s.is_operational %} nonop{% endif %}{% if f %} fatigue{% endif %}{% if d == today %} is-today{% endif %}{% if code in training_codes %} training{% endif %}">
             <!-- SHIFT CODE -->
             <form method="post" action="{{ url_for('assign_cell', staff_id=s.id, ym=ym, day=d.isoformat()) }}">
+              <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
               <select
                 name="code"
                 class="code-input {% if code %}{{ code|lower }} group-{{ prefix }}{% endif %}"
@@ -183,6 +197,7 @@
 
             <!-- ANNOTATION -->
             <form method="post" action="{{ url_for('assign_cell', staff_id=s.id, ym=ym, day=d.isoformat()) }}">
+              <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
               <select
                 name="annotation"
                 class="annot-select {% if ann %}has-annotation{% endif %}"

--- a/templates/unit_accounts.html
+++ b/templates/unit_accounts.html
@@ -30,7 +30,8 @@
         <td>{{ membership.status }}</td>
         <td>
           {% if membership.status == "active" and membership.person_id != current_user.id %}
-          <form method="post">
+          <form method="post"
+                onsubmit="return confirm('Deactivate this account? The user will no longer be able to sign in.');">
             <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="action" value="deactivate">
             <input type="hidden" name="membership_id" value="{{ membership.id }}">

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -50,6 +50,12 @@ from app import (
 )
 
 
+def csrf(client):
+    client.get("/roster/2025-07")
+    with client.session_transaction() as session:
+        return session["_csrf_token"]
+
+
 @pytest.fixture(scope="module", autouse=True)
 def setup_database():
     """Create a clean database for the duration of the module."""
@@ -166,7 +172,7 @@ def test_assign_cell_keeps_request_record_and_marks_fulfilled():
 
     assign_resp = client.post(
         f"/assign/{requester.id}/2025-07/{req_day.isoformat()}",
-        data={"code": "M"},
+        data={"_csrf_token": csrf(client), "code": "M"},
         follow_redirects=False,
     )
     assert assign_resp.status_code == 302

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -23,6 +23,7 @@ from app import (
     Staff,
     ShiftType,
     StaffWatchHistory,
+    Unit,
     ensure_month_requirement,
     generate_month,
     refresh_shift_cache,
@@ -39,6 +40,9 @@ def setup_database():
         db.drop_all()
         db.create_all()
 
+        db.session.add(Unit(
+            id=1, code="TST", name="Test Airport", active_user_limit=20
+        ))
         watch_a = Watch(name="Watch A", order_index=1)
         watch_b = Watch(name="Watch B", order_index=2)
         db.session.add_all([watch_a, watch_b])
@@ -64,6 +68,61 @@ def setup_database():
         )
         admin.set_password(ADMIN_CREDENTIALS["password"])
         db.session.add(admin)
+        role_users = [
+            Staff(
+                unit_id=1, username="editor_test", name="Editor Test",
+                staff_no="ED-001", role="editor", watch=watch_a,
+                is_operational=True,
+            ),
+            Staff(
+                unit_id=1, username="watch_manager_test", name="Watch Manager Test",
+                staff_no="WM-001", role="user", watch=watch_a,
+                is_wm=True, is_operational=True,
+            ),
+            Staff(
+                unit_id=1, username="duty_watch_manager_test",
+                name="Duty Watch Manager Test", staff_no="DWM-001",
+                role="user", watch=watch_b, is_dwm=True,
+                is_operational=True,
+            ),
+            Staff(
+                unit_id=1, username="staff_test", name="Staff Test",
+                staff_no="USR-001", role="user", watch=watch_b,
+                is_operational=True,
+            ),
+        ]
+        for user in role_users:
+            user.set_password("password123")
+        db.session.add_all(role_users)
+
+        control = Unit(
+            id=2, code="CTRL", name="Platform Control",
+            status="platform_control", active_user_limit=5,
+        )
+        other_unit = Unit(
+            id=3, code="OTH", name="Other Airport", active_user_limit=5,
+        )
+        db.session.add_all([control, other_unit])
+        db.session.flush()
+        platform_user = Staff(
+            unit_id=control.id, username="platform_test",
+            name="Platform Test", staff_no="CTRL-001",
+            role="superadmin", is_operational=False,
+        )
+        platform_user.set_password("password123")
+        other_user = Staff(
+            unit_id=other_unit.id, username="other_staff_test",
+            name="Other Airport Staff", staff_no="OTH-001",
+            role="user", is_operational=True,
+        )
+        other_user.set_password("password123")
+        db.session.add_all([platform_user, other_user])
+        db.session.flush()
+        db.session.add(app.PlatformIdentity(
+            public_id="platform-role-test",
+            username=platform_user.username,
+            password_hash=platform_user.password_hash,
+        ))
         db.session.commit()
 
         ensure_month_requirement(2025, 4)
@@ -104,6 +163,39 @@ def test_login_page_loads(client):
     resp = client.get("/login")
     assert resp.status_code == 200
     assert b"Login" in resp.data
+    assert b"Skip to main content" in resp.data
+    assert b'class="nav-toggle"' in resp.data
+    assert b'data-password-toggle="login-password"' in resp.data
+
+
+def test_friendly_error_pages_preserve_status_codes(client):
+    missing = client.get("/this-page-does-not-exist")
+    assert missing.status_code == 404
+    assert b"That page or record was not found" in missing.data
+
+    login(client)
+    expired_form = client.post(
+        "/leave",
+        data={
+            "form": "leave_add",
+            "staff_id": "1",
+            "leave_type": "AL",
+            "start": "2025-04-01",
+            "end": "2025-04-01",
+        },
+    )
+    assert expired_form.status_code == 400
+    assert b"page or form has expired" in expired_form.data
+
+
+def test_roster_has_persistent_zoom_presets(client):
+    login(client)
+    response = client.get("/roster/2025-04")
+    assert response.status_code == 200
+    assert b'data-roster-zoom="0.75"' in response.data
+    assert b'data-roster-zoom="0.90"' in response.data
+    assert b'data-roster-zoom="1"' in response.data
+    assert b'data-roster-zoom="fit"' in response.data
 
 
 def test_favicon_is_served(client):
@@ -200,11 +292,161 @@ def test_security_headers_are_present(client):
     assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
 
 
+def test_role_permission_matrix_and_cross_airport_isolation():
+    credentials = {
+        "superadmin": "platform_test",
+        "admin": ADMIN_CREDENTIALS["username"],
+        "editor": "editor_test",
+        "watch_manager": "watch_manager_test",
+        "duty_watch_manager": "duty_watch_manager_test",
+        "staff": "staff_test",
+    }
+    common = {
+        "roster": "/roster/2025-04",
+        "requests": "/requests",
+        "published": "/publications/2025-04",
+        "fatigue": "/fatigue/report",
+        "overtime": "/overtime",
+        "leave": "/leave",
+        "reports": "/reports",
+        "metrics": "/metrics",
+        "qualification": "/compliance",
+        "compliance": "/compliance-centre?ym=2025-04",
+        "operations": "/operations/2025-04",
+        "coverage": "/planning/coverage/2025-04",
+        "scenarios": "/planning/scenarios",
+        "accounts": "/unit/accounts",
+        "onboarding": "/unit/onboarding",
+        "admin": "/admin",
+        "reference": "/admin/reference",
+        "platform": "/platform/admin",
+    }
+    expected = {
+        "superadmin": {
+            **{name: 403 for name in common},
+            "platform": 200,
+        },
+        "admin": {
+            **{name: 200 for name in common},
+            "platform": 403,
+        },
+        "editor": {
+            "roster": 200, "requests": 200, "published": 200,
+            "fatigue": 200, "overtime": 200, "leave": 200,
+            "reports": 302, "metrics": 200, "qualification": 200,
+            "compliance": 403, "operations": 403, "coverage": 200,
+            "scenarios": 200, "accounts": 403, "onboarding": 403,
+            "admin": 403, "reference": 403, "platform": 403,
+        },
+        "watch_manager": {
+            "roster": 200, "requests": 200, "published": 200,
+            "fatigue": 200, "overtime": 403, "leave": 403,
+            "reports": 403, "metrics": 403, "qualification": 403,
+            "compliance": 403, "operations": 403, "coverage": 200,
+            "scenarios": 200, "accounts": 403, "onboarding": 403,
+            "admin": 403, "reference": 403, "platform": 403,
+        },
+        "duty_watch_manager": {
+            "roster": 200, "requests": 200, "published": 200,
+            "fatigue": 200, "overtime": 403, "leave": 403,
+            "reports": 403, "metrics": 403, "qualification": 403,
+            "compliance": 403, "operations": 403, "coverage": 200,
+            "scenarios": 200, "accounts": 403, "onboarding": 403,
+            "admin": 403, "reference": 403, "platform": 403,
+        },
+        "staff": {
+            "roster": 200, "requests": 200, "published": 200,
+            "fatigue": 200, "overtime": 403, "leave": 403,
+            "reports": 403, "metrics": 403, "qualification": 403,
+            "compliance": 403, "operations": 403, "coverage": 403,
+            "scenarios": 403, "accounts": 403, "onboarding": 403,
+            "admin": 403, "reference": 403, "platform": 403,
+        },
+    }
+
+    clients = {}
+    for role, username in credentials.items():
+        role_client = app.app.test_client()
+        response = role_client.post(
+            "/login",
+            data={"username": username, "password": "password123"},
+        )
+        assert response.status_code == 302
+        clients[role] = role_client
+        for capability, path in common.items():
+            actual = role_client.get(path).status_code
+            assert actual == expected[role][capability], (
+                role, capability, actual, expected[role][capability]
+            )
+
+    assert clients["superadmin"].get("/").headers["Location"].endswith(
+        "/platform/admin"
+    )
+
+    with app.app.app_context():
+        admin = Staff.query.filter_by(
+            username=ADMIN_CREDENTIALS["username"]
+        ).one()
+        same_unit_other = Staff.query.filter_by(username="staff_test").one()
+        other_airport = db.session.query(Staff).execution_options(
+            skip_tenant_scope=True
+        ).filter_by(username="other_staff_test").one()
+
+    assert clients["staff"].get(
+        f"/staff/{same_unit_other.id}"
+    ).status_code == 200
+    assert clients["staff"].get(f"/staff/{admin.id}").status_code == 403
+    assert clients["admin"].get(f"/staff/{same_unit_other.id}").status_code == 200
+    assert clients["admin"].get(f"/staff/{other_airport.id}").status_code == 404
+
+    target_day = "2025-04-02"
+    assert clients["staff"].post(
+        f"/assign/{admin.id}/2025-04/{target_day}",
+        data={"_csrf_token": csrf(clients["staff"]), "code": "A"},
+    ).status_code == 403
+    assert clients["watch_manager"].post(
+        f"/assign/{admin.id}/2025-04/{target_day}",
+        data={
+            "_csrf_token": csrf(clients["watch_manager"]),
+            "code": "A",
+        },
+    ).status_code == 302
+    assert clients["duty_watch_manager"].post(
+        f"/assign/{admin.id}/2025-04/{target_day}",
+        data={
+            "_csrf_token": csrf(clients["duty_watch_manager"]),
+            "code": "N",
+        },
+    ).status_code == 302
+    assert clients["editor"].post(
+        f"/assign/{admin.id}/2025-04/{target_day}",
+        data={"_csrf_token": csrf(clients["editor"]), "code": "M"},
+    ).status_code == 302
+
+
 def test_health_endpoints_report_ready(client):
     assert client.get("/health/live").get_json()["status"] == "ok"
     ready = client.get("/health/ready")
     assert ready.status_code == 200
     assert ready.get_json()["status"] == "ready"
+
+
+def test_overtime_finder_reports_an_empty_search_instead_of_looking_broken(client):
+    login(client)
+    token = csrf(client)
+    response = client.post(
+        "/overtime",
+        data={
+            "_csrf_token": token,
+            "action": "find",
+            "date": "2025-04-01",
+            "shift_code": "M",
+        },
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert b"Eligibility result" in response.data
+    assert b"Nobody is eligible for overtime for this date and shift" in response.data
 
 
 def test_production_operations_and_fatigue_workflows(client):


### PR DESCRIPTION
## What changed

- adds a deterministic multi-airport acceptance dataset and a complete manual test script
- hardens the shared UX with roster zoom presets, OFF-duty highlighting, mobile navigation, accessible recovery states, duplicate-submit protection, and clearer overtime results
- enforces server-side role boundaries for Platform Super Admin, Unit Admin, Editor, WM/DWM, and Staff User
- closes direct-URL access to operational data for Platform Super Admin and unit-wide qualification/coverage data for ordinary staff
- adds CSRF validation to roster-cell, AI-generation, leave/sickness, and overtime writes
- documents the tested permission matrix and the currently unavailable ReadOnlyAuditor product target
- expands regression coverage for role access, cross-airport isolation, error recovery, zoom controls, and overtime empty states

## Why

The acceptance platform needed stable rolling data and a repeatable test procedure. Permission checks also needed to be enforced consistently on the server rather than relying on hidden navigation, and several workflows needed clearer user feedback.

## Impact

Managers and staff receive a more predictable, accessible interface. Each implemented role now has an explicit, tested capability boundary, while cross-airport and control-plane isolation are enforced for direct URL access and writes.

## Validation

- `python -m pytest -q` — 38 passed
- `python -m compileall -q app.py tenancy.py saas_models.py account_limits.py scripts`
- `git diff --cached --check`
- live interactive checks across Super Admin, Unit Admin, Editor, Watch Manager, Duty Watch Manager, and Staff User accounts
- acceptance database readiness check passed