### PR TITLE
Add elite operational command centre

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -288,15 +288,73 @@ textarea{min-height:140px; resize:vertical;}
   display:flex;
   align-items:center;
   justify-content:space-between;
-  gap:1.5rem;
-  max-width:1600px;
+  gap:1rem 1.5rem;
+  max-width:1800px;
   margin:0 auto;
+  flex-wrap:wrap;
 }
 
-.brand{display:flex; flex-direction:column; gap:.1rem;}
+.brand{
+  display:flex;
+  align-items:center;
+  gap:.85rem;
+  min-width:max-content;
+}
+
+.brand-mark{
+  position:relative;
+  display:grid;
+  place-items:center;
+  width:46px;
+  height:46px;
+  flex:0 0 46px;
+  border:1px solid rgba(120,185,255,.58);
+  border-radius:50%;
+  background:
+    radial-gradient(circle, rgba(133,205,255,.95) 0 2px, transparent 3px),
+    repeating-radial-gradient(circle, transparent 0 7px, rgba(116,182,255,.22) 8px 9px),
+    rgba(24,57,101,.72);
+  box-shadow:0 0 0 5px rgba(76,146,255,.08), 0 16px 38px -20px rgba(75,177,255,.9);
+  overflow:hidden;
+}
+
+.brand-mark::before{
+  content:"";
+  position:absolute;
+  width:50%;
+  height:1px;
+  left:50%;
+  top:50%;
+  transform-origin:left center;
+  background:linear-gradient(90deg, rgba(132,218,255,.9), transparent);
+  animation:radar-sweep 5s linear infinite;
+}
+
+.brand-mark::after{
+  content:"";
+  position:absolute;
+  inset:5px;
+  border-radius:50%;
+  border:1px solid rgba(166,218,255,.2);
+}
+
+@keyframes radar-sweep{
+  to{transform:rotate(360deg);}
+}
+
+.brand-copy{display:flex; flex-direction:column; gap:.03rem;}
+
+.brand-eyebrow{
+  color:#7dd3fc;
+  font-size:.62rem;
+  font-weight:700;
+  letter-spacing:.18em;
+  line-height:1.2;
+  text-transform:uppercase;
+}
 
 .logo {
-  font-size: clamp(1.25rem, 1.1rem + .5vw, 1.7rem);
+  font-size:clamp(1.2rem, 1.08rem + .45vw, 1.58rem);
   font-weight:700;
   margin:0;
   letter-spacing:.08em;
@@ -310,29 +368,65 @@ textarea{min-height:140px; resize:vertical;}
 
 .logo-sub{
   margin:0;
-  font-size:.82rem;
-  letter-spacing:.36em;
+  font-size:.67rem;
+  letter-spacing:.2em;
   text-transform:uppercase;
   color:rgba(170,188,224,.7);
   font-weight:600;
 }
 
+.command-context{
+  display:flex;
+  align-items:stretch;
+  gap:.55rem;
+  min-width:0;
+  margin-left:auto;
+}
+
 .airport-context{
   display:flex;
   align-items:center;
-  flex-wrap:wrap;
-  gap:.45rem;
-  width:max-content;
-  max-width:100%;
-  margin-top:.45rem;
-  padding:.36rem .55rem .36rem .7rem;
-  border:1px solid rgba(108,179,255,.5);
-  border-radius:999px;
-  background:linear-gradient(135deg, rgba(34,87,150,.62), rgba(25,52,92,.88));
-  box-shadow:0 12px 30px -20px rgba(56,189,248,.8);
+  gap:.55rem;
+  padding:.48rem .55rem;
+  border:1px solid rgba(108,179,255,.42);
+  border-radius:12px;
+  background:linear-gradient(135deg, rgba(30,75,132,.58), rgba(20,43,77,.8));
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.04), 0 14px 34px -26px rgba(56,189,248,.8);
   color:#f8fbff;
   line-height:1.2;
+  min-width:0;
 }
