### PR TITLE
Fix roster shift colours

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -709,15 +709,19 @@ select.code-input{
   text-transform:uppercase;
 }
 
-.code-input.group-m{ background: var(--green); color:#000; }
-.code-input.group-d{ background: var(--purple); color:#fff; }
-.code-input.group-a{ background: var(--orange); color:#000; }
-.code-input.group-n{ background: var(--yellow); color:#000; }
-.code-input.off{ background: var(--off-blue); color:#10243a; }
+.roster .cell select.code-input.group-m{ background: var(--green); color:#000; }
+.roster .cell select.code-input.group-d{ background: var(--purple); color:#fff; }
+.roster .cell select.code-input.group-a{ background: var(--orange); color:#000; }
+.roster .cell select.code-input.group-n{ background: var(--yellow); color:#000; }
+.roster .cell select.code-input.off{ background: var(--off-blue); color:#10243a; }
 
-.code-input.sc, .code-input.ssc{ background: var(--red); color:#fff; }
-.code-input.al, .code-input.pl, .code-input.spl,
-.code-input.toui, .code-input.tou8{ background: var(--blue); color:#000; }
+.roster .cell select.code-input.sc,
+.roster .cell select.code-input.ssc{ background: var(--red); color:#fff; }
+.roster .cell select.code-input.al,
+.roster .cell select.code-input.pl,
+.roster .cell select.code-input.spl,
+.roster .cell select.code-input.toui,
+.roster .cell select.code-input.tou8{ background: var(--blue); color:#000; }
 
 .annot-select{
   width:100%;

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -197,6 +197,11 @@ def test_roster_has_persistent_zoom_presets(client):
     assert b'data-roster-zoom="1"' in response.data
     assert b'data-roster-zoom="fit"' in response.data
 
+    stylesheet = client.get("/static/styles.css")
+    assert stylesheet.status_code == 200
+    assert b".roster .cell select.code-input.off" in stylesheet.data
+    assert b"background: var(--off-blue)" in stylesheet.data
+
 
 def test_favicon_is_served(client):
     resp = client.get("/favicon.ico")


### PR DESCRIPTION
## What changed

- increases the specificity of roster shift-colour selectors so the generic select background can no longer override them
- restores light-blue OFF cells and the intended Morning, Day, Afternoon, Night, sickness, leave and TOIL colours
- adds a regression assertion for the rendered OFF selector and colour variable

## Root cause

The generic `.roster .cell select.code-input` rule was more specific than the semantic shift-colour selectors, so browsers computed a transparent background even though the colour rules existed.

## Impact

The monthly roster is immediately scannable again, with OFF shifts shown in light blue and operational shifts using their configured semantic colours.

## Validation

- 38 automated tests passed
- live browser computed styles verified: OFF `rgb(191, 229, 255)`, Morning green, Afternoon orange, Night yellow
- visual roster screenshot confirmed the corrected colours
- `git diff --check` passed