### PR TITLE
Harden platform security and database lifecycles

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -31,3 +31,50 @@ jobs:
           context: .
           push: false
           tags: atcroster:test
+
+  postgres-multidatabase:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: atcroster
+          POSTGRES_PASSWORD: integration-only
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U atcroster"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      FLASK_SECRET_KEY: integration-only-secret-with-at-least-32-characters
+      ATCROSTER_SKIP_RUNTIME_SCHEMA: "1"
+      ATCROSTER_TEST_CONTROL_DATABASE_URL: postgresql+psycopg://atcroster:integration-only@127.0.0.1:5432/atcroster_control
+      ATCROSTER_TEST_A_DATABASE_URL: postgresql+psycopg://atcroster:integration-only@127.0.0.1:5432/atcroster_airport_a
+      ATCROSTER_TEST_B_DATABASE_URL: postgresql+psycopg://atcroster:integration-only@127.0.0.1:5432/atcroster_airport_b
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: pip install -r requirements.txt
+      - name: Create isolated integration databases
+        run: |
+          python - <<'PY'
+          import psycopg
+          connection = psycopg.connect(
+              "postgresql://atcroster:integration-only@127.0.0.1:5432/postgres",
+              autocommit=True,
+          )
+          for name in (
+              "atcroster_control",
+              "atcroster_airport_a",
+              "atcroster_airport_b",
+          ):
+              connection.execute(f'CREATE DATABASE "{name}"')
+          connection.close()
+          PY
+      - run: python -m pytest -q tests/test_postgresql_multidatabase.py

--- a/README.md
+++ b/README.md
@@ -455,6 +455,11 @@ fallback secret in production.
 
 ### PostgreSQL production
 
+Production uses one control-plane PostgreSQL database and one physically
+separate operational PostgreSQL database per airport. See
+[Control-plane and operational database design](docs/control_operational_database_design.md)
+for platform MFA, provisioning, signup recovery, migration and rollback.
+
 Use a central control database for identities, memberships, plans, feature
 flags, database routing metadata, and aggregate usage. Provision a separate
 operational PostgreSQL database for each airport.

--- a/app.py
+++ b/app.py
@@ -32,12 +32,14 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from werkzeug.security import generate_password_hash, check_password_hash
 from werkzeug.exceptions import HTTPException
 from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
 from tenancy import (
     authenticated_unit_id,
     bind_authenticated_unit,
     bind_platform_control,
     clear_request_context,
     operational_engine_for_authenticated_unit,
+    operational_unit_context,
     reset_authenticated_unit,
     reset_platform_control,
 )
@@ -377,8 +379,12 @@ def _bind_tenant_context():
         and getattr(current_user, "role", "") == "superadmin"
     ):
         g.platform_control_token = bind_platform_control()
+        if not session.get("_platform_mfa_verified"):
+            logout_user()
+            session.clear()
+            return redirect(url_for("login"))
         allowed_platform_endpoints = {
-            "platform_admin", "logout", "password_change", "mfa_setup",
+            "platform_admin", "logout", "password_change",
             "static", "favicon", "health_live", "health_ready",
         }
         if request.endpoint == "index":
@@ -855,8 +861,6 @@ class Staff(UserMixin, db.Model):
         ).order_by(UnitMembership.id).first()
         if membership:
             return f"membership:{membership.id}"
-        if self.role == "superadmin":
-            return f"platform:{self.id}"
         return f"legacy:{self.unit_id}:{self.id}"
 
     def set_password(self, password: str) -> None:
@@ -1136,13 +1140,16 @@ class StaffWatchHistory(db.Model):
 from saas_models import register_saas_models
 SaaS = register_saas_models(db, utcnow)
 PlatformIdentity = SaaS.PlatformIdentity
+PlatformMfaCredential = SaaS.PlatformMfaCredential
 UnitMembership = SaaS.UnitMembership
 SecureInvitation = SaaS.SecureInvitation
+SignupWorkflow = SaaS.SignupWorkflow
 DatabaseRoutingMetadata = SaaS.DatabaseRoutingMetadata
 FeatureFlag = SaaS.FeatureFlag
 PlanHistory = SaaS.PlanHistory
 AggregateUsageEvent = SaaS.AggregateUsageEvent
 SuperAdminAudit = SaaS.SuperAdminAudit
+CentralSecurityAudit = SaaS.CentralSecurityAudit
 QualificationType = SaaS.QualificationType
 PersonQualification = SaaS.PersonQualification
 PersonQualificationHistory = SaaS.PersonQualificationHistory
@@ -1456,11 +1463,10 @@ def load_user(user_id):
         )
         g.tenant_context_token = token
         return db.session.get(Staff, membership.person_id)
-    if value.startswith("platform:"):
+    if value.startswith("platform-identity:"):
         try:
             return db.session.get(
-                Staff, int(value.split(":", 1)[1]),
-                bind_arguments={"bind": db.engine},
+                PlatformIdentity, int(value.split(":", 1)[1])
             )
         except ValueError:
             return None
@@ -3261,15 +3267,6 @@ def password_change():
                 username=current_user.username
             ).first_or_404()
             identity.password_hash = new_hash
-            # Platform bootstrap compatibility row is central control data.
-            db.session.execute(
-                text(
-                    "UPDATE staff SET password_hash=:password_hash "
-                    "WHERE id=:person_id AND role='superadmin'"
-                ),
-                {"password_hash": new_hash, "person_id": current_user.id},
-                bind_arguments={"bind": db.engine},
-            )
             db.session.commit()
         else:
             u = tenant_get(Staff, current_user.id)
@@ -6638,23 +6635,15 @@ def platform_admin():
                 try:
                     unit = Unit(
                         code=code, name=name, plan=plan,
-                        active_user_limit=limit, onboarding_step=1,
+                        active_user_limit=limit, onboarding_step=0,
+                        status="provisioning",
                     )
                     db.session.add(unit)
                     db.session.flush()
-                    raw_token = secrets.token_urlsafe(32)
-                    invitation = SecureInvitation(
-                        unit_id=unit.id,
-                        token_digest=hashlib.sha256(
-                            raw_token.encode()
-                        ).hexdigest(),
-                        role="UnitAdmin",
-                        expires_at=utcnow() + timedelta(days=7),
-                    )
-                    db.session.add(invitation)
                     db.session.add(DatabaseRoutingMetadata(
                         unit_id=unit.id,
                         secret_name=f"ATCROSTER_UNIT_{unit.id}_DATABASE_URL",
+                        provisioning_state="pending",
                     ))
                     db.session.add(PlanHistory(
                         unit_id=unit.id, plan=plan,
@@ -6666,18 +6655,132 @@ def platform_admin():
                         safe_summary=f"Created airport {code} on {plan} plan with limit {limit}",
                     ))
                     db.session.commit()
-                    invite_url = url_for(
-                        "accept_invitation", token=raw_token, _external=True
-                    )
                     flash(
-                        f"{name} created. Transfer this one-time bootstrap "
-                        f"link through the approved secure channel: {invite_url}",
+                        f"{name} metadata created. Configure its database "
+                        "secret, then run provisioning.",
                         "ok",
                     )
                     return redirect(url_for("platform_admin"))
                 except Exception:
                     db.session.rollback()
                     raise
+        elif action == "provision_unit":
+            unit_id = int(request.form.get("unit_id") or 0)
+            unit = db.session.get(Unit, unit_id)
+            routing = db.session.get(DatabaseRoutingMetadata, unit_id)
+            if not unit or unit.status == "platform_control" or not routing:
+                abort(404)
+            routing.attempt_count = int(routing.attempt_count or 0) + 1
+            routing.last_attempt_at = utcnow()
+            routing.last_error_code = ""
+            db.session.commit()
+            try:
+                if not re.fullmatch(
+                    r"ATCROSTER_UNIT_[1-9][0-9]*_DATABASE_URL",
+                    routing.secret_name or "",
+                ):
+                    raise RuntimeError("invalid_secret_reference")
+                operational_url = os.environ.get(routing.secret_name)
+                if not operational_url:
+                    raise RuntimeError("database_secret_unavailable")
+                control_url = (
+                    os.environ.get("CONTROL_DATABASE_URL")
+                    or app.config["SQLALCHEMY_DATABASE_URI"]
+                )
+                if operational_url == control_url:
+                    raise RuntimeError("database_not_isolated")
+                routing.provisioning_state = "database_configured"
+                db.session.commit()
+                from scripts.migrate_all_databases import upgrade_database
+                routing.migration_version = upgrade_database(
+                    operational_url, "operational"
+                )
+                routing.provisioning_state = "migrations_complete"
+                from sqlalchemy import create_engine, inspect
+                health_engine = create_engine(
+                    operational_url, pool_pre_ping=True
+                )
+                try:
+                    with health_engine.connect() as connection:
+                        connection.execute(text("SELECT 1"))
+                    required = {
+                        "staff", "assignment", "shift_request",
+                        "qualification_type",
+                    }
+                    if not required.issubset(
+                        set(inspect(health_engine).get_table_names())
+                    ):
+                        raise RuntimeError("schema_health_check_failed")
+                finally:
+                    health_engine.dispose()
+                invitation = SecureInvitation.query.filter_by(
+                    unit_id=unit.id, role="UnitAdmin",
+                    accepted_at=None, disabled_at=None,
+                ).first()
+                raw_token = None
+                if not invitation:
+                    raw_token = secrets.token_urlsafe(32)
+                    invitation = SecureInvitation(
+                        unit_id=unit.id,
+                        token_digest=hashlib.sha256(
+                            raw_token.encode()
+                        ).hexdigest(),
+                        role="UnitAdmin",
+                        expires_at=utcnow() + timedelta(days=7),
+                    )
+                    db.session.add(invitation)
+                routing.provisioning_state = "invitation_issued"
+                routing.health = "healthy"
+                routing.ready_at = utcnow()
+                db.session.add(SuperAdminAudit(
+                    actor_identity_id=platform_actor.id,
+                    unit_id=unit.id,
+                    action="airport_provisioned",
+                    safe_summary=(
+                        f"Operational schema ready for {unit.code}; "
+                        "bootstrap invitation issued."
+                    ),
+                ))
+                db.session.commit()
+                if raw_token:
+                    flash(
+                        "Provisioning completed. Transfer this one-time "
+                        f"bootstrap link securely: {url_for('accept_invitation', token=raw_token, _external=True)}",
+                        "ok",
+                    )
+                else:
+                    flash(
+                        "Provisioning is already complete; the existing "
+                        "invitation remains valid.", "ok",
+                    )
+            except Exception as exc:
+                db.session.rollback()
+                routing = db.session.get(DatabaseRoutingMetadata, unit_id)
+                allowed = {
+                    "invalid_secret_reference",
+                    "database_secret_unavailable",
+                    "database_not_isolated",
+                    "schema_health_check_failed",
+                }
+                code = (
+                    str(exc) if str(exc) in allowed
+                    else "database_provisioning_failed"
+                )
+                routing.provisioning_state = "failed"
+                routing.last_error_code = code
+                routing.health = "failed"
+                db.session.add(SuperAdminAudit(
+                    actor_identity_id=platform_actor.id,
+                    unit_id=unit_id,
+                    action="airport_provisioning_failed",
+                    safe_summary=f"Provisioning failed with code {code}.",
+                ))
+                db.session.commit()
+                flash(
+                    f"Provisioning did not complete ({code}). Correct the "
+                    "configuration and retry.", "error",
+                )
+            return redirect(url_for("platform_admin"))
         elif action == "update_limit":
             try:
                 unit_id = int(request.form.get("unit_id") or 0)
@@ -6801,6 +6904,12 @@ def platform_admin():
             "active_accounts": active_accounts,
             "flags": flags,
             "database_health": routing.health if routing else "unknown",