+
+.context-icon{
+  position:relative;
+  display:grid;
+  place-items:center;
+  width:30px;
+  height:30px;
+  border-radius:9px;
+  background:rgba(120,196,255,.12);
+  color:#8ed8ff;
+}
+
+.context-icon::before{
+  content:"";
+  width:14px;
+  height:14px;
+  border:1px solid #8ed8ff;
+  border-radius:50%;
+  background:radial-gradient(circle, #8ed8ff 0 2px, transparent 3px);
+  box-shadow:0 0 10px rgba(142,216,255,.42);
+}
+
+.context-icon::after{
+  content:"";
+  position:absolute;
+  width:18px;
+  height:1px;
+  background:linear-gradient(90deg, transparent, rgba(142,216,255,.8), transparent);
+}
+
+.context-copy{display:flex; flex-direction:column; justify-content:center; min-width:0;}
 
 .airport-context__label{
   color:rgba(201,222,255,.78);
@@ -343,8 +437,12 @@ textarea{min-height:140px; resize:vertical;}
 }
 
 .airport-context__name{
-  font-size:.82rem;
+  max-width:210px;
+  overflow:hidden;
+  font-size:.78rem;
   font-weight:700;
+  text-overflow:ellipsis;
+  white-space:nowrap;
 }
 
 .airport-context__code{
@@ -360,14 +458,77 @@ textarea{min-height:140px; resize:vertical;}
   font-size:.72rem;
   font-weight:700;
   letter-spacing:.08em;
+  flex:0 0 auto;
+}
+
+.session-context,
+.time-context{
+  display:flex;
+  align-items:center;
+  gap:.55rem;
+  padding:.48rem .7rem;
+  border:1px solid rgba(116,138,178,.28);
+  border-radius:12px;
+  background:rgba(13,24,43,.72);
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.035);
+}
+
+.session-context__status{
+  width:8px;
+  height:8px;
+  flex:0 0 8px;
+  border-radius:50%;
+  background:#4ade80;
+  box-shadow:0 0 0 4px rgba(74,222,128,.1), 0 0 14px rgba(74,222,128,.55);
+}
+
+.session-context__label,
+.time-context__label{
+  color:rgba(177,195,229,.7);
+  font-size:.58rem;
+  font-weight:700;
+  letter-spacing:.09em;
+  line-height:1.2;
+  text-transform:uppercase;
+}
+
+.session-context__name{
+  max-width:150px;
+  overflow:hidden;
+  color:#f7faff;
+  font-size:.76rem;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+}
+
+.time-context{
+  align-items:flex-start;
+  flex-direction:column;
+  justify-content:center;
+  gap:.05rem;
+  min-width:112px;
+}
+
+.time-context strong{
+  color:#dff4ff;
+  font-family:var(--font-mono);
+  font-size:.75rem;
+  letter-spacing:.02em;
+  white-space:nowrap;
 }
 
 .main-nav {
   display:flex;
-  gap:.65rem;
-  flex-wrap:wrap;
+  order:3;
+  width:100%;
+  gap:.35rem;
+  flex-wrap:nowrap;
   align-items:center;
-  justify-content:flex-end;
+  justify-content:flex-start;
+  overflow-x:auto;
+  padding-top:.65rem;
+  border-top:1px solid rgba(108,129,168,.18);
+  scrollbar-width:thin;
 }
 
 .nav-toggle{
@@ -380,11 +541,12 @@ textarea{min-height:140px; resize:vertical;}
   display:inline-flex;
   align-items:center;
   gap:.45rem;
-  padding:.5rem 1.05rem;
-  border-radius:999px;
-  background:rgba(21,30,47,.8);
+  padding:.43rem .68rem;
+  border-radius:9px;
+  background:rgba(18,29,49,.66);
   color:var(--text);
-  font-weight:600;
+  font-size:.78rem;
+  font-weight:650;
   border:1px solid transparent;
   box-shadow:0 16px 30px -28px rgba(51,102,204,.85);
   transition:background .18s ease, color .18s ease, transform .18s ease, border-color .18s ease, box-shadow .18s ease;
@@ -424,21 +586,46 @@ textarea{min-height:140px; resize:vertical;}
   outline-offset:3px;
 }
 
