### PR TITLE
Deploy ATCRoster production platform on Railway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ env/
 .pytest_cache/
 *.sqlite3
 *.db
+1 Version to deploy/
+2 Working Version/
+3 Last Known Working/

--- a/README.md
+++ b/README.md
@@ -493,6 +493,12 @@ docker compose run --rm web flask --app app bootstrap-platform
 docker compose up -d web
 ```
 
+For managed hosting, `railway.toml` configures the Docker build, Alembic
+pre-deployment migration, Waitress production server and readiness health
+check. Create separate Railway PostgreSQL and application services, keep all
+secrets in Railway's encrypted variables, and follow
+`docs/production_runbook.md` for bootstrap and verification.
+
 The Compose port binds to loopback. Place a maintained HTTPS reverse proxy in
 front of it; do not expose the application port directly.
 

--- a/app.py
+++ b/app.py
@@ -328,7 +328,20 @@ def _security_headers(response):
     response.headers.setdefault(
         "Permissions-Policy", "camera=(), microphone=(), geolocation=()"
     )
-    if request.is_secure:
+    response.headers.setdefault(
+        "Content-Security-Policy",
+        "default-src 'self'; "
+        "base-uri 'self'; "
+        "form-action 'self'; "
+        "frame-ancestors 'none'; "
+        "object-src 'none'; "
+        "img-src 'self' data:; "
+        "font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; "
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com "
+        "https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; "
+        "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
+    )
+    if request.is_secure or DEPLOYMENT_ENV == "production":
         response.headers.setdefault(
             "Strict-Transport-Security", "max-age=31536000; includeSubDomains"
         )
@@ -1237,11 +1250,13 @@ def bootstrap_reference_data() -> None:
     refresh_roster_settings_cache()
 
 
-try:
-    with app.app_context():
-        bootstrap_reference_data()
-except Exception:
-    db.session.rollback()
+if DEPLOYMENT_ENV != "production":
+    try:
+        with app.app_context():
+            bootstrap_reference_data()
+    except Exception:
+        with app.app_context():
+            db.session.rollback()
 
 # Cached shift lookup (define after models so ShiftType exists when called)
 

--- a/docs/production_runbook.md
+++ b/docs/production_runbook.md
@@ -47,6 +47,24 @@ docker compose run --rm web flask --app app bootstrap-platform
 docker compose up -d web
 ```
 
+### Railway
+
+The repository includes `railway.toml` for a managed Railway deployment.
+Provision one PostgreSQL service and one application service, then set these
+application variables through Railway's encrypted variable store:
+
+- `ATCROSTER_ENVIRONMENT=production`
+- `ATCROSTER_SECURE_COOKIES=true`
+- `FLASK_SECRET_KEY` with at least 32 random characters
+- `ATCROSTER_FIELD_ENCRYPTION_KEY` generated with Fernet
+- `DATABASE_URL` using the PostgreSQL service's private connection variables
+
+The deployment runs Alembic before starting, serves through Waitress on port
+8080 and uses `/health/ready` as its health check. After the first healthy
+deployment, run `flask --app app bootstrap-platform` once with a unique
+administrator password. Do not upload acceptance data or local environment
+files.
+
 ## Reverse proxy
 
 Terminate TLS at the proxy, redirect HTTP to HTTPS, preserve the original host

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,12 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+preDeployCommand = "alembic upgrade head"
+startCommand = "waitress-serve --host=0.0.0.0 --port=8080 --threads=8 wsgi:application"
+healthcheckPath = "/health/ready"
+healthcheckTimeout = 300
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10
+numReplicas = 1

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -302,6 +302,9 @@ def test_security_headers_are_present(client):
     assert response.headers["X-Content-Type-Options"] == "nosniff"
     assert response.headers["X-Frame-Options"] == "DENY"
     assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+    assert response.headers["Content-Security-Policy"].startswith(
+        "default-src 'self'"
+    )
 
 
 def test_role_permission_matrix_and_cross_airport_isolation():


### PR DESCRIPTION
## Summary
- add Railway Docker deployment, database migrations and readiness health checks
- harden production response headers and avoid database bootstrap during production imports
- document managed deployment and protect local working archives

## Verification
- 38 automated tests passed before deployment
- Railway build and Alembic pre-deploy succeeded
- `/health/live` and `/health/ready` return HTTP 200
- production Super Admin authentication and protected routing verified
- HSTS, CSP, clickjacking, MIME, referrer and permissions headers verified live