+            "provisioning_state": (
+                routing.provisioning_state if routing else "pending"
+            ),
+            "provisioning_error": (
+                routing.last_error_code if routing else ""
+            ),
             "migration_version": routing.migration_version if routing else "",
             "storage_bytes": routing.storage_bytes if routing else 0,
             "activity_count": int(activity or 0),
@@ -6861,31 +6970,41 @@ def unit_accounts():
             return redirect(url_for("unit_accounts"))
         if action == "create_account":
             name = (request.form.get("name") or "").strip()
-            username = (request.form.get("username") or "").strip().lower()
+            username = _normalized_login(
+                request.form.get("username") or ""
+            )
             password = request.form.get("password") or ""
             if not name or not username or len(password) < 12:
                 flash("Name, username, and a 12-character password are required.", "error")
                 return redirect(url_for("unit_accounts"))
-            if db.session.query(Staff).execution_options(skip_tenant_scope=True).filter_by(
-                username=username
-            ).first():
-                flash("That username already exists.", "error")
+            central_duplicate = PlatformIdentity.query.filter(
+                db.func.lower(PlatformIdentity.username) == username
+            ).first()
+            local_duplicate = Staff.query.filter(
+                db.func.lower(Staff.username) == username
+            ).first()
+            if central_duplicate or local_duplicate:
+                flash("That login identifier is unavailable.", "error")
                 return redirect(url_for("unit_accounts"))
+            identity = None
+            staff = None
             try:
+                password_hash = generate_password_hash(password)
+                identity = PlatformIdentity(
+                    public_id=f"member-{secrets.token_hex(12)}",
+                    username=username, password_hash=password_hash,
+                )
+                db.session.add(identity)
+                db.session.commit()
                 staff = Staff(
                     unit_id=unit_id, username=username, name=name,
                     staff_no=f"{unit.code}-LOGIN-{secrets.token_hex(3).upper()}",
                     role="user", is_operational=False,
+                    membership_status="pending",
                 )
-                staff.set_password(password)
+                staff.password_hash = password_hash
                 db.session.add(staff)
-                db.session.flush()
-                identity = PlatformIdentity(
-                    public_id=f"member-{secrets.token_hex(12)}",
-                    username=username, password_hash=staff.password_hash,
-                )
-                db.session.add(identity)
-                db.session.flush()
+                db.session.commit()
                 membership = UnitMembership(
                     identity_id=identity.id, unit_id=unit_id,
                     person_id=staff.id, role="StaffUser", status="invited",
@@ -6895,11 +7014,29 @@ def unit_accounts():
                 from account_limits import activate_membership
                 activate_membership(db, Unit, UnitMembership, membership.id)
                 membership.activated_at = utcnow()
+                staff.membership_status = "active"
                 db.session.commit()
                 flash("Account activated.", "ok")
-            except ValueError as exc:
+            except (ValueError, IntegrityError) as exc:
                 db.session.rollback()
-                flash(str(exc), "error")
+                if staff and staff.id:
+                    pending_staff = db.session.get(Staff, staff.id)
+                    if pending_staff and pending_staff.membership_status != "active":
+                        db.session.delete(pending_staff)
+                        db.session.commit()
+                if identity and identity.id:
+                    orphan = db.session.get(PlatformIdentity, identity.id)
+                    has_membership = UnitMembership.query.filter_by(
+                        identity_id=identity.id
+                    ).first()
+                    if orphan and not has_membership:
+                        db.session.delete(orphan)
+                        db.session.commit()
+                message = (
+                    str(exc) if isinstance(exc, ValueError)
+                    else "That login identifier is unavailable."
+                )
+                flash(message, "error")
             return redirect(url_for("unit_accounts"))
         if action == "deactivate":
             membership_id = int(request.form.get("membership_id") or 0)
@@ -6985,6 +7122,198 @@ def unit_accounts():
     )
 
 
+class SignupWorkflowError(RuntimeError):
+    pass
+
+
+def _normalized_login(value: str) -> str:
+    return value.strip().casefold()
+
+
+def _run_invitation_signup(
+    invitation, unit, name, username, password, fail_after=None,
+):
+    """Resume an invitation saga without claiming cross-DB atomicity."""
+    normalized = _normalized_login(username)
+    workflow = SignupWorkflow.query.filter_by(
+        invitation_id=invitation.id
+    ).first()
+    if not workflow:
+        workflow = SignupWorkflow(
+            invitation_id=invitation.id,
+            idempotency_key=hashlib.sha256(
+                f"signup:{invitation.id}:{invitation.token_digest}".encode()
+            ).hexdigest(),
+            normalized_username=normalized,
+            state="pending",
+        )
+        db.session.add(workflow)
+        try:
+            db.session.commit()
+        except IntegrityError as exc:
+            db.session.rollback()
+            workflow = SignupWorkflow.query.filter_by(
+                invitation_id=invitation.id
+            ).first()
+            if not workflow:
+                raise SignupWorkflowError(
+                    "Account setup could not be started safely."
+                ) from exc
+    if workflow.normalized_username != normalized:
+        raise SignupWorkflowError(
+            "This invitation already has an incomplete setup attempt."
+        )
+    if workflow.state == "completed":
+        return workflow
+    if workflow.state == "failed" and workflow.compensation_state:
+        workflow.state = workflow.compensation_state
+    workflow.attempt_count = int(workflow.attempt_count or 0) + 1
+    workflow.last_error_code = ""
+    workflow.updated_at = utcnow()
+    db.session.commit()
+    try:
+        if workflow.state == "pending":
+            duplicate = PlatformIdentity.query.filter(
+                db.func.lower(PlatformIdentity.username) == normalized
+            ).first()
+            if duplicate:
+                raise SignupWorkflowError(
+                    "That login identifier is unavailable."
+                )
+            identity = PlatformIdentity(
+                public_id=f"member-{secrets.token_hex(12)}",
+                username=normalized,
+                password_hash=generate_password_hash(password),
+            )
+            db.session.add(identity)
+            try:
+                db.session.commit()
+            except IntegrityError as exc:
+                db.session.rollback()
+                raise SignupWorkflowError(
+                    "That login identifier is unavailable."
+                ) from exc
+            workflow = db.session.get(SignupWorkflow, workflow.id)
+            workflow.identity_id = identity.id
+            workflow.state = "identity_created"
+            workflow.updated_at = utcnow()
+            db.session.commit()
+            if fail_after == "identity_created":
+                raise RuntimeError("injected_identity_created")
+        if workflow.state == "identity_created":
+            marker = f"{unit.code}-SIGNUP-{workflow.id}"
+            staff = Staff.query.filter_by(staff_no=marker).first()
+            if not staff:
+                if Staff.query.filter(
+                    db.func.lower(Staff.username) == normalized
+                ).first():
+                    raise SignupWorkflowError(
+                        "That login identifier is unavailable."
+                    )
+                role_map = {
+                    "UnitAdmin": "admin", "RosterEditor": "editor",
+                    "WatchManager": "user", "StaffUser": "user",
+                    "ReadOnlyAuditor": "auditor",
+                }
+                staff = Staff(
+                    unit_id=unit.id, username=normalized, name=name[:80],
+                    staff_no=marker, role=role_map[invitation.role],
+                    is_wm=invitation.role == "WatchManager",
+                    is_operational=False, membership_status="pending",
+                )
+                staff.set_password(password)
+                db.session.add(staff)
+                try:
+                    db.session.commit()
+                except IntegrityError as exc:
+                    db.session.rollback()
+                    raise SignupWorkflowError(
+                        "That login identifier is unavailable."
+                    ) from exc
+            workflow = db.session.get(SignupWorkflow, workflow.id)
+            workflow.operational_person_id = staff.id
+            workflow.state = "operational_account_created"
+            workflow.updated_at = utcnow()
+            db.session.commit()
+            if fail_after == "operational_account_created":
+                raise RuntimeError("injected_operational_account_created")
+        if workflow.state == "operational_account_created":
+            membership = UnitMembership.query.filter_by(
+                identity_id=workflow.identity_id, unit_id=unit.id
+            ).first()
+            if not membership:
+                membership = UnitMembership(
+                    identity_id=workflow.identity_id, unit_id=unit.id,
+                    person_id=workflow.operational_person_id,
+                    role=invitation.role, status="invited",
+                )
+                db.session.add(membership)
+                db.session.flush()
+                from account_limits import activate_membership
+                activate_membership(
+                    db, Unit, UnitMembership, membership.id
+                )
+                membership.activated_at = utcnow()
+                db.session.commit()
+            workflow = db.session.get(SignupWorkflow, workflow.id)
+            workflow.membership_id = membership.id
+            workflow.state = "membership_created"
+            workflow.updated_at = utcnow()
+            db.session.commit()
+            if fail_after == "membership_created":
+                raise RuntimeError("injected_membership_created")
+        if workflow.state == "membership_created":
+            staff = db.session.get(
+                Staff, workflow.operational_person_id
+            )
+            if not staff:
+                raise SignupWorkflowError(
+                    "Operational account requires reconciliation."
+                )
+            staff.membership_status = "active"
+            db.session.commit()
+            workflow = db.session.get(SignupWorkflow, workflow.id)
+            invitation = db.session.get(
+                SecureInvitation, workflow.invitation_id
+            )
+            invitation.accepted_at = utcnow()
+            if invitation.role == "UnitAdmin":
+                unit.status = "active"
+                routing = db.session.get(
+                    DatabaseRoutingMetadata, unit.id
+                )
+                routing.provisioning_state = "active"
+            workflow.state = "completed"
+            workflow.compensation_state = ""
+            workflow.updated_at = utcnow()
+            db.session.commit()
+        return workflow
+    except SignupWorkflowError:
+        db.session.rollback()
+        workflow = db.session.get(SignupWorkflow, workflow.id)
+        workflow.compensation_state = workflow.state
+        workflow.state = "failed"
+        workflow.last_error_code = "validation_failed"
+        workflow.updated_at = utcnow()
+        db.session.commit()
+        raise
+    except Exception as exc:
+        db.session.rollback()
+        workflow = db.session.get(SignupWorkflow, workflow.id)
+        workflow.compensation_state = workflow.state
+        workflow.state = "failed"
+        workflow.last_error_code = (
+            str(exc) if str(exc).startswith("injected_")
+            else "stage_interrupted"
+        )
+        workflow.updated_at = utcnow()
+        db.session.commit()
+        raise SignupWorkflowError(
+            "Account setup was interrupted safely. Retry this invitation "
+            "or ask an administrator to reconcile it."
+        ) from exc
+
+
 @app.route("/invite/<token>", methods=["GET", "POST"])
 def accept_invitation(token):
     """Accept a one-time, expiring invitation without trusting tenant input."""
@@ -7004,13 +7333,24 @@ def accept_invitation(token):
     ):
         abort(410, "This invitation has expired or has already been used.")
     unit = db.session.get(Unit, invitation.unit_id)
-    if not unit or unit.status != "active":
+    routing = (
+        db.session.get(DatabaseRoutingMetadata, invitation.unit_id)
+        if unit else None
+    )
+    if (
+        not unit
+        or unit.status not in {"active", "provisioning"}
+        or (
+            unit.status == "provisioning"
+            and (
+                not routing
+                or routing.provisioning_state != "invitation_issued"
+            )
+        )
+    ):
         abort(409, "This airport account is not accepting invitations.")
     if request.method == "POST":
         _validate_csrf()