+.nav-link i{color:#91bfff; font-size:.78rem;}
+.nav-link.active i{color:#fff;}
+.nav-link--quiet{color:var(--text-muted);}
+
 @media (max-width: 900px){
-  .nav-container{align-items:center; flex-wrap:wrap;}
-  .brand{align-items:flex-start;}
+  .nav-container{align-items:center;}
+  .brand{min-width:0;}
+  .brand-mark{width:40px; height:40px; flex-basis:40px;}
+  .brand-eyebrow{display:none;}
+  .logo-sub{letter-spacing:.12em;}
+  .command-context{order:3; width:100%; margin:0;}
+  .airport-context{flex:1 1 auto;}
+  .session-context{display:none;}
+  .time-context{min-width:104px;}
   .nav-toggle{display:inline-flex; margin-left:auto;}
   .main-nav{
     display:none;
+    order:4;
     width:100%;
     max-height:calc(100vh - 150px);
     overflow-y:auto;
+    overflow-x:hidden;
     padding:.75rem 0 .25rem;
     justify-content:flex-start;
     border-top:1px solid var(--line);
   }
-  .main-nav.is-open{display:flex;}
-  .nav-link{padding:.45rem .9rem;}
+  .main-nav.is-open{
+    display:grid;
+    grid-template-columns:repeat(2, minmax(0, 1fr));
+  }
+  .nav-link{justify-content:flex-start; padding:.6rem .75rem;}
+  .nav-link--quiet{margin-left:0;}
+}
+
+@media (max-width: 520px){
+  .site-header{padding:.75rem 1rem;}
+  .brand-mark{display:none;}
+  .logo-sub{font-size:.58rem;}
+  .airport-context__name{max-width:118px;}
+  .time-context{padding:.42rem .55rem; min-width:98px;}
 }
 
 /* ==============================

--- a/templates/base.html
+++ b/templates/base.html
@@ -30,47 +30,77 @@
   <header class="site-header">
     <div class="nav-container">
       <div class="brand">
-        <h1 class="logo">ATC Roster Tool</h1>
-        <p class="logo-sub">Precision scheduling for elite controllers</p>
-        {% if current_user.is_authenticated and current_unit %}
-          <div class="airport-context" role="status"
-               aria-label="Logged into {{ current_unit.name }}, airport code {{ current_unit.code }}">
-            <span class="airport-context__label">Logged into</span>
-            <strong class="airport-context__name">{{ current_unit.name }}</strong>
-            <span class="airport-context__code">{{ current_unit.code }}</span>
-          </div>
-        {% endif %}
+        <span class="brand-mark" aria-hidden="true"><span></span></span>
+        <div class="brand-copy">
+          <span class="brand-eyebrow">Operational roster control</span>
+          <h1 class="logo">ATC Roster</h1>
+          <p class="logo-sub">Precision scheduling for critical operations</p>
+        </div>
       </div>
+      {% if current_user.is_authenticated %}
+        {% set role_label = {
+          'superadmin': 'Platform Super Admin',
+          'admin': 'Unit Administrator',
+          'editor': 'Roster Editor',
+          'watch_manager': 'Watch Manager',
+          'duty_watch_manager': 'Duty Watch Manager',
+          'user': 'Operational ATCO'
+        }.get(current_user.role, current_user.role|replace('_', ' ')|title) %}
+        <div class="command-context" aria-label="Current operational context">
+          {% if current_unit %}
+            <div class="airport-context" role="status"
+                 aria-label="Logged into {{ current_unit.name }}, airport code {{ current_unit.code }}">
+              <span class="context-icon" aria-hidden="true"></span>
+              <span class="context-copy">
+                <span class="airport-context__label">Active unit</span>
+                <strong class="airport-context__name">{{ current_unit.name }}</strong>
+              </span>
+              <span class="airport-context__code">{{ current_unit.code }}</span>
+            </div>
+          {% endif %}
+          <div class="session-context">
+            <span class="session-context__status" aria-hidden="true"></span>
+            <span class="context-copy">
+              <span class="session-context__label">Secure session · {{ role_label }}</span>
+              <strong class="session-context__name">{{ current_user.name }}</strong>
+            </span>
+          </div>
+          <div class="time-context" aria-label="Current local and UTC time">
+            <span class="time-context__label">LCL / UTC</span>
+            <strong data-operational-clock>--:-- / --:--</strong>
+          </div>
+        </div>
+      {% endif %}
       <button class="nav-toggle" type="button" aria-expanded="false"
               aria-controls="primary-navigation">
-        <span aria-hidden="true">☰</span>
+        <i class="fa-solid fa-bars" aria-hidden="true"></i>
         <span>Menu</span>
       </button>
       <nav class="main-nav" id="primary-navigation" aria-label="Primary">
         {% if current_user.is_authenticated %}
           {% if current_user.role == 'superadmin' %}
-            <a href="{{ url_for('platform_admin') }}" {% if request.endpoint == 'platform_admin' %}aria-current="page"{% endif %} class="nav-link {% if request.endpoint == 'platform_admin' %}active{% endif %}">🛡️ Platform Admin</a>
+            <a href="{{ url_for('platform_admin') }}" {% if request.endpoint == 'platform_admin' %}aria-current="page"{% endif %} class="nav-link {% if request.endpoint == 'platform_admin' %}active{% endif %}"><i class="fa-solid fa-shield-halved" aria-hidden="true"></i> Platform Admin</a>
           {% else %}
-            <a href="{{ url_for('index') }}" {% if request.endpoint == 'roster_month' %}aria-current="page"{% endif %} class="nav-link {% if request.endpoint == 'roster_month' %}active{% endif %}">📅 Roster</a>
-            <a href="{{ url_for('requests_page') }}" class="nav-link {% if request.endpoint == 'requests_page' %}active{% endif %}">📝 Requests</a>
-            <a href="{{ url_for('publication_index') }}" class="nav-link {% if request.endpoint in ('publication_index','publication_centre') %}active{% endif %}">✅ Published</a>
-            <a href="{{ url_for('staff_profile', sid=current_user.id) }}" class="nav-link {% if request.endpoint == 'staff_profile' %}active{% endif %}">👤 Profile</a>
-            <a href="{{ url_for('fatigue_self_report') }}" class="nav-link {% if request.endpoint == 'fatigue_self_report' %}active{% endif %}">⚠️ Fatigue</a>
+            <a href="{{ url_for('index') }}" {% if request.endpoint == 'roster_month' %}aria-current="page"{% endif %} class="nav-link {% if request.endpoint == 'roster_month' %}active{% endif %}"><i class="fa-solid fa-calendar-days" aria-hidden="true"></i> Roster</a>
+            <a href="{{ url_for('requests_page') }}" class="nav-link {% if request.endpoint == 'requests_page' %}active{% endif %}"><i class="fa-solid fa-inbox" aria-hidden="true"></i> Requests</a>
+            <a href="{{ url_for('publication_index') }}" class="nav-link {% if request.endpoint in ('publication_index','publication_centre') %}active{% endif %}"><i class="fa-solid fa-circle-check" aria-hidden="true"></i> Published</a>
+            <a href="{{ url_for('staff_profile', sid=current_user.id) }}" class="nav-link {% if request.endpoint == 'staff_profile' %}active{% endif %}"><i class="fa-solid fa-id-badge" aria-hidden="true"></i> Profile</a>
+            <a href="{{ url_for('fatigue_self_report') }}" class="nav-link {% if request.endpoint == 'fatigue_self_report' %}active{% endif %}"><i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i> Fatigue</a>
             {% if is_admin or is_editor %}
-              <a href="{{ url_for('overtime') }}" class="nav-link {% if request.endpoint == 'overtime' %}active{% endif %}">🛰️ Overtime Finder</a>
-              <a href="{{ url_for('leave') }}" class="nav-link {% if request.endpoint == 'leave' %}active{% endif %}">📝 Leave / Sickness</a>
-              <a href="{{ url_for('reports_index') }}" class="nav-link {% if request.endpoint in ('reports_index','report_leave','report_fatigue','report_leave_year','report_leave_month','report_sickness') %}active{% endif %}">📑 Reports</a>
-              <a href="{{ url_for('compliance_centre') }}" class="nav-link {% if request.endpoint in ('compliance_centre','compliance_centre_export') %}active{% endif %}">🛡️ Compliance</a>
-              {% if is_admin %}<a href="{{ url_for('operations_assurance', ym=now().strftime('%Y-%m')) }}" class="nav-link {% if request.endpoint == 'operations_assurance' %}active{% endif %}">🗼 Operations</a>{% endif %}
+              <a href="{{ url_for('overtime') }}" class="nav-link {% if request.endpoint == 'overtime' %}active{% endif %}"><i class="fa-solid fa-satellite-dish" aria-hidden="true"></i> Overtime Finder</a>
+              <a href="{{ url_for('leave') }}" class="nav-link {% if request.endpoint == 'leave' %}active{% endif %}"><i class="fa-solid fa-user-clock" aria-hidden="true"></i> Leave / Sickness</a>
+              <a href="{{ url_for('reports_index') }}" class="nav-link {% if request.endpoint in ('reports_index','report_leave','report_fatigue','report_leave_year','report_leave_month','report_sickness') %}active{% endif %}"><i class="fa-solid fa-chart-line" aria-hidden="true"></i> Reports</a>
+              <a href="{{ url_for('compliance_centre') }}" class="nav-link {% if request.endpoint in ('compliance_centre','compliance_centre_export') %}active{% endif %}"><i class="fa-solid fa-shield-halved" aria-hidden="true"></i> Compliance</a>
+              {% if is_admin %}<a href="{{ url_for('operations_assurance', ym=now().strftime('%Y-%m')) }}" class="nav-link {% if request.endpoint == 'operations_assurance' %}active{% endif %}"><i class="fa-solid fa-tower-observation" aria-hidden="true"></i> Operations</a>{% endif %}
             {% endif %}
             {% if is_admin %}
-              <a href="{{ url_for('unit_accounts') }}" class="nav-link {% if request.endpoint == 'unit_accounts' %}active{% endif %}">👥 Accounts</a>
-              <a href="{{ url_for('admin') }}" class="nav-link {% if request.endpoint == 'admin' %}active{% endif %}">⚙️ Admin</a>
+              <a href="{{ url_for('unit_accounts') }}" class="nav-link {% if request.endpoint == 'unit_accounts' %}active{% endif %}"><i class="fa-solid fa-users-gear" aria-hidden="true"></i> Accounts</a>
+              <a href="{{ url_for('admin') }}" class="nav-link {% if request.endpoint == 'admin' %}active{% endif %}"><i class="fa-solid fa-sliders" aria-hidden="true"></i> Admin</a>
             {% endif %}
           {% endif %}
-          <a href="{{ url_for('logout') }}" class="nav-link">🚪 Logout</a>
+          <a href="{{ url_for('logout') }}" class="nav-link nav-link--quiet"><i class="fa-solid fa-arrow-right-from-bracket" aria-hidden="true"></i> Logout</a>
         {% else %}
-          <a href="{{ url_for('login') }}" class="nav-link {% if request.endpoint == 'login' %}active{% endif %}">🔐 Login</a>
+          <a href="{{ url_for('login') }}" class="nav-link {% if request.endpoint == 'login' %}active{% endif %}"><i class="fa-solid fa-lock" aria-hidden="true"></i> Login</a>
         {% endif %}
       </nav>
     </div>
@@ -150,6 +180,29 @@
     document.querySelectorAll('.nav-link.active').forEach((link) => {
       link.setAttribute('aria-current', 'page');
     });
+
+    const operationalClock = document.querySelector('[data-operational-clock]');
+    if (operationalClock) {
+      const clockFormatter = new Intl.DateTimeFormat('en-GB', {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+        timeZone: 'Europe/London'
+      });
+      const utcClockFormatter = new Intl.DateTimeFormat('en-GB', {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+        timeZone: 'UTC'
+      });
+      const updateOperationalClock = () => {
+        const now = new Date();
+        operationalClock.textContent =
+          `${clockFormatter.format(now)} / ${utcClockFormatter.format(now)}`;
+      };
+      updateOperationalClock();
+      window.setInterval(updateOperationalClock, 30000);
+    }
 
     // Prevent accidental duplicate writes while preserving the clicked
     // submit button's action/name in the submitted payload.

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -198,6 +198,9 @@ def test_roster_has_persistent_zoom_presets(client):
     assert b'data-roster-zoom="fit"' in response.data
     assert b"code-input code-len-3" in response.data
     assert b"shift on 01 April 2025" in response.data
+    assert b"Active unit" in response.data
+    assert b"data-operational-clock" in response.data
+    assert b"Secure session" in response.data
 
     stylesheet = client.get("/static/styles.css")
     assert stylesheet.status_code == 200


### PR DESCRIPTION
## What changed
- redesign the global header as an operational command centre
- show active airport, authenticated user, role, secure-session status and live local/UTC time
- replace emoji navigation with a restrained icon system
- keep desktop navigation compact and introduce a two-column mobile command menu
- add responsive safeguards for long airport names and codes
- add regression assertions for the new operational context

## Why
The product needed stronger command-context hierarchy so operators can immediately see which unit, account, authority level and time context they are acting within.

## Validation
- `python -m pytest -q` — 38 passed
- Python compilation checks passed
- `git diff --check` passed
- desktop and mobile browser testing completed
- menu interaction, responsive overflow and live clock verified
- no browser console errors