-        routing = db.session.get(
-            DatabaseRoutingMetadata, invitation.unit_id
-        )
         if DEPLOYMENT_ENV == "production" and not routing:
             abort(503, "Operational database routing is unavailable.")
         g.tenant_context_token = bind_authenticated_unit(
@@ -7030,61 +7370,11 @@ def accept_invitation(token):
             return render_template(
                 "invitation_accept.html", invitation=invitation, unit=unit
             ), 400
-        if PlatformIdentity.query.filter_by(username=username).first() or (
-            db.session.query(Staff)
-            .execution_options(skip_tenant_scope=True)
-            .filter_by(username=username)
-            .first()
-        ):
-            flash("That username is unavailable.", "error")
-            return render_template(
-                "invitation_accept.html", invitation=invitation, unit=unit
-            ), 409
-        role_map = {
-            "UnitAdmin": "admin",
-            "RosterEditor": "editor",
-            "WatchManager": "user",
-            "StaffUser": "user",
-            "ReadOnlyAuditor": "auditor",
-        }
         try:
-            staff = Staff(
-                unit_id=unit.id,
-                username=username,
-                name=name[:80],
-                staff_no=f"{unit.code}-LOGIN-{secrets.token_hex(3).upper()}",
-                role=role_map[invitation.role],
-                is_wm=invitation.role == "WatchManager",
-                is_operational=False,
+            _run_invitation_signup(
+                invitation, unit, name, username, password
             )
-            staff.set_password(password)
-            db.session.add(staff)
-            db.session.flush()
-            identity = PlatformIdentity(
-                public_id=f"member-{secrets.token_hex(12)}",
-                username=username,
-                password_hash=staff.password_hash,
-            )
-            db.session.add(identity)
-            db.session.flush()
-            membership = UnitMembership(
-                identity_id=identity.id,
-                unit_id=unit.id,
-                person_id=staff.id,
-                role=invitation.role,
-                status="invited",
-            )
-            db.session.add(membership)
-            db.session.flush()
-            from account_limits import activate_membership
-            activate_membership(
-                db, Unit, UnitMembership, membership.id
-            )
-            membership.activated_at = utcnow()
-            invitation.accepted_at = utcnow()
-            db.session.commit()
-        except ValueError as exc:
-            db.session.rollback()
+        except (SignupWorkflowError, ValueError) as exc:
             flash(str(exc), "error")
             return render_template(
                 "invitation_accept.html", invitation=invitation, unit=unit
@@ -8018,6 +8308,17 @@ def _security_event(event: str, **safe_fields) -> None:
     ))
 
 
+def _central_security_event(
+    event_type: str, outcome: str, identity_id: int | None = None,
+    principal: str = "", detail: str = "",
+) -> None:
+    db.session.add(CentralSecurityAudit(
+        identity_id=identity_id, event_type=event_type[:80],
+        outcome=outcome[:20], principal_digest=principal[:32],
+        safe_detail=detail[:200],
+    ))
+
+
 def _record_successful_login(user: Staff) -> None:
     now = utcnow()
     identity = PlatformIdentity.query.filter_by(
@@ -8038,7 +8339,9 @@ def _record_successful_login(user: Staff) -> None:
 @app.route("/login", methods=["GET", "POST"], endpoint="login")
 def signin_form():   # function name can be anything; endpoint is 'login'
     if request.method == "POST":
-        username = (request.form.get("username") or "").strip()
+        username = _normalized_login(
+            request.form.get("username") or ""
+        )
         password = (request.form.get("password") or "").strip()
         rate_key = _login_rate_key(username)
         attempts = _login_attempts[rate_key]
@@ -8050,6 +8353,7 @@ def signin_form():   # function name can be anything; endpoint is 'login'
             abort(429, "Too many login attempts. Try again later.")
         identity = PlatformIdentity.query.filter_by(username=username).first()
         user = None
+        platform_login = False
         credentials_valid = False
         if identity:
             credentials_valid = check_password_hash(
@@ -8075,14 +8379,10 @@ def signin_form():   # function name can be anything; endpoint is 'login'
                     )
                     user = db.session.get(Staff, membership.person_id)
                 else:
-                    platform_user = db.session.execute(
-                        db.select(Staff).where(
-                            Staff.username == username,
-                            Staff.role == "superadmin",
-                        ),
-                        bind_arguments={"bind": db.engine},
-                    ).scalar_one_or_none()
-                    user = platform_user
+                    user = identity
+                    platform_login = identity.public_id.startswith(
+                        "platform-"
+                    )
         else:
             user = Staff.query.filter_by(username=username).first()
             credentials_valid = bool(
@@ -8104,13 +8404,31 @@ def signin_form():   # function name can be anything; endpoint is 'login'
                 )
                 flash("This airport account is not active.", "error")
                 return render_template("login.html"), 403
-            credential = (
-                None if user.role == "superadmin"
-                else MfaCredential.query.filter_by(
-                    person_id=user.id, enabled=True
-                ).first()
-            )
             session.clear()
+            if platform_login:
+                credential = PlatformMfaCredential.query.filter_by(
+                    identity_id=identity.id, enabled=True,
+                    reset_required=False,
+                ).first()
+                session["_platform_mfa_identity_id"] = identity.id
+                session["_platform_mfa_user_id"] = user.id
+                session["_platform_mfa_rate_key"] = rate_key
+                session["_platform_mfa_next"] = (
+                    request.args.get("next")
+                    if _is_safe_local_redirect(request.args.get("next")) else ""
+                )
+                _central_security_event(
+                    "platform_password_verified", "challenge",
+                    identity.id, rate_key[-16:],
+                )
+                db.session.commit()
+                return redirect(url_for(
+                    "platform_mfa_challenge"
+                    if credential else "platform_mfa_setup"
+                ))
+            credential = MfaCredential.query.filter_by(
+                person_id=user.id, enabled=True
+            ).first()
             if credential:
                 session["_mfa_user_id"] = user.id
                 session["_mfa_unit_id"] = user.unit_id
@@ -8135,6 +8453,12 @@ def signin_form():   # function name can be anything; endpoint is 'login'
             nxt = request.args.get("next")
             return redirect(nxt if _is_safe_local_redirect(nxt) else url_for("index"))
         attempts.append(utcnow())
+        if identity:
+            _central_security_event(
+                "platform_login_failed", "denied", identity.id,
+                rate_key[-16:],
+            )
+            db.session.commit()
         _security_event("login_failed", principal=rate_key[-16:])
         flash("Invalid username or password.", "error")
     return render_template("login.html")
@@ -8158,6 +8482,165 @@ def _matching_totp_step(secret: str, code: str) -> int | None:
         if secrets.compare_digest(candidate, code):
             return int(candidate_time.timestamp() // 30)
     return None
+
+
+_platform_mfa_attempts: dict[int, deque[datetime]] = defaultdict(deque)
+
+
+def _pending_platform_login():
+    identity_id = int(session.get("_platform_mfa_identity_id") or 0)
+    user_id = int(session.get("_platform_mfa_user_id") or 0)
+    if not identity_id or user_id != identity_id:
+        return None, None
+    identity = db.session.get(PlatformIdentity, identity_id)
+    if not identity or identity.role != "superadmin":
+        return None, None
+    return identity, identity
+
+
+def _complete_platform_login(identity, user, recovery_used=False):
+    next_url = session.get("_platform_mfa_next", "")
+    rate_key = session.get("_platform_mfa_rate_key", "")
+    session.clear()
+    login_user(user)
+    session.permanent = True
+    session["_session_started_at"] = utcnow().isoformat()
+    session["_platform_mfa_verified"] = True
+    identity.last_active_at = utcnow()
+    _central_security_event(
+        "platform_recovery_code_used" if recovery_used
+        else "platform_mfa_verified",
+        "success", identity.id,
+        hashlib.sha256(identity.username.lower().encode()).hexdigest()[:16],
+    )
+    db.session.commit()
+    if rate_key:
+        _login_attempts.pop(rate_key, None)
+    _platform_mfa_attempts.pop(identity.id, None)
+    return redirect(next_url or url_for("platform_admin"))
+
+
+@app.route("/login/platform-mfa/setup", methods=["GET", "POST"])
+def platform_mfa_setup():
+    identity, user = _pending_platform_login()
+    if not identity or not user:
+        session.clear()
+        return redirect(url_for("login"))
+    existing = PlatformMfaCredential.query.filter_by(
+        identity_id=identity.id, enabled=True, reset_required=False,
+    ).first()
+    if existing:
+        return redirect(url_for("platform_mfa_challenge"))
+    pending = session.get("_pending_platform_mfa_secret")
+    if not pending:
+        pending = pyotp.random_base32()
+        session["_pending_platform_mfa_secret"] = pending
+    provisioning_uri = pyotp.TOTP(pending).provisioning_uri(
+        name=identity.username, issuer_name="ATCRoster Platform"
+    )
+    if request.method == "POST":
+        _validate_csrf()
+        code = re.sub(r"\s", "", request.form.get("code") or "")
+        if not pyotp.TOTP(pending).verify(code, valid_window=1):
+            _central_security_event(
+                "platform_mfa_enrolment", "denied", identity.id
+            )
+            db.session.commit()
+            flash("The verification code is not valid.", "error")
+            return redirect(url_for("platform_mfa_setup"))
+        recovery_codes = [secrets.token_hex(5).upper() for _ in range(10)]
+        credential = PlatformMfaCredential.query.filter_by(
+            identity_id=identity.id
+        ).first()
+        if not credential:
+            credential = PlatformMfaCredential(
+                identity_id=identity.id, encrypted_secret=""
+            )
+            db.session.add(credential)
+        credential.encrypted_secret = _field_cipher().encrypt(
+            pending.encode()
+        ).decode()
+        credential.enabled = True
+        credential.reset_required = False
+        credential.enrolled_at = utcnow()
+        credential.recovery_codes_digest = json.dumps([
+            hashlib.sha256(value.encode()).hexdigest()
+            for value in recovery_codes
+        ])
+        _central_security_event(
+            "platform_mfa_enrolment", "success", identity.id
+        )
+        db.session.commit()
+        session.pop("_pending_platform_mfa_secret", None)
+        return render_template(
+            "mfa_setup.html", enabled=True,
+            recovery_codes=recovery_codes, platform_enrolment=True,
+        )
+    return render_template(
+        "mfa_setup.html", enabled=False, secret=pending,
+        provisioning_uri=provisioning_uri, platform_enrolment=True,
+    )
+
+
+@app.route("/login/platform-mfa", methods=["GET", "POST"])
+def platform_mfa_challenge():
+    identity, user = _pending_platform_login()
+    if not identity or not user:
+        session.clear()
+        return redirect(url_for("login"))
+    credential = PlatformMfaCredential.query.filter_by(
+        identity_id=identity.id, enabled=True, reset_required=False,
+    ).first()
+    if not credential:
+        return redirect(url_for("platform_mfa_setup"))
+    attempts = _platform_mfa_attempts[identity.id]
+    cutoff = utcnow() - LOGIN_RATE_WINDOW
+    while attempts and attempts[0] < cutoff:
+        attempts.popleft()
+    if len(attempts) >= LOGIN_RATE_LIMIT:
+        _central_security_event(
+            "platform_mfa_rate_limited", "denied", identity.id
+        )
+        db.session.commit()
+        abort(429, "Too many verification attempts. Try again later.")
+    if request.method == "POST":
+        _validate_csrf()
+        code = re.sub(
+            r"[\s-]", "", request.form.get("code") or ""
+        ).upper()
+        accepted = False
+        recovery_used = False
+        if re.fullmatch(r"\d{6}", code):
+            step = _matching_totp_step(
+                _decrypt_mfa_secret(credential), code
+            )
+            if step is not None and (
+                credential.last_used_step is None
+                or step > credential.last_used_step
+            ):
+                credential.last_used_step = step
+                accepted = True
+        elif re.fullmatch(r"[A-Z0-9]{10}", code):
+            digests = json.loads(
+                credential.recovery_codes_digest or "[]"
+            )
+            digest = hashlib.sha256(code.encode()).hexdigest()
+            if digest in digests:
+                digests.remove(digest)
+                credential.recovery_codes_digest = json.dumps(digests)
+                accepted = True
+                recovery_used = True
+        if accepted:
+            return _complete_platform_login(
+                identity, user, recovery_used=recovery_used
+            )
+        attempts.append(utcnow())
+        _central_security_event(
+            "platform_mfa_verification", "denied", identity.id
+        )
+        db.session.commit()
+        flash("Invalid, expired or already-used verification code.", "error")
+    return render_template("mfa_challenge.html", platform_challenge=True)
 
 
 @app.route("/login/mfa", methods=["GET", "POST"])
@@ -8301,27 +8784,109 @@ def bootstrap_platform(username, password):
         db.session.add(control)
         db.session.flush()
     password_hash = generate_password_hash(password)
-    db.session.execute(
-        text(
-            "INSERT INTO staff "
-            "(unit_id,username,password_hash,role,membership_status,"
-            "permissions_json,name,staff_no,is_operational) VALUES "
-            "(:unit_id,:username,:password_hash,'superadmin','active','{}',"
-            "'Platform Super Admin',:staff_no,false)"
-        ),
-        {
-            "unit_id": control.id, "username": username,
-            "password_hash": password_hash,
-            "staff_no": f"PLATFORM-{secrets.token_hex(3).upper()}",
-        },
-        bind_arguments={"bind": db.engine},
-    )
     db.session.add(PlatformIdentity(
         public_id=f"platform-{secrets.token_hex(12)}",
         username=username, password_hash=password_hash,
     ))
     db.session.commit()
     click.echo(f"Platform Super Admin {username} created.")
+
+
+@app.cli.command("reset-platform-mfa")
+@click.option("--username", prompt=True)
+def reset_platform_mfa(username):
+    """Invalidate platform MFA and require trusted re-enrolment."""
+    normalized = username.strip().lower()
+    identity = PlatformIdentity.query.filter(
+        db.func.lower(PlatformIdentity.username) == normalized
+    ).first()
+    if not identity:
+        raise click.ClickException("Platform identity was not found.")
+    credential = PlatformMfaCredential.query.filter_by(
+        identity_id=identity.id
+    ).first()
+    if credential:
+        credential.enabled = False
+        credential.reset_required = True
+        credential.encrypted_secret = ""
+        credential.recovery_codes_digest = "[]"
+        credential.last_used_step = None
+    _central_security_event(
+        "platform_mfa_reset", "success", identity.id,
+        hashlib.sha256(normalized.encode()).hexdigest()[:16],
+        "Re-enrolment required by trusted operator.",
+    )
+    db.session.commit()
+    click.echo("Platform MFA reset; re-enrolment is required at next login.")
+
+
+@app.cli.command("reconcile-signups")
+@click.option("--apply", "apply_changes", is_flag=True)
+def reconcile_signups(apply_changes):
+    """Report or safely reconcile interrupted cross-database signups."""
+    rows = SignupWorkflow.query.filter(
+        SignupWorkflow.state != "completed"
+    ).order_by(SignupWorkflow.id).all()
+    for row in rows:
+        invitation = db.session.get(SecureInvitation, row.invitation_id)
+        routing = (
+            db.session.get(
+                DatabaseRoutingMetadata, invitation.unit_id
+            )
+            if invitation else None
+        )
+        click.echo(
+            f"workflow={row.id} state={row.state} "
+            f"error={row.last_error_code or 'none'}"
+        )
+        if not apply_changes or not invitation or not routing:
+            continue
+        if row.membership_id and row.operational_person_id:
+            with operational_unit_context(
+                invitation.unit_id, routing.secret_name
+            ):
+                staff = db.session.get(
+                    Staff, row.operational_person_id
+                )
+                if staff:
+                    staff.membership_status = "active"
+                    db.session.commit()
+            invitation.accepted_at = invitation.accepted_at or utcnow()
+            row.state = "completed"
+            row.compensation_state = ""
+            row.last_error_code = ""
+            if invitation.role == "UnitAdmin":
+                unit = db.session.get(Unit, invitation.unit_id)
+                unit.status = "active"
+                routing.provisioning_state = "active"
+            db.session.commit()
+        else:
+            if row.operational_person_id:
+                with operational_unit_context(
+                    invitation.unit_id, routing.secret_name
+                ):
+                    staff = db.session.get(
+                        Staff, row.operational_person_id
+                    )
+                    if staff and staff.membership_status != "active":
+                        db.session.delete(staff)
+                        db.session.commit()
+                row.operational_person_id = None
+            if row.identity_id:
+                identity = db.session.get(
+                    PlatformIdentity, row.identity_id
+                )
+                membership = UnitMembership.query.filter_by(
+                    identity_id=row.identity_id
+                ).first()
+                if identity and not membership:
+                    db.session.delete(identity)
+                    row.identity_id = None
+            row.state = "compensation_required"
+            row.compensation_state = "pending"
+            row.last_error_code = "compensated_retry_required"
+            db.session.commit()
+    click.echo(f"{len(rows)} incomplete signup workflow(s) inspected.")
 
 
 # -------------------- DB init (single, safe block) --------------------

--- a/docs/architecture_review_2026-03-28.md
+++ b/docs/architecture_review_2026-03-28.md
@@ -2,6 +2,13 @@
 
 Updated 24 July 2026. The filename is retained to preserve existing links.
 
+The July 2026 security hardening separates the control-plane schema from every
+airport operational schema. Control owns global identities, memberships,
+platform MFA, provisioning and signup workflow state; airport databases own
+all personnel and roster information. Role-filtered Alembic migrations and a
+three-database PostgreSQL 16 CI job verify the physical boundary. See
+[control_operational_database_design.md](control_operational_database_design.md).
+
 ## Current platform
 
 ATCRoster is a Flask/SQLAlchemy application with server-rendered responsive

--- a/docs/control_operational_database_design.md
+++ b/docs/control_operational_database_design.md
@@ -1,0 +1,91 @@
+# Control-plane and operational database design
+
+## Security boundary
+
+The control database contains airport metadata, plan limits, global login
+identities, memberships, secret references, invitations, provisioning and
+signup workflow state, platform MFA credentials, and privacy-safe platform
+audits. It must not contain airport personnel, qualifications, rosters,
+requests, annotations, medical/licence dates, or airport audit detail.
+
+Every airport has a separate operational database containing staff, shifts,
+qualifications, rosters, assignments, requests, annotations, rules and
+airport-level audit events. Operational tables retain `unit_id` as a
+defence-in-depth ownership key but do not reference a control-plane `unit`
+table. ORM routing is derived from the authenticated server-side membership;
+a browser-supplied airport identifier is never a routing authority.
+
+Migrations share an audited revision sequence but execute through distinct
+roles:
+
+```bash
+ATCROSTER_SCHEMA_ROLE=control python -m alembic upgrade head
+ATCROSTER_SCHEMA_ROLE=operational python -m alembic upgrade head
+```
+
+`scripts/migrate_all_databases.py` applies the control role first, reads only
+secret references, then applies the operational role to each airport. It
+prints unit IDs and revision results but never URLs or secret values.
+
+## Platform MFA
+
+`PlatformMfaCredential` is control-plane only. TOTP seeds are encrypted with
+`ATCROSTER_FIELD_ENCRYPTION_KEY`; recovery codes are stored as SHA-256 digests
+and removed after one use. Password success creates only a pre-authentication
+session. A fresh authenticated session is created after MFA verification.
+Login, enrolment, verification, recovery and reset create non-sensitive
+central audit events and are rate limited.
+
+Reset a credential only through a trusted administrative shell:
+
+```bash
+flask --app app reset-platform-mfa --username PLATFORM_LOGIN
+```
+
+## Airport provisioning
+
+An airport progresses through `pending`, `database_configured`,
+`migrations_complete`, `invitation_issued`, `active`, or `failed`.
+Creation stores only non-personal metadata and a deployment-secret name.
+Provisioning validates that reference, connects, migrates, checks the required
+operational schema, and only then creates the one-time UnitAdmin invitation.
+The airport becomes active only when that invitation completes.
+
+Retries are idempotent. A failure stores an allow-listed error code and
+privacy-safe audit event; connection strings and exception text are not
+displayed or logged.
+
+## Signup saga and recovery
+
+Invitation acceptance is a durable saga:
+
+1. `pending`
+2. `identity_created` in control
+3. `operational_account_created` with access disabled
+4. `membership_created`
+5. `completed`, enabling the account and consuming the invitation
+
+Every invitation has one stable idempotency key. A retry resumes the last
+durable stage and deterministic staff marker, so it cannot duplicate an
+identity, person or membership. Intermediate identities have no membership;
+intermediate staff accounts have `membership_status=pending`.
+
+Inspect and reconcile interrupted work:
+
+```bash
+flask --app app reconcile-signups
+flask --app app reconcile-signups --apply
+```
+
+## Migration and rollback
+
+1. Take and verify independent encrypted backups of the existing database.
+2. Put the application in maintenance mode.
+3. Configure the control URL and every airport secret reference.
+4. Run the migration tool and retain its per-database result.
+5. Run readiness checks and acceptance tests before reopening.
+
+Revision `20260726_09` and the physical split are forward-only security
+boundaries. Rollback means stopping the new application and restoring the
+matching control and operational backups as one recovery set. Do not run a
+schema downgrade or copy operational personal data into control.

--- a/docs/migration_runbook.md
+++ b/docs/migration_runbook.md
@@ -1,5 +1,27 @@
 # Database migration runbook
 
+The current head is `20260726_09`. Production migration must use
+`scripts/migrate_all_databases.py`, which applies the `control` schema role to
+the control database and the `operational` role separately to every configured
+airport database. It is safe to rerun and does not create control-plane tables
+or a `unit` table in an operational database.
+
+Back up the control database and every airport database as one labelled
+recovery set. A failed airport migration stops with its unit ID and a
+non-sensitive error; correct the secret/database configuration and rerun.
+Never include database URLs in tickets or logs.
+
+Interrupted invitation acceptance is handled with:
+
+```bash
+flask --app app reconcile-signups
+flask --app app reconcile-signups --apply
+```
+
+Rollback is backup restoration, not Alembic downgrade. Restore control and
+every airport database from the same recovery point before starting the prior
+application image.
+
 ## Before deployment
 
 1. Freeze schema-changing releases and identify the exact application commit.

--- a/docs/production_runbook.md
+++ b/docs/production_runbook.md
@@ -4,6 +4,17 @@ This runbook covers a self-hosted production deployment. Formal aviation
 acceptance, data-protection approval and security certification remain the
 operator's responsibility.
 
+Airport creation is intentionally two-phase. Create non-personal metadata,
+configure the named database secret, then use **Provision / retry**. The
+platform connects, runs operational migrations, checks schema health and only
+then displays the one-time bootstrap invitation. Do not send an invitation
+while provisioning is `pending` or `failed`.
+
+Platform SuperAdmins must enrol application-verified MFA. Their encrypted
+credential and one-time recovery-code hashes live only in control. Use
+`flask --app app reset-platform-mfa` through the trusted operator shell for
+recovery; never disable the MFA requirement.
+
 ## Required services
 
 - PostgreSQL 16 or a supported managed PostgreSQL service

--- a/docs/release_security_report_2026-07-25.md
+++ b/docs/release_security_report_2026-07-25.md
@@ -40,7 +40,11 @@ foreign key.
 
 ## Verification evidence
 
-- Full automated suite: 67 passed on Python 3.12 without warnings.
+- Full automated suite: 73 passed and one PostgreSQL-only test skipped when
+  its three integration database URLs are not supplied.
+- PostgreSQL 16 three-database integration: 1 passed, covering independent
+  control/operational migrations, disjoint schemas and authenticated airport
+  read isolation.
 - PostgreSQL 16: control plus two physically separate airport databases
   migrated and passed authenticated cross-database isolation.
 - Production container image built successfully and its production

--- a/migrations/fresh_schema.py
+++ b/migrations/fresh_schema.py
@@ -1,6 +1,58 @@
 """Explicit fresh-install schema used by the first Alembic revision."""
+import os
+
 import sqlalchemy as sa
-from alembic import op
+from alembic import op as _alembic_op
+
+CONTROL_TABLES = frozenset({
+    "unit", "platform_identity", "unit_membership", "secure_invitation",
+    "database_routing_metadata", "feature_flag", "plan_history",
+    "aggregate_usage_event", "super_admin_audit",
+    "platform_mfa_credential", "signup_workflow", "central_security_audit",
+})
+
+
+class _RoleFilteredOperations:
+    """Filter explicit schema operations for the configured database role."""
+
+    def _allowed(self, table_name):
+        role = os.environ.get(
+            "ATCROSTER_SCHEMA_ROLE", "combined"
+        ).lower()
+        if role == "control":
+            return table_name in CONTROL_TABLES
+        if role == "operational":
+            return table_name not in CONTROL_TABLES
+        return True
+
+    def create_table(self, table_name, *elements, **kwargs):
+        if not self._allowed(table_name):
+            return None
+        filtered = []
+        for element in elements:
+            if isinstance(element, sa.Column) and any(
+                foreign_key.target_fullname.split(".", 1)[0]
+                in CONTROL_TABLES
+                for foreign_key in element.foreign_keys
+            ):
+                element = sa.Column(
+                    element.name, element.type,
+                    primary_key=element.primary_key,
+                    nullable=element.nullable,
+                    server_default=element.server_default,
+                )
+            filtered.append(element)
+        return _alembic_op.create_table(table_name, *filtered, **kwargs)
+
+    def create_index(self, name, table_name, *args, **kwargs):
+        if not self._allowed(table_name):
+            return None
+        return _alembic_op.create_index(
+            name, table_name, *args, **kwargs
+        )
+
+
+op = _RoleFilteredOperations()
 
 
 def create_fresh_schema():

--- a/migrations/versions/20260724_02_production_operations.py
+++ b/migrations/versions/20260724_02_production_operations.py
@@ -3,6 +3,8 @@
 Revision ID: 20260724_02
 Revises: 20260724_01
 """
+import os
+
 from alembic import op
 import sqlalchemy as sa
 
@@ -20,6 +22,8 @@ def _tenant_columns():
 
 
 def upgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
     existing = set(sa.inspect(op.get_bind()).get_table_names())
     if "operational_position" in existing:
         if "mfa_credential" not in existing:

--- a/migrations/versions/20260725_03_request_assurance.py
+++ b/migrations/versions/20260725_03_request_assurance.py
@@ -3,6 +3,8 @@
 Revision ID: 20260725_03
 Revises: 20260724_02
 """
+import os
+
 from alembic import op
 import sqlalchemy as sa
 
@@ -18,6 +20,8 @@ def _column_names(inspector, table):
 
 
 def upgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
     bind = op.get_bind()
     inspector = sa.inspect(bind)
     tables = set(inspector.get_table_names())

--- a/migrations/versions/20260725_04_annotation_assurance.py
+++ b/migrations/versions/20260725_04_annotation_assurance.py
@@ -3,6 +3,8 @@
 Revision ID: 20260725_04
 Revises: 20260725_03
 """
+import os
+
 from alembic import op
 import sqlalchemy as sa
 
@@ -14,6 +16,8 @@ depends_on = None
 
 
 def upgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
     bind = op.get_bind()
     inspector = sa.inspect(bind)
     tables = set(inspector.get_table_names())

--- a/migrations/versions/20260725_05_unit_settings.py
+++ b/migrations/versions/20260725_05_unit_settings.py
@@ -3,6 +3,8 @@
 Revision ID: 20260725_05
 Revises: 20260725_04
 """
+import os
+
 from alembic import op
 import sqlalchemy as sa
 
@@ -14,6 +16,8 @@ depends_on = None
 
 
 def upgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
     bind = op.get_bind()
     inspector = sa.inspect(bind)
     if "roster_setting" not in inspector.get_table_names():

--- a/migrations/versions/20260725_06_qualification_authority.py
+++ b/migrations/versions/20260725_06_qualification_authority.py
@@ -3,6 +3,8 @@
 Revision ID: 20260725_06
 Revises: 20260725_05
 """
+import os
+
 import sqlalchemy as sa
 from alembic import op
 
@@ -19,6 +21,8 @@ def _columns(inspector, table):
 
 
 def upgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
     bind = op.get_bind()
     inspector = sa.inspect(bind)
     tables = set(inspector.get_table_names())
@@ -128,10 +132,13 @@ def upgrade():
         ("UCA", "Unit Competence Assessor", False),
         ("ENGLISH_LANGUAGE", "English Language", True),
     )
+    unit_source = (
+        "SELECT DISTINCT unit_id FROM staff ORDER BY unit_id"
+        if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "operational"
+        else "SELECT id FROM unit ORDER BY id"
+    )
     unit_ids = [
-        row[0] for row in bind.execute(
-            sa.text("SELECT id FROM unit ORDER BY id")
-        )
+        row[0] for row in bind.execute(sa.text(unit_source))
     ]
     for unit_id in unit_ids:
         for code, label, expiry_required in defaults:

--- a/migrations/versions/20260725_08_tenant_constraints.py
+++ b/migrations/versions/20260725_08_tenant_constraints.py
@@ -3,6 +3,8 @@
 Revision ID: 20260725_08
 Revises: 20260725_07
 """
+import os
+
 import sqlalchemy as sa
 from alembic import op
 
@@ -72,9 +74,14 @@ SCOPED_UNIQUES = {
 
 
 def upgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
     bind = op.get_bind()
     tables = set(sa.inspect(bind).get_table_names())
-    for table in TENANT_TABLES:
+    schema_role = os.environ.get(
+        "ATCROSTER_SCHEMA_ROLE", "combined"
+    ).lower()
+    for table in (() if schema_role == "operational" else TENANT_TABLES):
         if table not in tables:
             continue
         inspector = sa.inspect(bind)

--- a/migrations/versions/20260726_09_platform_security_lifecycle.py
+++ b/migrations/versions/20260726_09_platform_security_lifecycle.py
@@ -1,0 +1,88 @@
+"""Add central platform security and lifecycle state.
+
+Revision ID: 20260726_09
+Revises: 20260725_08
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260726_09"
+down_revision = "20260725_08"
+branch_labels = None
+depends_on = None
+
+
+def _tables():
+    return set(sa.inspect(op.get_bind()).get_table_names())
+
+
+def _columns(table):
+    return {
+        column["name"]
+        for column in sa.inspect(op.get_bind()).get_columns(table)
+    }
+
+
+def upgrade():
+    tables = _tables()
+    if "platform_identity" in tables and "platform_mfa_credential" not in tables:
+        op.create_table(
+            "platform_mfa_credential",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("identity_id", sa.Integer(), sa.ForeignKey("platform_identity.id"), nullable=False, unique=True),
+            sa.Column("encrypted_secret", sa.Text(), nullable=False),
+            sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.false()),
+            sa.Column("enrolled_at", sa.DateTime()),
+            sa.Column("last_used_step", sa.BigInteger()),
+            sa.Column("recovery_codes_digest", sa.Text(), nullable=False, server_default="[]"),
+            sa.Column("reset_required", sa.Boolean(), nullable=False, server_default=sa.false()),
+        )
+    if "secure_invitation" in tables and "issued_at" not in _columns("secure_invitation"):
+        with op.batch_alter_table("secure_invitation") as batch:
+            batch.add_column(sa.Column("issued_at", sa.DateTime()))
+        op.execute("UPDATE secure_invitation SET issued_at=CURRENT_TIMESTAMP WHERE issued_at IS NULL")
+    if {"secure_invitation", "platform_identity", "unit_membership"} <= tables and "signup_workflow" not in tables:
+        op.create_table(
+            "signup_workflow",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("invitation_id", sa.Integer(), sa.ForeignKey("secure_invitation.id"), nullable=False, unique=True),
+            sa.Column("idempotency_key", sa.String(64), nullable=False, unique=True),
+            sa.Column("state", sa.String(40), nullable=False),
+            sa.Column("normalized_username", sa.String(120), nullable=False),
+            sa.Column("identity_id", sa.Integer(), sa.ForeignKey("platform_identity.id")),
+            sa.Column("operational_person_id", sa.Integer()),
+            sa.Column("membership_id", sa.Integer(), sa.ForeignKey("unit_membership.id")),
+            sa.Column("attempt_count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("last_error_code", sa.String(80), nullable=False, server_default=""),
+            sa.Column("compensation_state", sa.String(40), nullable=False, server_default=""),
+            sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        )
+    if "database_routing_metadata" in tables:
+        existing = _columns("database_routing_metadata")
+        additions = (
+            ("provisioning_state", sa.String(40), "pending"),
+            ("last_error_code", sa.String(80), ""),
+            ("attempt_count", sa.Integer(), "0"),
+            ("last_attempt_at", sa.DateTime(), None),
+            ("ready_at", sa.DateTime(), None),
+        )
+        with op.batch_alter_table("database_routing_metadata") as batch:
+            for name, column_type, default in additions:
+                if name not in existing:
+                    batch.add_column(sa.Column(name, column_type, server_default=default))
+    if "platform_identity" in tables and "central_security_audit" not in tables:
+        op.create_table(
+            "central_security_audit",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("identity_id", sa.Integer(), sa.ForeignKey("platform_identity.id")),
+            sa.Column("event_type", sa.String(80), nullable=False),
+            sa.Column("principal_digest", sa.String(32), nullable=False, server_default=""),
+            sa.Column("outcome", sa.String(20), nullable=False),
+            sa.Column("safe_detail", sa.String(200), nullable=False, server_default=""),
+            sa.Column("occurred_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        )
+
+
+def downgrade():
+    raise RuntimeError("Platform security lifecycle state is not safely reversible.")

--- a/saas_models.py
+++ b/saas_models.py
@@ -19,6 +19,60 @@ def register_saas_models(db, utcnow):
         created_at = db.Column(db.DateTime, nullable=False, default=utcnow)
         last_active_at = db.Column(db.DateTime)
 
+        unit_id = 0
+        name = "Platform Administrator"
+
+        @property
+        def role(self):
+            return (
+                "superadmin"
+                if self.public_id.startswith("platform-") else "inactive"
+            )
+
+        @property
+        def membership_status(self):
+            return (
+                "active"
+                if self.public_id.startswith("platform-") else "pending"
+            )
+
+        @property
+        def is_authenticated(self):
+            return True
+
+        @property
+        def is_active(self):
+            return True
+
+        @property
+        def is_anonymous(self):
+            return False
+
+        def get_id(self):
+            return f"platform-identity:{self.id}"
+
+        def check_password(self, password):
+            from werkzeug.security import check_password_hash
+            return check_password_hash(self.password_hash, password)
+
+        def set_password(self, password):
+            from werkzeug.security import generate_password_hash
+            self.password_hash = generate_password_hash(password)
+
+    class PlatformMfaCredential(db.Model):
+        __tablename__ = "platform_mfa_credential"
+        id = db.Column(db.Integer, primary_key=True)
+        identity_id = db.Column(
+            db.Integer, db.ForeignKey("platform_identity.id"),
+            nullable=False, unique=True,
+        )
+        encrypted_secret = db.Column(db.Text, nullable=False)
+        enabled = db.Column(db.Boolean, nullable=False, default=False)
+        enrolled_at = db.Column(db.DateTime)
+        last_used_step = db.Column(db.BigInteger)
+        recovery_codes_digest = db.Column(db.Text, nullable=False, default="[]")
+        reset_required = db.Column(db.Boolean, nullable=False, default=False)
+
     class UnitMembership(db.Model):
         __tablename__ = "unit_membership"
         id = db.Column(db.Integer, primary_key=True)
@@ -46,6 +100,26 @@ def register_saas_models(db, utcnow):
         expires_at = db.Column(db.DateTime, nullable=False)
         accepted_at = db.Column(db.DateTime)
         disabled_at = db.Column(db.DateTime)
+        issued_at = db.Column(db.DateTime, nullable=False, default=utcnow)
+
+    class SignupWorkflow(db.Model):
+        __tablename__ = "signup_workflow"
+        id = db.Column(db.Integer, primary_key=True)
+        invitation_id = db.Column(
+            db.Integer, db.ForeignKey("secure_invitation.id"),
+            nullable=False, unique=True,
+        )
+        idempotency_key = db.Column(db.String(64), nullable=False, unique=True)
+        state = db.Column(db.String(40), nullable=False, default="pending")
+        normalized_username = db.Column(db.String(120), nullable=False)
+        identity_id = db.Column(db.Integer, db.ForeignKey("platform_identity.id"))
+        operational_person_id = db.Column(db.Integer)
+        membership_id = db.Column(db.Integer, db.ForeignKey("unit_membership.id"))
+        attempt_count = db.Column(db.Integer, nullable=False, default=0)
+        last_error_code = db.Column(db.String(80), nullable=False, default="")
+        compensation_state = db.Column(db.String(40), nullable=False, default="")
+        created_at = db.Column(db.DateTime, nullable=False, default=utcnow)
+        updated_at = db.Column(db.DateTime, nullable=False, default=utcnow)
 
     class DatabaseRoutingMetadata(db.Model):
         __tablename__ = "database_routing_metadata"
@@ -54,6 +128,13 @@ def register_saas_models(db, utcnow):
         health = db.Column(db.String(20), nullable=False, default="unknown")
         migration_version = db.Column(db.String(64), nullable=False, default="")
         storage_bytes = db.Column(db.BigInteger, nullable=False, default=0)
+        provisioning_state = db.Column(
+            db.String(40), nullable=False, default="pending"
+        )
+        last_error_code = db.Column(db.String(80), nullable=False, default="")
+        attempt_count = db.Column(db.Integer, nullable=False, default=0)
+        last_attempt_at = db.Column(db.DateTime)
+        ready_at = db.Column(db.DateTime)
 
     class FeatureFlag(db.Model):
         __tablename__ = "feature_flag"
@@ -84,9 +165,19 @@ def register_saas_models(db, utcnow):
         __tablename__ = "super_admin_audit"
         id = db.Column(db.Integer, primary_key=True)
         actor_identity_id = db.Column(db.Integer, db.ForeignKey("platform_identity.id"), nullable=False)
-        unit_id = db.Column(db.Integer, db.ForeignKey("unit.id"), nullable=False)
+        unit_id = db.Column(db.Integer, db.ForeignKey("unit.id"))
         action = db.Column(db.String(80), nullable=False)
         safe_summary = db.Column(db.String(500), nullable=False)
+        occurred_at = db.Column(db.DateTime, nullable=False, default=utcnow)
+
+    class CentralSecurityAudit(db.Model):
+        __tablename__ = "central_security_audit"
+        id = db.Column(db.Integer, primary_key=True)
+        identity_id = db.Column(db.Integer, db.ForeignKey("platform_identity.id"))
+        event_type = db.Column(db.String(80), nullable=False)
+        principal_digest = db.Column(db.String(32), nullable=False, default="")
+        outcome = db.Column(db.String(20), nullable=False)
+        safe_detail = db.Column(db.String(200), nullable=False, default="")
         occurred_at = db.Column(db.DateTime, nullable=False, default=utcnow)
 
     class QualificationType(db.Model):

--- a/scripts/migrate_all_databases.py
+++ b/scripts/migrate_all_databases.py
@@ -8,24 +8,41 @@ from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
+from alembic.runtime.migration import MigrationContext
 from sqlalchemy import create_engine, text
 
 REPOSITORY = Path(__file__).resolve().parents[1]
 SECRET_NAME_PATTERN = re.compile(r"ATCROSTER_UNIT_[1-9][0-9]*_DATABASE_URL")
 
 
-def _upgrade(database_url: str) -> None:
+def upgrade_database(
+    database_url: str, schema_role: str = "combined"
+) -> str:
     previous = os.environ.get("DATABASE_URL")
+    previous_role = os.environ.get("ATCROSTER_SCHEMA_ROLE")
     os.environ["DATABASE_URL"] = database_url
+    os.environ["ATCROSTER_SCHEMA_ROLE"] = schema_role
     try:
         config = Config(str(REPOSITORY / "alembic.ini"))
         config.set_main_option("script_location", str(REPOSITORY / "migrations"))
         command.upgrade(config, "head")
+        engine = create_engine(database_url, pool_pre_ping=True)
+        try:
+            with engine.connect() as connection:
+                return MigrationContext.configure(
+                    connection
+                ).get_current_revision() or ""
+        finally:
+            engine.dispose()
     finally:
         if previous is None:
             os.environ.pop("DATABASE_URL", None)
         else:
             os.environ["DATABASE_URL"] = previous
+        if previous_role is None:
+            os.environ.pop("ATCROSTER_SCHEMA_ROLE", None)
+        else:
+            os.environ["ATCROSTER_SCHEMA_ROLE"] = previous_role
 
 
 def main() -> None:
@@ -34,22 +51,19 @@ def main() -> None:
     )
     if not control_url:
         raise SystemExit("CONTROL_DATABASE_URL is required.")
-    _upgrade(control_url)
+    control_version = upgrade_database(control_url, "control")
+    print(f"Control database upgraded to {control_version}.")
     control_engine = create_engine(control_url, pool_pre_ping=True)
     try:
         with control_engine.connect() as connection:
             routes = connection.execute(text(
-                "SELECT r.unit_id, r.secret_name, u.code, u.name, "
-                "u.timezone, u.locale, u.date_format, u.branding_json "
+                "SELECT r.unit_id, r.secret_name "
                 "FROM database_routing_metadata r "
-                "JOIN unit u ON u.id=r.unit_id ORDER BY r.unit_id"
+                "ORDER BY r.unit_id"
             )).all()
     finally:
         control_engine.dispose()
-    for (
-        unit_id, secret_name, code, name, timezone_name, locale,
-        date_format, branding_json,
-    ) in routes:
+    for unit_id, secret_name in routes:
         if not SECRET_NAME_PATTERN.fullmatch(secret_name or ""):
             raise SystemExit(
                 f"Unit {unit_id} has an invalid deployment-secret name."
@@ -63,29 +77,11 @@ def main() -> None:
             raise SystemExit(
                 f"Unit {unit_id} operational database must differ from control."
             )
-        _upgrade(operational_url)
-        operational_engine = create_engine(
-            operational_url, pool_pre_ping=True
+        version = upgrade_database(operational_url, "operational")
+        print(
+            f"Operational database for unit {unit_id} upgraded to "
+            f"{version}."
         )
-        try:
-            with operational_engine.begin() as connection:
-                connection.execute(text(
-                    "INSERT INTO unit "
-                    "(id,code,name,timezone,locale,date_format,branding_json,"
-                    "status,plan,request_months_ahead,request_lock_day,"
-                    "active_user_limit,onboarding_step,created_at) VALUES "
-                    "(:id,:code,:name,:timezone,:locale,:date_format,"
-                    ":branding,'active','operational',3,20,1,1,"
-                    "CURRENT_TIMESTAMP) ON CONFLICT (id) DO NOTHING"
-                ), {
-                    "id": unit_id, "code": code, "name": name,
-                    "timezone": timezone_name, "locale": locale,
-                    "date_format": date_format,
-                    "branding": branding_json or "{}",
-                })
-        finally:
-            operational_engine.dispose()
-        print(f"Upgraded operational database for unit {unit_id}.")
 
 
 if __name__ == "__main__":

--- a/templates/mfa_setup.html
+++ b/templates/mfa_setup.html
@@ -7,7 +7,7 @@
       <h2>Save your recovery codes</h2>
       <p>These codes are displayed once. Store them in an approved password manager. Each code works only once.</p>
       <div class="recovery-code-grid">{% for code in recovery_codes %}<code>{{ code }}</code>{% endfor %}</div>
-      <a class="btn btn-primary mt-3" href="{{ url_for('index') }}">I have stored the codes</a>
+      <a class="btn btn-primary mt-3" href="{{ url_for('platform_mfa_challenge') if platform_enrolment else url_for('index') }}">I have stored the codes</a>
     {% elif enabled %}
       <p class="compliance-clear"><i class="fa-solid fa-circle-check"></i> Multi-factor authentication is enabled.</p>
       <p>Contact an authorised administrator through the approved support process if access must be recovered.</p>

--- a/templates/platform_admin.html
+++ b/templates/platform_admin.html
@@ -16,7 +16,7 @@
       <div class="col-md-3"><label>Active-user limit<input class="form-control" type="number" name="active_user_limit" min="1" max="10000" value="10" required></label></div>
       <div class="col-12">
         <p class="form-text">The platform creates an opaque, one-time bootstrap invitation. The airport administrator enters their own identity and password and must configure MFA before accessing operational data.</p>
-        <button class="btn btn-primary" type="submit">Create airport and bootstrap invitation</button>
+        <button class="btn btn-primary" type="submit">Create airport metadata</button>
       </div>
     </form>
   </section>
@@ -35,7 +35,18 @@
             Renewal {{ row.unit.renews_at.strftime('%d %b %Y') if row.unit.renews_at else '—' }}<br>
             Last active {{ row.unit.last_active_at.strftime('%d %b %Y %H:%M') if row.unit.last_active_at else '—' }}
           </td>
-          <td>{{ row.bootstrap_status }}</td>
+          <td>
+            {{ row.bootstrap_status }}<br>
+            <small>{{ row.provisioning_state }}{% if row.provisioning_error %} · {{ row.provisioning_error }}{% endif %}</small>
+            {% if row.provisioning_state != "active" %}
+            <form method="post" class="mt-2">
+              <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+              <input type="hidden" name="action" value="provision_unit">
+              <input type="hidden" name="unit_id" value="{{ row.unit.id }}">
+              <button class="btn btn-sm" type="submit">Provision / retry</button>
+            </form>
+            {% endif %}
+          </td>
           <td>{{ row.active_accounts }} / {{ row.unit.active_user_limit }}</td>
           <td>
             {% for key in feature_keys %}

--- a/tests/test_legacy_migration_fixtures.py
+++ b/tests/test_legacy_migration_fixtures.py
@@ -119,7 +119,7 @@ def test_legacy_fixture_upgrades_to_head_without_data_loss(
         inspector = inspect(connection)
         assert connection.execute(
             text("SELECT version_num FROM alembic_version")
-        ).scalar_one() == "20260725_08"
+        ).scalar_one() == "20260726_09"
         for table, count in before.items():
             assert connection.execute(
                 text(f'SELECT COUNT(*) FROM "{table}"')

--- a/tests/test_legacy_migration_fixtures.py
+++ b/tests/test_legacy_migration_fixtures.py
@@ -1,13 +1,13 @@
 import os
 import sqlite3
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 from sqlalchemy import create_engine, inspect, text
 
 REPOSITORY = Path(__file__).resolve().parents[1]
-ALEMBIC = Path("/tmp/atcroster-py312/bin/alembic")
 
 
 FIXTURES = {
@@ -110,7 +110,7 @@ def test_legacy_fixture_upgrades_to_head_without_data_loss(
         "ATCROSTER_SKIP_RUNTIME_SCHEMA": "1",
     })
     result = subprocess.run(
-        [str(ALEMBIC), "upgrade", "head"],
+        [sys.executable, "-m", "alembic", "upgrade", "head"],
         cwd=REPOSITORY, env=environment,
         capture_output=True, text=True, check=False,
     )

--- a/tests/test_physical_database_isolation.py
+++ b/tests/test_physical_database_isolation.py
@@ -32,11 +32,16 @@ def _operational_tables():
     ]
 
 
-def _seed_operational_unit(unit_id, secret_name, username, marker):
+def _seed_operational_unit(
+    unit_id, secret_name, username, marker, create_schema=True
+):
     token = bind_authenticated_unit(unit_id, secret_name)
     try:
         engine = operational_engine_for_authenticated_unit()
-        db.metadata.create_all(bind=engine, tables=_operational_tables())
+        if create_schema:
+            db.metadata.create_all(
+                bind=engine, tables=_operational_tables()
+            )
         watch = Watch(unit_id=unit_id, name=f"Watch {marker}")
         db.session.add(watch)
         db.session.flush()

--- a/tests/test_platform_admin.py
+++ b/tests/test_platform_admin.py
@@ -26,7 +26,32 @@ def _login(client, username, password):
     assert response.status_code == 302
 
 
-def test_super_admin_provisions_airport_and_account_limit_is_transactional():
+def _login_platform_with_mfa(client, username, password):
+    _login(client, username, password)
+    setup = client.get("/login/platform-mfa/setup")
+    assert setup.status_code == 200
+    with client.session_transaction() as session:
+        secret = session["_pending_platform_mfa_secret"]
+        token = session["_csrf_token"]
+    enrolled = client.post(
+        "/login/platform-mfa/setup",
+        data={"_csrf_token": token, "code": pyotp.TOTP(secret).now()},
+    )
+    assert enrolled.status_code == 200
+    challenge = client.get("/login/platform-mfa")
+    assert challenge.status_code == 200
+    with client.session_transaction() as session:
+        token = session["_csrf_token"]
+    verified = client.post(
+        "/login/platform-mfa",
+        data={"_csrf_token": token, "code": pyotp.TOTP(secret).now()},
+    )
+    assert verified.status_code == 302
+
+
+def test_super_admin_provisions_airport_and_account_limit_is_transactional(
+    tmp_path, monkeypatch
+):
     with app.app.app_context():
         db.drop_all()
         db.create_all()
@@ -54,7 +79,9 @@ def test_super_admin_provisions_airport_and_account_limit_is_transactional():
         assert db.session.get(Staff, platform_user.id).role == "superadmin"
 
     super_client = app.app.test_client()
-    _login(super_client, "platform.admin", "Platform-Test-2026!")
+    _login_platform_with_mfa(
+        super_client, "platform.admin", "Platform-Test-2026!"
+    )
     token = _csrf(super_client, "/platform/admin")
     created = super_client.post(
         "/platform/admin",
@@ -72,10 +99,29 @@ def test_super_admin_provisions_airport_and_account_limit_is_transactional():
         follow_redirects=True,
     )
     assert created.status_code == 200
-    assert b"Test Airport created" in created.data
+    assert b"Test Airport metadata created" in created.data
     # The control-plane listing does not display personnel details.
     assert b"tst.admin" not in created.data
-    bootstrap_match = re.search(rb"/invite/([A-Za-z0-9_-]+)", created.data)
+    with app.app.app_context():
+        unit = Unit.query.filter_by(code="TST").one()
+        secret_name = f"ATCROSTER_UNIT_{unit.id}_DATABASE_URL"
+    monkeypatch.setenv(
+        secret_name, f"sqlite:///{tmp_path / 'tst-operational.db'}"
+    )
+    provision_token = _csrf(super_client, "/platform/admin")
+    provisioned = super_client.post(
+        "/platform/admin",
+        data={
+            "_csrf_token": provision_token,
+            "action": "provision_unit",
+            "unit_id": str(unit.id),
+        },
+        follow_redirects=True,
+    )
+    assert provisioned.status_code == 200
+    bootstrap_match = re.search(
+        rb"/invite/([A-Za-z0-9_-]+)", provisioned.data
+    )
     assert bootstrap_match
     bootstrap_path = bootstrap_match.group(0).decode()
 
@@ -112,6 +158,29 @@ def test_super_admin_provisions_airport_and_account_limit_is_transactional():
     )
     assert enrolled.status_code == 200
     unit_token = _csrf(unit_client, "/unit/accounts")
+    with app.app.app_context():
+        db.session.add(PlatformIdentity(
+            public_id="other-airport-duplicate",
+            username="tst.duplicate",
+            password_hash="not-a-login-secret",
+        ))
+        db.session.commit()
+    duplicate = unit_client.post(
+        "/unit/accounts",
+        data={
+            "_csrf_token": unit_token,
+            "action": "create_account",
+            "name": "Must Not Be Created",
+            "username": "TST.DUPLICATE",
+            "password": "Duplicate-Test-2026!",
+        },
+        follow_redirects=True,
+    )
+    assert b"login identifier is unavailable" in duplicate.data
+    with app.app.app_context():
+        assert UnitMembership.query.join(PlatformIdentity).filter(
+            PlatformIdentity.username == "tst.duplicate"
+        ).count() == 0
     second = unit_client.post(
         "/unit/accounts",
         data={
@@ -211,7 +280,9 @@ def test_platform_admin_onboarding_contains_no_personal_identity_fields():
         ))
         db.session.commit()
     client = app.app.test_client()
-    _login(client, "privacy.platform", "Platform-Privacy-2026!")
+    _login_platform_with_mfa(
+        client, "privacy.platform", "Platform-Privacy-2026!"
+    )
     page = client.get("/platform/admin")
     assert page.status_code == 200
     prohibited = (

--- a/tests/test_platform_security_lifecycle.py
+++ b/tests/test_platform_security_lifecycle.py
@@ -1,0 +1,275 @@
+import hashlib
+
+import pyotp
+import pytest
+from sqlalchemy import create_engine, inspect
+
+import app
+from app import (
+    DatabaseRoutingMetadata,
+    PlatformIdentity,
+    PlatformMfaCredential,
+    SecureInvitation,
+    SignupWorkflow,
+    Staff,
+    Unit,
+    UnitMembership,
+    db,
+)
+from scripts.migrate_all_databases import upgrade_database
+from tenancy import dispose_operational_engines, operational_unit_context
+
+
+def _reset():
+    dispose_operational_engines()
+    with app.app.app_context():
+        db.session.remove()
+        db.drop_all()
+        db.create_all()
+
+
+def _platform_account():
+    control = Unit(
+        code="CTRL", name="Platform Control",
+        status="platform_control", active_user_limit=2,
+    )
+    db.session.add(control)
+    db.session.flush()
+    user = Staff(
+        unit_id=control.id, username="security.platform",
+        name="Platform Security", staff_no="CTRL-SEC",
+        role="superadmin", is_operational=False,
+    )
+    user.set_password("Platform-Security-2026!")
+    db.session.add(user)
+    db.session.flush()
+    identity = PlatformIdentity(
+        public_id="platform-security-test",
+        username=user.username, password_hash=user.password_hash,
+    )
+    db.session.add(identity)
+    db.session.commit()
+    return user, identity
+
+
+def _csrf(client):
+    with client.session_transaction() as session:
+        return session["_csrf_token"]
+
+
+def test_superadmin_requires_central_mfa_before_platform_access():
+    _reset()
+    with app.app.app_context():
+        _platform_account()
+    client = app.app.test_client()
+    password = client.post("/login", data={
+        "username": "security.platform",
+        "password": "Platform-Security-2026!",
+    })
+    assert password.status_code == 302
+    blocked = client.get("/platform/admin")
+    assert blocked.status_code == 302
+    assert "/login" in blocked.headers["Location"]
+    setup = client.get("/login/platform-mfa/setup")
+    assert setup.status_code == 200
+    with client.session_transaction() as session:
+        secret = session["_pending_platform_mfa_secret"]
+        token = session["_csrf_token"]
+    enabled = client.post("/login/platform-mfa/setup", data={
+        "_csrf_token": token, "code": pyotp.TOTP(secret).now(),
+    })
+    assert enabled.status_code == 200
+    with app.app.app_context():
+        credential = PlatformMfaCredential.query.one()
+        assert credential.enabled
+        assert secret not in credential.encrypted_secret
+        assert credential.recovery_codes_digest != "[]"
+    client.get("/login/platform-mfa")
+    verified = client.post("/login/platform-mfa", data={
+        "_csrf_token": _csrf(client),
+        "code": pyotp.TOTP(secret).now(),
+    })
+    assert verified.status_code == 302
+    assert client.get("/platform/admin").status_code == 200
+
+
+def test_provisioning_failure_is_safe_and_retryable(tmp_path, monkeypatch):
+    _reset()
+    with app.app.app_context():
+        _user, identity = _platform_account()
+        unit = Unit(
+            code="PRV", name="Provisioning Test",
+            status="provisioning", active_user_limit=3,
+        )
+        db.session.add(unit)
+        db.session.flush()
+        route = DatabaseRoutingMetadata(
+            unit_id=unit.id,
+            secret_name=f"ATCROSTER_UNIT_{unit.id}_DATABASE_URL",
+            provisioning_state="pending",
+        )
+        db.session.add(route)
+        db.session.commit()
+        identity_id = identity.id
+        unit_id, secret_name = unit.id, route.secret_name
+    client = app.app.test_client()
+    with client.session_transaction() as session:
+        session["_user_id"] = f"platform-identity:{identity_id}"
+        session["_fresh"] = True
+        session["_platform_mfa_verified"] = True
+    client.get("/platform/admin")
+    failed = client.post("/platform/admin", data={
+        "_csrf_token": _csrf(client),
+        "action": "provision_unit", "unit_id": str(unit_id),
+    })
+    assert failed.status_code == 302
+    with app.app.app_context():
+        route = db.session.get(DatabaseRoutingMetadata, unit_id)
+        assert route.provisioning_state == "failed"
+        assert route.last_error_code == "database_secret_unavailable"
+        assert SecureInvitation.query.filter_by(unit_id=unit_id).count() == 0
+    operational_url = f"sqlite:///{tmp_path / 'provisioned.db'}"
+    monkeypatch.setenv(secret_name, operational_url)
+    from scripts import migrate_all_databases
+    real_upgrade = migrate_all_databases.upgrade_database
+    monkeypatch.setattr(
+        migrate_all_databases, "upgrade_database",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("synthetic migration failure")
+        ),
+    )
+    client.get("/platform/admin")
+    migration_failed = client.post("/platform/admin", data={
+        "_csrf_token": _csrf(client),
+        "action": "provision_unit", "unit_id": str(unit_id),
+    })
+    assert migration_failed.status_code == 302
+    with app.app.app_context():
+        route = db.session.get(DatabaseRoutingMetadata, unit_id)
+        assert route.provisioning_state == "failed"
+        assert route.last_error_code == "database_provisioning_failed"
+        assert SecureInvitation.query.filter_by(unit_id=unit_id).count() == 0
+    monkeypatch.setattr(
+        migrate_all_databases, "upgrade_database", real_upgrade
+    )
+    client.get("/platform/admin")
+    retried = client.post("/platform/admin", data={
+        "_csrf_token": _csrf(client),
+        "action": "provision_unit", "unit_id": str(unit_id),
+    })
+    assert retried.status_code == 302
+    with app.app.app_context():
+        route = db.session.get(DatabaseRoutingMetadata, unit_id)
+        assert route.provisioning_state == "invitation_issued"
+        assert route.attempt_count == 3
+        assert SecureInvitation.query.filter_by(unit_id=unit_id).count() == 1
+    engine = create_engine(operational_url)
+    try:
+        tables = set(inspect(engine).get_table_names())
+        assert "staff" in tables
+        assert "platform_identity" not in tables
+        assert "unit" not in tables
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.parametrize("stage", [
+    "identity_created",
+    "operational_account_created",
+    "membership_created",
+])
+def test_signup_saga_recovers_idempotently_after_each_stage(
+    stage, tmp_path, monkeypatch
+):
+    _reset()
+    operational_url = f"sqlite:///{tmp_path / f'{stage}.db'}"
+    upgrade_database(operational_url, "operational")
+    with app.app.app_context():
+        unit = Unit(
+            code="SGA", name="Saga Airport", status="active",
+            active_user_limit=5,
+        )
+        db.session.add(unit)
+        db.session.flush()
+        secret_name = f"ATCROSTER_UNIT_{unit.id}_DATABASE_URL"
+        monkeypatch.setenv(secret_name, operational_url)
+        route = DatabaseRoutingMetadata(
+            unit_id=unit.id, secret_name=secret_name,
+            provisioning_state="invitation_issued",
+        )
+        invitation = SecureInvitation(
+            unit_id=unit.id,
+            token_digest=hashlib.sha256(stage.encode()).hexdigest(),
+            role="StaffUser",
+            expires_at=app.utcnow() + app.timedelta(days=1),
+        )
+        db.session.add_all([route, invitation])
+        db.session.commit()
+        with operational_unit_context(unit.id, secret_name):
+            with pytest.raises(app.SignupWorkflowError):
+                app._run_invitation_signup(
+                    invitation, unit, "Saga Person",
+                    f"{stage}-test".replace("_", "-"),
+                    "Saga-Password-2026!", fail_after=stage,
+                )
+            workflow = SignupWorkflow.query.filter_by(
+                invitation_id=invitation.id
+            ).one()
+            assert workflow.state == "failed"
+            app._run_invitation_signup(
+                invitation, unit, "Saga Person",
+                f"{stage}-test".replace("_", "-"),
+                "Saga-Password-2026!",
+            )
+            assert Staff.query.count() == 1
+        workflow = SignupWorkflow.query.filter_by(
+            invitation_id=invitation.id
+        ).one()
+        assert workflow.state == "completed"
+        assert UnitMembership.query.filter_by(unit_id=unit.id).count() == 1
+        assert db.session.get(SecureInvitation, invitation.id).accepted_at
+
+
+def test_global_identity_duplicate_creates_no_operational_staff(
+    tmp_path, monkeypatch
+):
+    _reset()
+    operational_url = f"sqlite:///{tmp_path / 'duplicate.db'}"
+    upgrade_database(operational_url, "operational")
+    with app.app.app_context():
+        unit = Unit(
+            code="DUP", name="Duplicate Test", status="active",
+            active_user_limit=2,
+        )
+        db.session.add(unit)
+        db.session.flush()
+        secret_name = f"ATCROSTER_UNIT_{unit.id}_DATABASE_URL"
+        monkeypatch.setenv(secret_name, operational_url)
+        db.session.add_all([
+            DatabaseRoutingMetadata(
+                unit_id=unit.id, secret_name=secret_name,
+                provisioning_state="invitation_issued",
+            ),
+            PlatformIdentity(
+                public_id="existing-global",
+                username="global.user", password_hash="not-used",
+            ),
+        ])
+        invitation = SecureInvitation(
+            unit_id=unit.id,
+            token_digest=hashlib.sha256(b"duplicate").hexdigest(),
+            role="StaffUser",
+            expires_at=app.utcnow() + app.timedelta(days=1),
+        )
+        db.session.add(invitation)
+        db.session.commit()
+        with operational_unit_context(unit.id, secret_name):
+            with pytest.raises(
+                app.SignupWorkflowError,
+                match="login identifier is unavailable",
+            ):
+                app._run_invitation_signup(
+                    invitation, unit, "Duplicate Person",
+                    "GLOBAL.USER", "Duplicate-Password-2026!",
+                )
+            assert Staff.query.count() == 0

--- a/tests/test_postgresql_multidatabase.py
+++ b/tests/test_postgresql_multidatabase.py
@@ -1,0 +1,128 @@
+"""PostgreSQL-only proof of the physical control/airport boundary."""
+import os
+
+import pytest
+from sqlalchemy import create_engine, inspect, text
+
+CONTROL_URL = os.environ.get("ATCROSTER_TEST_CONTROL_DATABASE_URL")
+AIRPORT_A_URL = os.environ.get("ATCROSTER_TEST_A_DATABASE_URL")
+AIRPORT_B_URL = os.environ.get("ATCROSTER_TEST_B_DATABASE_URL")
+
+pytestmark = pytest.mark.skipif(
+    not all((CONTROL_URL, AIRPORT_A_URL, AIRPORT_B_URL)),
+    reason="three PostgreSQL integration database URLs are required",
+)
+
+if CONTROL_URL:
+    os.environ["DATABASE_URL"] = CONTROL_URL
+    os.environ["CONTROL_DATABASE_URL"] = CONTROL_URL
+    os.environ["ATCROSTER_SKIP_RUNTIME_SCHEMA"] = "1"
+
+import app  # noqa: E402
+from app import (  # noqa: E402
+    DatabaseRoutingMetadata,
+    PlatformIdentity,
+    Unit,
+    UnitMembership,
+    db,
+)
+from scripts.migrate_all_databases import upgrade_database  # noqa: E402
+from tenancy import dispose_operational_engines  # noqa: E402
+from tests.test_physical_database_isolation import (  # noqa: E402
+    _seed_operational_unit,
+)
+
+
+def _reset_postgres(url):
+    engine = create_engine(url, isolation_level="AUTOCOMMIT")
+    try:
+        with engine.begin() as connection:
+            connection.execute(text("DROP SCHEMA public CASCADE"))
+            connection.execute(text("CREATE SCHEMA public"))
+    finally:
+        engine.dispose()
+
+
+def test_postgresql_control_and_two_airport_databases_are_isolated(
+    monkeypatch,
+):
+    dispose_operational_engines()
+    for url in (CONTROL_URL, AIRPORT_A_URL, AIRPORT_B_URL):
+        _reset_postgres(url)
+    assert upgrade_database(CONTROL_URL, "control") == "20260726_09"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260726_09"
+    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260726_09"
+    secret_a = "ATCROSTER_UNIT_1_DATABASE_URL"
+    secret_b = "ATCROSTER_UNIT_2_DATABASE_URL"
+    monkeypatch.setenv(secret_a, AIRPORT_A_URL)
+    monkeypatch.setenv(secret_b, AIRPORT_B_URL)
+    with app.app.app_context():
+        db.session.add_all([
+            Unit(id=1, code="PGA", name="Postgres Airport A"),
+            Unit(id=2, code="PGB", name="Postgres Airport B"),
+        ])
+        db.session.commit()
+        person_a, password_a, _ = _seed_operational_unit(
+            1, secret_a, "postgres-a", "POSTGRES-A",
+            create_schema=False,
+        )
+        person_b, password_b, _ = _seed_operational_unit(
+            2, secret_b, "postgres-b", "POSTGRES-B",
+            create_schema=False,
+        )
+        identity_a = PlatformIdentity(
+            public_id="postgres-a", username="postgres-a",
+            password_hash=password_a,
+        )
+        identity_b = PlatformIdentity(
+            public_id="postgres-b", username="postgres-b",
+            password_hash=password_b,
+        )
+        db.session.add_all([identity_a, identity_b])
+        db.session.flush()
+        db.session.add_all([
+            UnitMembership(
+                identity_id=identity_a.id, unit_id=1,
+                person_id=person_a, role="StaffUser", status="active",
+            ),
+            UnitMembership(
+                identity_id=identity_b.id, unit_id=2,
+                person_id=person_b, role="StaffUser", status="active",
+            ),
+            DatabaseRoutingMetadata(
+                unit_id=1, secret_name=secret_a,
+                provisioning_state="active",
+            ),
+            DatabaseRoutingMetadata(
+                unit_id=2, secret_name=secret_b,
+                provisioning_state="active",
+            ),
+        ])
+        db.session.commit()
+    client_a = app.app.test_client()
+    client_b = app.app.test_client()
+    assert client_a.post("/login", data={
+        "username": "postgres-a", "password": "Physical-Test-2026!",
+    }).status_code == 302
+    assert client_b.post("/login", data={
+        "username": "postgres-b", "password": "Physical-Test-2026!",
+    }).status_code == 302
+    page_a = client_a.get("/requests")
+    page_b = client_b.get("/requests")
+    assert b"POSTGRES-A-ONLY" in page_a.data
+    assert b"POSTGRES-B-ONLY" not in page_a.data
+    assert b"POSTGRES-B-ONLY" in page_b.data
+    assert b"POSTGRES-A-ONLY" not in page_b.data
+    control_tables = set(inspect(create_engine(CONTROL_URL)).get_table_names())
+    airport_a_tables = set(
+        inspect(create_engine(AIRPORT_A_URL)).get_table_names()
+    )
+    airport_b_tables = set(
+        inspect(create_engine(AIRPORT_B_URL)).get_table_names()
+    )
+    assert "platform_identity" in control_tables
+    assert "staff" not in control_tables
+    assert "staff" in airport_a_tables and "staff" in airport_b_tables
+    assert "platform_identity" not in airport_a_tables
+    assert "unit" not in airport_a_tables
+    dispose_operational_engines()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -399,6 +399,33 @@ def test_role_permission_matrix_and_cross_airport_isolation():
             data={"username": username, "password": "password123"},
         )
         assert response.status_code == 302
+        if role == "superadmin":
+            protected = role_client.get("/platform/admin")
+            assert protected.status_code == 302
+            assert "/login" in protected.headers["Location"]
+            setup = role_client.get("/login/platform-mfa/setup")
+            assert setup.status_code == 200
+            with role_client.session_transaction() as session:
+                secret = session["_pending_platform_mfa_secret"]
+                token = session["_csrf_token"]
+            role_client.post(
+                "/login/platform-mfa/setup",
+                data={
+                    "_csrf_token": token,
+                    "code": pyotp.TOTP(secret).now(),
+                },
+            )
+            role_client.get("/login/platform-mfa")
+            with role_client.session_transaction() as session:
+                token = session["_csrf_token"]
+            verified = role_client.post(
+                "/login/platform-mfa",
+                data={
+                    "_csrf_token": token,
+                    "code": pyotp.TOTP(secret).now(),
+                },
+            )
+            assert verified.status_code == 302
         clients[role] = role_client
         for capability, path in common.items():
             actual = role_client.get(path).status_code


### PR DESCRIPTION
## What changed

- restores portable Alembic test invocation for clean GitHub runners
- adds control-plane-only SuperAdmin MFA with encrypted TOTP secrets, hashed one-time recovery codes, rate limiting, session rotation and safe audits
- introduces retryable airport database provisioning before bootstrap invitation issuance
- replaces cross-database invitation acceptance with an idempotent staged signup saga and reconciliation command
- enforces normalized global identity uniqueness and compensates partial direct-account creation
- separates control and operational migration roles so airport databases contain no control-plane identity or unit tables
- adds a PostgreSQL 16 CI topology with one control and two airport databases
- documents migration, recovery and rollback procedures

## Why

The previous design could bypass SuperAdmin MFA, treated commits across independent databases as atomic, and applied a combined schema everywhere. These were release-blocking security, privacy and recoverability risks.

## Validation

- `73 passed, 1 skipped` in the complete local suite (the skip is the environment-gated PostgreSQL test)
- PostgreSQL 16 three-database integration: `1 passed`
- five supported legacy migration fixtures passed
- control and operational fresh migrations reached `20260726_09`
- final Docker image built successfully
- targeted correctness lint and compile checks passed
- `pip-audit`: no known vulnerabilities

No production deployment or production data change was performed.
