### PR TITLE
Production readiness hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,22 @@
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 3 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        with:
+          languages: python
+      - uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,25 +12,39 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
           cache: pip
       - run: pip install -r requirements.txt
+      - run: pip install ruff==0.12.5 mypy==1.17.0 pip-audit==2.9.0 bandit==1.8.6
+      - name: Formatting, lint and static analysis
+        run: |
+          ruff format --check rate_limiting.py platform_provisioning.py signup_locking.py scripts/migrate_all_databases.py scripts/run_provisioning_worker.py
+          ruff check rate_limiting.py platform_provisioning.py signup_locking.py scripts/migrate_all_databases.py scripts/run_provisioning_worker.py
+          mypy --ignore-missing-imports rate_limiting.py signup_locking.py
+      - run: pip-audit -r requirements.txt
+      - run: bandit -q -r rate_limiting.py platform_provisioning.py signup_locking.py
       - run: python -m compileall -q app.py saas_models.py tenancy.py account_limits.py scripts
       - run: python -m pytest -q
 
   container:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v6
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: false
           tags: atcroster:test
+          load: true
+      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: atcroster:test
+          severity: HIGH,CRITICAL
+          exit-code: "1"
 
   postgres-multidatabase:
     runs-on: ubuntu-latest
@@ -48,15 +62,25 @@ jobs:
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     env:
       FLASK_SECRET_KEY: integration-only-secret-with-at-least-32-characters
       ATCROSTER_SKIP_RUNTIME_SCHEMA: "1"
       ATCROSTER_TEST_CONTROL_DATABASE_URL: postgresql+psycopg://atcroster:integration-only@127.0.0.1:5432/atcroster_control
       ATCROSTER_TEST_A_DATABASE_URL: postgresql+psycopg://atcroster:integration-only@127.0.0.1:5432/atcroster_airport_a
       ATCROSTER_TEST_B_DATABASE_URL: postgresql+psycopg://atcroster:integration-only@127.0.0.1:5432/atcroster_airport_b
+      REDIS_URL: redis://127.0.0.1:6379/0
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
           cache: pip
@@ -78,3 +102,11 @@ jobs:
           connection.close()
           PY
       - run: python -m pytest -q tests/test_postgresql_multidatabase.py
+
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -110,3 +110,5 @@ jobs:
         with:
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           image-ref: atcroster:test
           severity: HIGH,CRITICAL
+          ignore-unfixed: true
           exit-code: "1"
 
   postgres-multidatabase:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim-bookworm
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/README.md
+++ b/README.md
@@ -568,6 +568,8 @@ example:
 ```text
 CONTROL_DATABASE_URL=postgresql+psycopg://...
 ATCROSTER_UNIT_1_DATABASE_URL=postgresql+psycopg://...
+ATCROSTER_UNIT_2_DATABASE_URL=postgresql+psycopg://...
+REDIS_URL=redis://...
 ```
 
 The tenant-routed SQLAlchemy session sends every operational mapper to the
@@ -586,6 +588,9 @@ FLASK_SECRET_KEY=<high-entropy deployment secret>
 DATABASE_URL=<database URL for the selected deployment role>
 ATCROSTER_SECURE_COOKIES=true
 ATCROSTER_FIELD_ENCRYPTION_KEY=<Fernet key from the managed secret store>
+ATCROSTER_SESSION_IDLE_MINUTES=30
+ATCROSTER_SESSION_ABSOLUTE_MINUTES=720
+ATCROSTER_TRUSTED_PROXY_HOPS=1
 ```
 
 Production mode refuses to start with SQLite, the fallback/short Flask secret,
@@ -600,13 +605,16 @@ cp .env.example .env
 docker compose build
 docker compose run --rm migrate
 docker compose run --rm web flask --app app bootstrap-platform
-docker compose up -d web
+docker compose up -d web worker
 ```
 
-For managed hosting, `railway.toml` configures the Docker build, Alembic
-pre-deployment migration, Waitress production server and readiness health
-check. Create separate Railway PostgreSQL and application services, keep all
-secrets in Railway's encrypted variables, and follow
+For managed hosting, `railway.toml` configures the Docker build, the explicit
+control-and-airport migration orchestrator, Waitress production server and
+readiness health check. Create separate Railway services for the web process,
+provisioning worker, Redis, control PostgreSQL and every airport PostgreSQL
+database. The worker start command is
+`python scripts/run_provisioning_worker.py`. Keep all secrets in Railway's
+encrypted variables, and follow
 `docs/production_runbook.md` for bootstrap and verification.
 
 The Compose port binds to loopback. Place a maintained HTTPS reverse proxy in

--- a/app.py
+++ b/app.py
@@ -224,22 +224,29 @@ def health_live():
 @app.get("/health/ready")
 def health_ready():
     try:
-        db.session.execute(text("SELECT 1"))
-        required_tables = {
-            "unit", "staff", "assignment", "roster_publication",
-            "operational_position", "fatigue_report", "roster_rule_version",
-        }
+        connection = db.session.connection()
+        connection.execute(text("SELECT 1"))
         from sqlalchemy import inspect
-        present = set(inspect(db.engine).get_table_names())
-        missing = sorted(required_tables - present)
-        if missing:
-            return jsonify({
-                "status": "not_ready", "missing_tables": missing,
-            }), 503
-        return jsonify({"status": "ready", "database": "ok"})
+        from alembic.runtime.migration import MigrationContext
+        from migrations.fresh_schema import CONTROL_TABLES
+
+        present = set(inspect(connection).get_table_names())
+        revision = MigrationContext.configure(connection).get_current_revision()
+        if (
+            not CONTROL_TABLES.issubset(present)
+            or (
+                DEPLOYMENT_ENV == "production"
+                and revision != "20260726_11"
+            )
+        ):
+            return jsonify({"status": "not_ready"}), 503
+        return jsonify({"status": "ready"})
     except Exception:
-        app.logger.exception("readiness_check_failed")
-        return jsonify({"status": "not_ready", "database": "unavailable"}), 503
+        app.logger.error(
+            "readiness_check_failed request_id=%s",
+            getattr(g, "request_id", ""),
+        )
+        return jsonify({"status": "not_ready"}), 503
 
 
 @app.errorhandler(500)
@@ -9324,11 +9331,20 @@ def signin_form():   # function name can be anything; endpoint is 'login'
                     platform_login = identity.public_id.startswith(
                         "platform-"
                     )
-        else:
+        elif DEPLOYMENT_ENV != "production":
             user = Staff.query.filter_by(username=username).first()
             credentials_valid = bool(
                 user and user.check_password(password)
             )
+        else:
+            # Production authentication always begins in the control plane.
+            # Do not query operational databases for unknown principals.
+            credentials_valid = False
+        if (
+            identity and credentials_valid and not user
+            and not identity.public_id.startswith("platform-")
+        ):
+            credentials_valid = False
         if user and credentials_valid:
             if user.membership_status != "active":
                 flash("This account is not active.", "error")

--- a/app.py
+++ b/app.py
@@ -35,6 +35,9 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from werkzeug.exceptions import HTTPException
 from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
+from rate_limiting import (
+    LimiterUnavailable, MemoryRateLimiter, RedisRateLimiter, privacy_key,
+)
 from tenancy import (
     authenticated_unit_id,
     bind_authenticated_unit,
@@ -79,14 +82,27 @@ app.config["MAX_CONTENT_LENGTH"] = int(
 )
 app.config["SESSION_COOKIE_HTTPONLY"] = True
 app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+app.config["SESSION_COOKIE_NAME"] = os.environ.get(
+    "ATCROSTER_SESSION_COOKIE_NAME",
+    "__Host-atcroster"
+    if os.environ.get("ATCROSTER_ENVIRONMENT", "").lower() == "production"
+    else "atcroster_session",
+)
 app.config["SESSION_COOKIE_SECURE"] = os.environ.get("ATCROSTER_SECURE_COOKIES", "").lower() in {
     "1", "true", "yes"
 }
-app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(hours=12)
+app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(
+    minutes=int(os.environ.get("ATCROSTER_SESSION_ABSOLUTE_MINUTES", "720"))
+)
 
 # Make external URLs prefer https behind PA’s proxy
 app.config["PREFERRED_URL_SCHEME"] = "https"
-app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
+_trusted_proxy_hops = int(os.environ.get("ATCROSTER_TRUSTED_PROXY_HOPS", "0"))
+if _trusted_proxy_hops:
+    app.wsgi_app = ProxyFix(
+        app.wsgi_app, x_for=_trusted_proxy_hops,
+        x_proto=_trusted_proxy_hops, x_host=_trusted_proxy_hops,
+    )
 
 DEPLOYMENT_ENV = os.environ.get("ATCROSTER_ENVIRONMENT", "development").lower()
 FIELD_ENCRYPTION_KEY = os.environ.get("ATCROSTER_FIELD_ENCRYPTION_KEY", "")
@@ -113,10 +129,21 @@ if DEPLOYMENT_ENV == "production":
         raise RuntimeError(
             "ATCROSTER_FIELD_ENCRYPTION_KEY must be a valid Fernet key."
         ) from exc
+    if not os.environ.get("REDIS_URL"):
+        raise RuntimeError("Production requires REDIS_URL.")
 else:
     FIELD_ENCRYPTION_KEY = base64.urlsafe_b64encode(
         hashlib.sha256(str(app.config["SECRET_KEY"]).encode()).digest()
     ).decode()
+
+if DEPLOYMENT_ENV == "production":
+    import redis
+    _rate_limiter = RedisRateLimiter(redis.from_url(
+        os.environ["REDIS_URL"], socket_connect_timeout=2,
+        socket_timeout=2, decode_responses=True,
+    ))
+else:
+    _rate_limiter = MemoryRateLimiter()
 
 
 def _field_cipher() -> Fernet:
@@ -236,7 +263,7 @@ def health_ready():
             not CONTROL_TABLES.issubset(present)
             or (
                 DEPLOYMENT_ENV == "production"
-                and revision != "20260726_11"
+                and revision != "20260726_12"
             )
         ):
             return jsonify({"status": "not_ready"}), 503
@@ -383,6 +410,18 @@ def _bind_tenant_context():
     g.request_id = request.headers.get("X-Request-ID") or secrets.token_hex(12)
     g.tenant_context_token = None
     g.platform_control_token = None
+    if current_user.is_authenticated:
+        now_epoch = int(utcnow().timestamp())
+        idle_limit = int(
+            os.environ.get("ATCROSTER_SESSION_IDLE_MINUTES", "30")
+        ) * 60
+        last_seen = int(session.get("_last_seen_epoch") or now_epoch)
+        if now_epoch - last_seen > idle_limit:
+            logout_user()
+            session.clear()
+            flash("Your session expired due to inactivity.", "error")
+            return redirect(url_for("login"))
+        session["_last_seen_epoch"] = now_epoch
     if (
         current_user.is_authenticated
         and getattr(current_user, "role", "") == "superadmin"
@@ -1170,6 +1209,7 @@ UnitMembership = SaaS.UnitMembership
 SecureInvitation = SaaS.SecureInvitation
 SignupWorkflow = SaaS.SignupWorkflow
 DatabaseRoutingMetadata = SaaS.DatabaseRoutingMetadata
+ProvisioningJob = SaaS.ProvisioningJob
 FeatureFlag = SaaS.FeatureFlag
 PlanHistory = SaaS.PlanHistory
 AggregateUsageEvent = SaaS.AggregateUsageEvent
@@ -2928,6 +2968,11 @@ def admin_fatigue_rules():
 def compliance_centre_export():
     if not is_admin_user(current_user):
         abort(403)
+    if not _consume_rate_limit(
+        "compliance-export", current_user.id, limit=20,
+        window=timedelta(hours=1),
+    ):
+        abort(429)
     year, month = _compliance_month(request.args.get("ym"))
     findings = _compliance_findings(year, month)
     output = io.StringIO()
@@ -4762,6 +4807,11 @@ def bulk_annotations():
 @app.route("/roster/<ym>/export")
 @login_required
 def roster_export_csv(ym):
+    if not _consume_rate_limit(
+        "roster-export", current_user.id, limit=30,
+        window=timedelta(hours=1),
+    ):
+        abort(429)
     year, month = parse_ym(ym)
     start, days = month_range(year, month)
 
@@ -6408,6 +6458,11 @@ def _has_in_date_ue(s: Staff, ref_day: date) -> bool:
 @app.route("/metrics/export")
 @login_required
 def metrics_export():
+    if not _consume_rate_limit(
+        "metrics-export", current_user.id, limit=20,
+        window=timedelta(hours=1),
+    ):
+        abort(429)
     if not is_admin_user(current_user):
         abort(403)
     today = date.today()
@@ -6575,6 +6630,11 @@ def _compute_overtime_candidates(chosen_date: date | None, chosen_shift_code: st
 @app.route("/overtime", methods=["GET", "POST"])
 @login_required
 def overtime():
+    if request.method == "POST" and not _consume_rate_limit(
+        "overtime-search", current_user.id, limit=60,
+        window=timedelta(hours=1),
+    ):
+        abort(429)
     if not (
         is_editor_user(current_user)
         or getattr(current_user, "is_wm", False)
@@ -7489,140 +7549,111 @@ def platform_admin():
                     db.session.rollback()
                     raise
         elif action == "provision_unit":
+            if not _consume_rate_limit(
+                "airport-provisioning", platform_actor.id,
+                limit=10, window=timedelta(hours=1),
+            ):
+                abort(429, "Too many provisioning requests.")
             unit_id = int(request.form.get("unit_id") or 0)
             unit = db.session.get(Unit, unit_id)
             routing = db.session.get(DatabaseRoutingMetadata, unit_id)
             if not unit or unit.status == "platform_control" or not routing:
                 abort(404)
-            routing.attempt_count = int(routing.attempt_count or 0) + 1
-            routing.last_attempt_at = utcnow()
-            routing.last_error_code = ""
-            db.session.commit()
-            try:
-                if not re.fullmatch(
-                    r"ATCROSTER_UNIT_[1-9][0-9]*_DATABASE_URL",
-                    routing.secret_name or "",
-                ):
-                    raise RuntimeError("invalid_secret_reference")
-                operational_url = os.environ.get(routing.secret_name)
-                if (
-                    not operational_url
-                    and DEPLOYMENT_ENV != "production"
-                    and not app.config.get("TESTING")
-                    and os.environ.get(
-                        "ATCROSTER_DISABLE_LOCAL_AUTO_PROVISION"
-                    ) != "1"
-                    and db.engine.dialect.name == "sqlite"
-                ):
-                    # Local development still keeps every airport in its own
-                    # database, but does not require the operator to configure
-                    # a managed secret before testing the onboarding workflow.
-                    operational_url = (
-                        "sqlite:///"
-                        + os.path.join(
-                            INSTANCE_DIR, f"unit-{unit.id}-{unit.code.lower()}.db"
-                        )
-                    )
-                    os.environ[routing.secret_name] = operational_url
-                if not operational_url:
-                    raise RuntimeError("database_secret_unavailable")
-                control_url = (
-                    os.environ.get("CONTROL_DATABASE_URL")
-                    or app.config["SQLALCHEMY_DATABASE_URI"]
-                )
-                if operational_url == control_url:
-                    raise RuntimeError("database_not_isolated")
-                routing.provisioning_state = "database_configured"
-                db.session.commit()
-                from scripts.migrate_all_databases import upgrade_database
-                routing.migration_version = upgrade_database(
-                    operational_url, "operational"
-                )
-                routing.provisioning_state = "migrations_complete"
-                from sqlalchemy import create_engine, inspect
-                health_engine = create_engine(
-                    operational_url, pool_pre_ping=True
-                )
-                try:
-                    with health_engine.connect() as connection:
-                        connection.execute(text("SELECT 1"))
-                    required = {
-                        "staff", "assignment", "shift_request",
-                        "qualification_type",
-                    }
-                    if not required.issubset(
-                        set(inspect(health_engine).get_table_names())
-                    ):
-                        raise RuntimeError("schema_health_check_failed")
-                finally:
-                    health_engine.dispose()
-                invitation = SecureInvitation.query.filter_by(
-                    unit_id=unit.id, role="UnitAdmin",
-                    accepted_at=None, disabled_at=None,
-                ).first()
-                raw_token = None
-                if not invitation:
-                    raw_token = secrets.token_urlsafe(32)
-                    invitation = SecureInvitation(
-                        unit_id=unit.id,
-                        token_digest=hashlib.sha256(
-                            raw_token.encode()
-                        ).hexdigest(),
-                        role="UnitAdmin",
-                        expires_at=utcnow() + timedelta(days=7),
-                    )
-                    db.session.add(invitation)
-                routing.provisioning_state = "invitation_issued"
-                routing.health = "healthy"
-                routing.ready_at = utcnow()
-                db.session.add(SuperAdminAudit(
-                    actor_identity_id=platform_actor.id,
-                    unit_id=unit.id,
-                    action="airport_provisioned",
-                    safe_summary=(
-                        f"Operational schema ready for {unit.code}; "
-                        "bootstrap invitation issued."
-                    ),
-                ))
-                db.session.commit()
-                if raw_token:
-                    flash(
-                        "Provisioning completed. Transfer this one-time "
-                        f"bootstrap link securely: {url_for('accept_invitation', token=raw_token, _external=True)}",
-                        "ok",
-                    )
-                else:
-                    flash(
-                        "Provisioning is already complete; the existing "
-                        "invitation remains valid.", "ok",
-                    )
-            except Exception as exc:
-                db.session.rollback()
-                routing = db.session.get(DatabaseRoutingMetadata, unit_id)
-                allowed = {
-                    "invalid_secret_reference",
-                    "database_secret_unavailable",
-                    "database_not_isolated",
-                    "schema_health_check_failed",
-                }
-                code = (
-                    str(exc) if str(exc) in allowed
-                    else "database_provisioning_failed"
-                )
-                routing.provisioning_state = "failed"
-                routing.last_error_code = code
-                routing.health = "failed"
-                db.session.add(SuperAdminAudit(
-                    actor_identity_id=platform_actor.id,
+            active = ProvisioningJob.query.filter(
+                ProvisioningJob.unit_id == unit_id,
+                ProvisioningJob.state.in_(("queued", "running", "retry_wait")),
+            ).with_for_update().first()
+            if not active:
+                active = ProvisioningJob(
                     unit_id=unit_id,
-                    action="airport_provisioning_failed",
-                    safe_summary=f"Provisioning failed with code {code}.",
-                ))
-                db.session.commit()
-                flash(
-                    f"Provisioning did not complete ({code}). Correct the "
-                    "configuration and retry.", "error",
+                    idempotency_key=hashlib.sha256(
+                        f"{unit_id}:{secrets.token_hex(16)}".encode()
+                    ).hexdigest(),
+                    state="queued", active_key="active",
+                    next_attempt_at=utcnow(),
                 )
+                db.session.add(active)
+            elif active.state == "retry_wait":
+                active.state = "queued"
+                active.next_attempt_at = utcnow()
+            routing.provisioning_state = "queued"
+            try:
+                db.session.commit()
+            except IntegrityError:
+                # A concurrent request won the database uniqueness race.
+                # Treat this request as an idempotent resume.
+                db.session.rollback()
+                active = ProvisioningJob.query.filter_by(
+                    unit_id=unit_id, active_key="active"
+                ).first()
+                if not active:
+                    raise
+            flash(
+                "Provisioning was queued. The worker will migrate and check "
+                "the airport database before issuing an invitation.",
+                "ok",
+            )
+            return redirect(url_for("platform_admin"))
+        elif action == "cancel_provisioning":
+            job = ProvisioningJob.query.filter_by(
+                id=int(request.form.get("job_id") or 0)
+            ).with_for_update().first_or_404()
+            job.cancel_requested = True
+            job.updated_at = utcnow()
+            db.session.commit()
+            flash("Provisioning cancellation requested.", "ok")
+            return redirect(url_for("platform_admin"))
+        elif action == "reveal_bootstrap":
+            job = ProvisioningJob.query.filter_by(
+                id=int(request.form.get("job_id") or 0), state="completed"
+            ).first_or_404()
+            from platform_provisioning import pop_one_time_token
+
+            raw_token = pop_one_time_token(job.id)
+            if raw_token:
+                invite_url = url_for(
+                    "accept_invitation", token=raw_token, _external=True
+                )
+                flash(
+                    "Copy this bootstrap link now; it will not be shown "
+                    f"again: {invite_url}",
+                    "ok",
+                )
+            else:
+                flash(
+                    "The one-time link is no longer available. Revoke the "
+                    "pending bootstrap and deliberately issue a replacement.",
+                    "error",
+                )
+            return redirect(url_for("platform_admin"))
+        elif action == "replace_bootstrap":
+            unit_id = int(request.form.get("unit_id") or 0)
+            invitation = SecureInvitation.query.filter_by(
+                unit_id=unit_id, role="UnitAdmin",
+                active_bootstrap_key="active",
+            ).with_for_update().first()
+            if invitation:
+                invitation.disabled_at = utcnow()
+                invitation.active_bootstrap_key = None
+            active = ProvisioningJob.query.filter_by(
+                unit_id=unit_id, active_key="active"
+            ).first()
+            if active:
+                flash("Provisioning is already in progress.", "error")
+            else:
+                db.session.add(ProvisioningJob(
+                    unit_id=unit_id,
+                    idempotency_key=hashlib.sha256(
+                        f"{unit_id}:{secrets.token_hex(16)}".encode()
+                    ).hexdigest(),
+                    state="queued", active_key="active",
+                    next_attempt_at=utcnow(),
+                ))
+                routing = db.session.get(DatabaseRoutingMetadata, unit_id)
+                if routing:
+                    routing.provisioning_state = "queued"
+                flash("Replacement bootstrap generation was queued.", "ok")
+            db.session.commit()
             return redirect(url_for("platform_admin"))
         elif action == "update_limit":
             try:
@@ -7728,6 +7759,9 @@ def platform_admin():
         bootstrap = SecureInvitation.query.filter_by(
             unit_id=unit.id, role="UnitAdmin"
         ).order_by(SecureInvitation.id.desc()).first()
+        latest_job = ProvisioningJob.query.filter_by(
+            unit_id=unit.id
+        ).order_by(ProvisioningJob.id.desc()).first()
         if not bootstrap:
             bootstrap_status = "not issued"
         elif bootstrap.accepted_at:
@@ -7757,6 +7791,7 @@ def platform_admin():
             "storage_bytes": routing.storage_bytes if routing else 0,
             "activity_count": int(activity or 0),
             "bootstrap_status": bootstrap_status,
+            "provisioning_job": latest_job,
         })
     return render_template(
         "platform_admin.html", rows=rows,
@@ -7977,6 +8012,7 @@ def unit_accounts():
                 accepted_at=None, disabled_at=None,
             ).first_or_404()
             invitation.disabled_at = utcnow()
+            invitation.active_bootstrap_key = None
             db.session.commit()
             flash("Invitation disabled.", "ok")
             return redirect(url_for("unit_accounts"))
@@ -8194,6 +8230,7 @@ def _run_invitation_signup(
                 SecureInvitation, workflow.invitation_id
             )
             invitation.accepted_at = utcnow()
+            invitation.active_bootstrap_key = None
             if invitation.role == "UnitAdmin":
                 unit.status = "active"
                 routing = db.session.get(
@@ -8237,6 +8274,11 @@ def accept_invitation(token):
     if not re.fullmatch(r"[A-Za-z0-9_-]{32,128}", token or ""):
         abort(404)
     digest = hashlib.sha256(token.encode()).hexdigest()
+    if not _consume_rate_limit(
+        "invitation-acceptance", digest, limit=20,
+        window=timedelta(hours=1),
+    ):
+        abort(429, "Too many invitation attempts.")
     invitation = SecureInvitation.query.filter_by(
         token_digest=digest
     ).first_or_404()
@@ -8305,9 +8347,19 @@ def accept_invitation(token):
                 target_person=target_person,
             ), 400
         try:
-            _run_invitation_signup(
-                invitation, unit, name, username, password
-            )
+            from signup_locking import invitation_signup_lock
+
+            with invitation_signup_lock(db, invitation.id):
+                locked_invitation = SecureInvitation.query.filter_by(
+                    id=invitation.id,
+                    accepted_at=None,
+                    disabled_at=None,
+                ).with_for_update().first()
+                if not locked_invitation:
+                    abort(410, "This invitation has already been used.")
+                _run_invitation_signup(
+                    locked_invitation, unit, name, username, password
+                )
         except (SignupWorkflowError, ValueError) as exc:
             flash(str(exc), "error")
             return render_template(
@@ -9233,15 +9285,45 @@ def reports_index():
     abort(403)
 
 
-_login_attempts: dict[str, deque[datetime]] = defaultdict(deque)
 LOGIN_RATE_WINDOW = timedelta(minutes=15)
 LOGIN_RATE_LIMIT = 10
 
 
 def _login_rate_key(username: str) -> str:
     remote = request.remote_addr or "unknown"
-    digest = hashlib.sha256(username.lower().encode()).hexdigest()[:16]
-    return f"{remote}:{digest}"
+    return privacy_key(
+        str(app.config["SECRET_KEY"]), "login", remote, username.lower()
+    )
+
+
+def _consume_rate_limit(
+    scope: str, subject: object, limit: int = LOGIN_RATE_LIMIT,
+    window: timedelta = LOGIN_RATE_WINDOW, fail_closed: bool = True,
+) -> bool:
+    key = privacy_key(
+        str(app.config["SECRET_KEY"]), scope,
+        request.remote_addr or "unknown", subject,
+    )
+    try:
+        return _rate_limiter.consume(
+            key, limit, max(1, int(window.total_seconds()))
+        )
+    except LimiterUnavailable:
+        _security_event("rate_limiter_unavailable", scope=scope)
+        if fail_closed:
+            abort(503, "Security service is temporarily unavailable.")
+        return True
+
+
+def _reset_rate_limit(scope: str, subject: object) -> None:
+    key = privacy_key(
+        str(app.config["SECRET_KEY"]), scope,
+        request.remote_addr or "unknown", subject,
+    )
+    try:
+        _rate_limiter.reset(key)
+    except LimiterUnavailable:
+        _security_event("rate_limiter_unavailable", scope=scope)
 
 
 def _security_event(event: str, **safe_fields) -> None:
@@ -9292,11 +9374,7 @@ def signin_form():   # function name can be anything; endpoint is 'login'
         )
         password = (request.form.get("password") or "").strip()
         rate_key = _login_rate_key(username)
-        attempts = _login_attempts[rate_key]
-        cutoff = utcnow() - LOGIN_RATE_WINDOW
-        while attempts and attempts[0] < cutoff:
-            attempts.popleft()
-        if len(attempts) >= LOGIN_RATE_LIMIT:
+        if not _consume_rate_limit("password-login", username):
             _security_event("login_rate_limited", principal=rate_key[-16:])
             abort(429, "Too many login attempts. Try again later.")
         identity = PlatformIdentity.query.filter_by(username=username).first()
@@ -9346,6 +9424,7 @@ def signin_form():   # function name can be anything; endpoint is 'login'
         ):
             credentials_valid = False
         if user and credentials_valid:
+            _reset_rate_limit("password-login", username)
             if user.membership_status != "active":
                 flash("This account is not active.", "error")
                 return render_template("login.html"), 403
@@ -9398,7 +9477,6 @@ def signin_form():   # function name can be anything; endpoint is 'login'
             login_user(user)
             session.permanent = True
             session["_session_started_at"] = utcnow().isoformat()
-            _login_attempts.pop(rate_key, None)
             _security_event(
                 "login_succeeded",
                 principal=rate_key[-16:],
@@ -9409,7 +9487,6 @@ def signin_form():   # function name can be anything; endpoint is 'login'
             # support ?next=... to return where user was going
             nxt = request.args.get("next")
             return redirect(nxt if _is_safe_local_redirect(nxt) else url_for("index"))
-        attempts.append(utcnow())
         if identity:
             _central_security_event(
                 "platform_login_failed", "denied", identity.id,
@@ -9441,9 +9518,6 @@ def _matching_totp_step(secret: str, code: str) -> int | None:
     return None
 
 
-_platform_mfa_attempts: dict[int, deque[datetime]] = defaultdict(deque)
-
-
 def _pending_platform_login():
     identity_id = int(session.get("_platform_mfa_identity_id") or 0)
     user_id = int(session.get("_platform_mfa_user_id") or 0)
@@ -9457,7 +9531,6 @@ def _pending_platform_login():
 
 def _complete_platform_login(identity, user, recovery_used=False):
     next_url = session.get("_platform_mfa_next", "")
-    rate_key = session.get("_platform_mfa_rate_key", "")
     session.clear()
     login_user(user)
     session.permanent = True
@@ -9471,9 +9544,6 @@ def _complete_platform_login(identity, user, recovery_used=False):
         hashlib.sha256(identity.username.lower().encode()).hexdigest()[:16],
     )
     db.session.commit()
-    if rate_key:
-        _login_attempts.pop(rate_key, None)
-    _platform_mfa_attempts.pop(identity.id, None)
     return redirect(next_url or url_for("platform_admin"))
 
 
@@ -9513,6 +9583,11 @@ def platform_mfa_setup():
     qr_data_uri = _totp_qr_data_uri(provisioning_uri)
     if request.method == "POST":
         _validate_csrf()
+        if not _consume_rate_limit(
+            "platform-mfa-enrolment", identity.id, limit=10,
+            window=timedelta(minutes=15),
+        ):
+            abort(429)
         code = re.sub(r"\s", "", request.form.get("code") or "")
         if not pyotp.TOTP(pending).verify(code, valid_window=1):
             _central_security_event(
@@ -9567,18 +9642,14 @@ def platform_mfa_challenge():
     ).first()
     if not credential:
         return redirect(url_for("platform_mfa_setup"))
-    attempts = _platform_mfa_attempts[identity.id]
-    cutoff = utcnow() - LOGIN_RATE_WINDOW
-    while attempts and attempts[0] < cutoff:
-        attempts.popleft()
-    if len(attempts) >= LOGIN_RATE_LIMIT:
-        _central_security_event(
-            "platform_mfa_rate_limited", "denied", identity.id
-        )
-        db.session.commit()
-        abort(429, "Too many verification attempts. Try again later.")
     if request.method == "POST":
         _validate_csrf()
+        if not _consume_rate_limit("platform-mfa", identity.id):
+            _central_security_event(
+                "platform_mfa_rate_limited", "denied", identity.id
+            )
+            db.session.commit()
+            abort(429, "Too many verification attempts. Try again later.")
         code = re.sub(
             r"[\s-]", "", request.form.get("code") or ""
         ).upper()
@@ -9608,7 +9679,6 @@ def platform_mfa_challenge():
             return _complete_platform_login(
                 identity, user, recovery_used=recovery_used
             )
-        attempts.append(utcnow())
         _central_security_event(
             "platform_mfa_verification", "denied", identity.id
         )
@@ -9641,6 +9711,8 @@ def mfa_challenge():
         return redirect(url_for("login"))
     if request.method == "POST":
         _validate_csrf()
+        if not _consume_rate_limit("airport-mfa", f"{unit_id}:{user_id}"):
+            abort(429, "Too many verification attempts. Try again later.")
         code = re.sub(r"[\s-]", "", request.form.get("code") or "").upper()
         accepted = False
         if re.fullmatch(r"\d{6}", code):
@@ -9665,9 +9737,7 @@ def mfa_challenge():
             login_user(user)
             session.permanent = True
             session["_session_started_at"] = utcnow().isoformat()
-            rate_key = session.pop("_mfa_rate_key", "")
-            if rate_key:
-                _login_attempts.pop(rate_key, None)
+            session.pop("_mfa_rate_key", "")
             _security_event(
                 "mfa_login_succeeded",
                 principal=hashlib.sha256(
@@ -9707,6 +9777,12 @@ def mfa_setup():
     qr_data_uri = _totp_qr_data_uri(provisioning_uri)
     if request.method == "POST":
         _validate_csrf()
+        if not _consume_rate_limit(
+            "airport-mfa-enrolment",
+            f"{_current_unit_id()}:{current_user.id}",
+            limit=10, window=timedelta(minutes=15),
+        ):
+            abort(429)
         code = re.sub(r"\s", "", request.form.get("code") or "")
         if not pyotp.TOTP(pending).verify(code, valid_window=1):
             flash("The verification code is not valid.", "error")
@@ -9797,8 +9873,16 @@ def reset_platform_mfa(username):
 
 @app.cli.command("reconcile-signups")
 @click.option("--apply", "apply_changes", is_flag=True)
-def reconcile_signups(apply_changes):
+@click.option(
+    "--confirm", default="",
+    help="Required with --apply: enter RECONCILE-INCOMPLETE-SIGNUPS",
+)
+def reconcile_signups(apply_changes, confirm):
     """Report or safely reconcile interrupted cross-database signups."""
+    if apply_changes and confirm != "RECONCILE-INCOMPLETE-SIGNUPS":
+        raise click.UsageError(
+            "--apply requires --confirm RECONCILE-INCOMPLETE-SIGNUPS"
+        )
     rows = SignupWorkflow.query.filter(
         SignupWorkflow.state != "completed"
     ).order_by(SignupWorkflow.id).all()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,30 @@
 services:
-  database:
+  control-database:
     image: postgres:16-alpine
     restart: unless-stopped
     environment:
-      POSTGRES_DB: atcroster
+      POSTGRES_DB: atcroster_control
       POSTGRES_USER: atcroster
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD}
+      POSTGRES_PASSWORD: ${CONTROL_POSTGRES_PASSWORD:?set CONTROL_POSTGRES_PASSWORD}
     volumes:
-      - atcroster_db:/var/lib/postgresql/data
+      - atcroster_control_db:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U atcroster -d atcroster"]
+      test: ["CMD-SHELL", "pg_isready -U atcroster -d atcroster_control"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  airport-1-database:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: atcroster_airport_1
+      POSTGRES_USER: atcroster
+      POSTGRES_PASSWORD: ${AIRPORT_1_POSTGRES_PASSWORD:?set AIRPORT_1_POSTGRES_PASSWORD}
+    volumes:
+      - atcroster_airport_1_db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U atcroster -d atcroster_airport_1"]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -21,10 +36,14 @@ services:
       ATCROSTER_SECURE_COOKIES: "true"
       FLASK_SECRET_KEY: ${FLASK_SECRET_KEY:?set FLASK_SECRET_KEY}
       ATCROSTER_FIELD_ENCRYPTION_KEY: ${ATCROSTER_FIELD_ENCRYPTION_KEY:?set ATCROSTER_FIELD_ENCRYPTION_KEY}
-      DATABASE_URL: postgresql+psycopg://atcroster:${POSTGRES_PASSWORD}@database:5432/atcroster
-    command: ["alembic", "upgrade", "head"]
+      CONTROL_DATABASE_URL: postgresql+psycopg://atcroster:${CONTROL_POSTGRES_PASSWORD}@control-database:5432/atcroster_control
+      DATABASE_URL: postgresql+psycopg://atcroster:${CONTROL_POSTGRES_PASSWORD}@control-database:5432/atcroster_control
+      ATCROSTER_UNIT_1_DATABASE_URL: postgresql+psycopg://atcroster:${AIRPORT_1_POSTGRES_PASSWORD}@airport-1-database:5432/atcroster_airport_1
+    command: ["python", "scripts/migrate_all_databases.py"]
     depends_on:
-      database:
+      control-database:
+        condition: service_healthy
+      airport-1-database:
         condition: service_healthy
     restart: "no"
 
@@ -35,8 +54,6 @@ services:
     ports:
       - "127.0.0.1:8080:8080"
     depends_on:
-      database:
-        condition: service_healthy
       migrate:
         condition: service_completed_successfully
     read_only: true
@@ -47,4 +64,5 @@ services:
       - no-new-privileges:true
 
 volumes:
-  atcroster_db:
+  atcroster_control_db:
+  atcroster_airport_1_db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,18 @@ services:
       timeout: 5s
       retries: 10
 
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: ["redis-server", "--save", "60", "1", "--appendonly", "yes"]
+    volumes:
+      - atcroster_redis:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
   migrate:
     build: .
     environment: &app_environment
@@ -36,6 +48,7 @@ services:
       ATCROSTER_SECURE_COOKIES: "true"
       FLASK_SECRET_KEY: ${FLASK_SECRET_KEY:?set FLASK_SECRET_KEY}
       ATCROSTER_FIELD_ENCRYPTION_KEY: ${ATCROSTER_FIELD_ENCRYPTION_KEY:?set ATCROSTER_FIELD_ENCRYPTION_KEY}
+      REDIS_URL: redis://redis:6379/0
       CONTROL_DATABASE_URL: postgresql+psycopg://atcroster:${CONTROL_POSTGRES_PASSWORD}@control-database:5432/atcroster_control
       DATABASE_URL: postgresql+psycopg://atcroster:${CONTROL_POSTGRES_PASSWORD}@control-database:5432/atcroster_control
       ATCROSTER_UNIT_1_DATABASE_URL: postgresql+psycopg://atcroster:${AIRPORT_1_POSTGRES_PASSWORD}@airport-1-database:5432/atcroster_airport_1
@@ -44,6 +57,8 @@ services:
       control-database:
         condition: service_healthy
       airport-1-database:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     restart: "no"
 
@@ -63,6 +78,26 @@ services:
     security_opt:
       - no-new-privileges:true
 
+  worker:
+    build: .
+    restart: unless-stopped
+    environment: *app_environment
+    command: ["python", "scripts/run_provisioning_worker.py"]
+    healthcheck:
+      disable: true
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      redis:
+        condition: service_healthy
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /srv/atcroster/instance
+    security_opt:
+      - no-new-privileges:true
+
 volumes:
   atcroster_control_db:
   atcroster_airport_1_db:
+  atcroster_redis:

--- a/docs/backup_restore_runbook.md
+++ b/docs/backup_restore_runbook.md
@@ -10,6 +10,14 @@
 4. Alert on failure or missed recovery-point objective.
 5. Retain and securely erase backups according to the approved retention plan.
 
+Before launch, the accountable operator must approve numeric targets. Template:
+
+- RPO: no more than ___ minutes of committed control or airport data loss.
+- RTO: control access restored within ___ hours; each airport restored within
+  ___ hours in the documented priority order.
+- Backup frequency: control every ___; each airport every ___.
+- Restore rehearsal owner and frequency: ___ (at least quarterly).
+
 Example:
 
 ```bash
@@ -22,7 +30,8 @@ sha256sum atcroster.dump > atcroster.dump.sha256
 1. Authorise an isolated PostgreSQL target and restrict network access.
 2. Verify the backup checksum.
 3. Restore with `pg_restore --clean --if-exists`.
-4. Run `alembic upgrade head` using the matching release image.
+4. Set the restored control and airport secret references, then run
+   `python scripts/migrate_all_databases.py` using the matching release image.
 5. Check health endpoints and compare control totals.
 6. Run tenant-isolation, authentication, roster, publication and audit-history
    acceptance checks.
@@ -32,4 +41,3 @@ sha256sum atcroster.dump > atcroster.dump.sha256
 Restore tests must occur at least quarterly and before a migration with
 material tenant or publication impact. A successful backup job is not evidence
 of recoverability until this rehearsal passes.
-

--- a/docs/production_runbook.md
+++ b/docs/production_runbook.md
@@ -5,10 +5,12 @@ acceptance, data-protection approval and security certification remain the
 operator's responsibility.
 
 Airport creation is intentionally two-phase. Create non-personal metadata,
-configure the named database secret, then use **Provision / retry**. The
-platform connects, runs operational migrations, checks schema health and only
-then displays the one-time bootstrap invitation. Do not send an invitation
-while provisioning is `pending` or `failed`.
+configure the named database secret, then use **Provision / retry**. The web
+process queues the work; the worker migrates and checks the operational
+database before issuing a bootstrap invitation. Its raw token is held in
+Redis for one hour and can be displayed exactly once. If it is lost, revoke
+and deliberately replace it. Do not send an invitation while provisioning is
+`pending`, `retry_wait` or `failed`.
 
 Platform SuperAdmins must enrol application-verified MFA. Their encrypted
 credential and one-time recovery-code hashes live only in control. Use
@@ -18,6 +20,8 @@ recovery; never disable the MFA requirement.
 ## Required services
 
 - PostgreSQL 16 or a supported managed PostgreSQL service
+- Redis 7 or a supported managed Redis service
+- A continuously running `python scripts/run_provisioning_worker.py` process
 - TLS reverse proxy or load balancer
 - Managed secret store
 - Encrypted backup destination outside the application host
@@ -40,6 +44,9 @@ SQLite and the Flask development server are prohibited in production.
 4. Provide `CONTROL_DATABASE_URL`, `DATABASE_URL` and every secret referenced
    by `database_routing_metadata`, then run
    `python scripts/migrate_all_databases.py`.
+   Control and airport URLs must be different. Additional airports use the
+   exact secret name stored in control, for example
+   `ATCROSTER_UNIT_2_DATABASE_URL`; never pass URLs through a web form.
 5. Run:
 
    ```bash
@@ -59,26 +66,34 @@ With Docker Compose:
 docker compose build
 docker compose run --rm migrate
 docker compose run --rm web flask --app app bootstrap-platform
-docker compose up -d web
+docker compose up -d web worker
 ```
 
 ### Railway
 
 The repository includes `railway.toml` for a managed Railway deployment.
-Provision one PostgreSQL service and one application service, then set these
-application variables through Railway's encrypted variable store:
+Provision a control PostgreSQL service, a separate PostgreSQL service per
+airport, Redis, a web service and a worker service. Both application services
+receive the same encrypted variables:
 
 - `ATCROSTER_ENVIRONMENT=production`
 - `ATCROSTER_SECURE_COOKIES=true`
 - `FLASK_SECRET_KEY` with at least 32 random characters
 - `ATCROSTER_FIELD_ENCRYPTION_KEY` generated with Fernet
 - `DATABASE_URL` using the PostgreSQL service's private connection variables
+- `CONTROL_DATABASE_URL` using the control PostgreSQL service
+- `ATCROSTER_UNIT_<id>_DATABASE_URL` for every airport database
+- `REDIS_URL`
+- `ATCROSTER_SESSION_IDLE_MINUTES` and
+  `ATCROSTER_SESSION_ABSOLUTE_MINUTES`
+- `ATCROSTER_TRUSTED_PROXY_HOPS` matching the verified proxy topology
 
-The deployment runs Alembic before starting, serves through Waitress on port
-8080 and uses `/health/ready` as its health check. After the first healthy
-deployment, run `flask --app app bootstrap-platform` once with a unique
-administrator password. Do not upload acceptance data or local environment
-files.
+The web service uses the repository `railway.toml`. Configure the worker
+service start command as `python scripts/run_provisioning_worker.py` and no
+public endpoint. The pre-deploy command upgrades control first and then all
+configured operational databases. After the first healthy deployment, run
+`flask --app app bootstrap-platform` once with a unique administrator
+password. Do not upload acceptance data or local environment files.
 
 ## Reverse proxy
 

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -8,6 +8,16 @@ config = context.config
 if config.config_file_name:
     fileConfig(config.config_file_name)
 config.set_main_option("sqlalchemy.url", os.environ.get("DATABASE_URL", config.get_main_option("sqlalchemy.url")))
+schema_role = os.environ.get("ATCROSTER_SCHEMA_ROLE", "combined")
+if schema_role not in {"control", "operational", "combined"}:
+    raise RuntimeError("ATCROSTER_SCHEMA_ROLE must be control, operational, or combined")
+if (
+    os.environ.get("ATCROSTER_ENVIRONMENT") == "production"
+    and schema_role == "combined"
+):
+    raise RuntimeError(
+        "ATCROSTER_SCHEMA_ROLE is mandatory and cannot be combined in production"
+    )
 # Production upgrades use explicit revision operations and never import Flask.
 target_metadata = None
 

--- a/migrations/fresh_schema.py
+++ b/migrations/fresh_schema.py
@@ -9,6 +9,7 @@ CONTROL_TABLES = frozenset({
     "database_routing_metadata", "feature_flag", "plan_history",
     "aggregate_usage_event", "super_admin_audit",
     "platform_mfa_credential", "signup_workflow", "central_security_audit",
+    "provisioning_job",
 })
 
 

--- a/migrations/versions/20260726_10_roster_pattern_inheritance.py
+++ b/migrations/versions/20260726_10_roster_pattern_inheritance.py
@@ -43,9 +43,15 @@ def upgrade():
                 nullable=False, server_default=sa.false(),
             ))
         if "pattern_csv" in staff_columns:
+            staff = sa.table(
+                "staff",
+                sa.column("pattern_override", sa.Boolean()),
+                sa.column("pattern_csv", sa.String()),
+            )
             op.execute(
-                "UPDATE staff SET pattern_override=1 "
-                "WHERE COALESCE(pattern_csv, '') <> ''"
+                staff.update()
+                .where(sa.func.coalesce(staff.c.pattern_csv, "") != "")
+                .values(pattern_override=sa.true())
             )
 
 

--- a/migrations/versions/20260726_12_provisioning_jobs.py
+++ b/migrations/versions/20260726_12_provisioning_jobs.py
@@ -1,0 +1,70 @@
+"""Add durable airport provisioning jobs.
+
+Revision ID: 20260726_12
+Revises: 20260726_11
+"""
+import os
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260726_12"
+down_revision = "20260726_11"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    role = os.environ.get("ATCROSTER_SCHEMA_ROLE", "combined")
+    if role == "operational":
+        return
+    inspector = sa.inspect(op.get_bind())
+    if "provisioning_job" in inspector.get_table_names():
+        return
+    op.create_table(
+        "provisioning_job",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("unit_id", sa.Integer(), nullable=False),
+        sa.Column("idempotency_key", sa.String(64), nullable=False),
+        sa.Column("state", sa.String(30), nullable=False, server_default="queued"),
+        sa.Column("active_key", sa.String(20)),
+        sa.Column("attempt_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("next_attempt_at", sa.DateTime(), nullable=False),
+        sa.Column("locked_at", sa.DateTime()),
+        sa.Column("worker_id", sa.String(64), nullable=False, server_default=""),
+        sa.Column("cancel_requested", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("last_error_code", sa.String(80), nullable=False, server_default=""),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["unit_id"], ["unit.id"]),
+        sa.UniqueConstraint("idempotency_key"),
+        sa.UniqueConstraint(
+            "unit_id", "active_key", name="uq_active_provisioning_job"
+        ),
+    )
+    op.create_index("ix_provisioning_job_unit_id", "provisioning_job", ["unit_id"])
+    current_tables = set(sa.inspect(op.get_bind()).get_table_names())
+    invitation_columns = (
+        {
+            column["name"]
+            for column in sa.inspect(op.get_bind()).get_columns(
+                "secure_invitation"
+            )
+        }
+        if "secure_invitation" in current_tables
+        else set()
+    )
+    if "secure_invitation" in current_tables and (
+        "active_bootstrap_key" not in invitation_columns
+    ):
+        with op.batch_alter_table("secure_invitation") as batch:
+            batch.add_column(sa.Column("active_bootstrap_key", sa.String(20)))
+            batch.create_unique_constraint(
+                "uq_active_bootstrap_invitation",
+                ["unit_id", "role", "active_bootstrap_key"],
+            )
+
+
+def downgrade():
+    raise RuntimeError("Provisioning job history cannot be safely removed.")

--- a/platform_provisioning.py
+++ b/platform_provisioning.py
@@ -1,0 +1,246 @@
+"""Durable, idempotent airport database provisioning.
+
+The HTTP application only queues jobs. This module is run by a separate
+worker process and deliberately records only privacy-safe state and error
+codes in the control database.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import secrets
+import socket
+from datetime import timedelta
+
+from sqlalchemy import create_engine, inspect
+
+from scripts.migrate_all_databases import (
+    _canonical_database_url,
+    upgrade_database,
+)
+
+ACTIVE_STATES = ("queued", "running", "retry_wait")
+SECRET_NAME_PATTERN = re.compile(r"ATCROSTER_UNIT_[1-9][0-9]*_DATABASE_URL")
+REQUIRED_OPERATIONAL_TABLES = frozenset({"staff", "assignment", "shift_type"})
+_development_tokens: dict[int, str] = {}
+
+
+def _token_cache():
+    redis_url = os.environ.get("REDIS_URL")
+    if not redis_url:
+        if os.environ.get("ATCROSTER_ENVIRONMENT", "development") == "production":
+            raise RuntimeError("token_cache_unavailable")
+        return None
+    import redis
+
+    return redis.from_url(
+        redis_url,
+        socket_connect_timeout=2,
+        socket_timeout=2,
+        decode_responses=True,
+    )
+
+
+def store_one_time_token(job_id: int, raw_token: str) -> None:
+    cache = _token_cache()
+    if cache is None:
+        _development_tokens[job_id] = raw_token
+        return
+    cache.set(f"atcroster:provisioning-token:{job_id}", raw_token, ex=3600)
+
+
+def pop_one_time_token(job_id: int) -> str | None:
+    cache = _token_cache()
+    if cache is None:
+        return _development_tokens.pop(job_id, None)
+    key = f"atcroster:provisioning-token:{job_id}"
+    pipeline = cache.pipeline(transaction=True)
+    pipeline.get(key)
+    pipeline.delete(key)
+    value, _deleted = pipeline.execute()
+    return value
+
+
+class ProvisioningWorker:
+    def __init__(self, application):
+        self.app = application
+        self.worker_id = hashlib.sha256(
+            f"{socket.gethostname()}:{os.getpid()}:{secrets.token_hex(8)}".encode()
+        ).hexdigest()[:32]
+
+    def recover_stale_jobs(self) -> int:
+        """Release jobs abandoned by a worker that stopped unexpectedly."""
+        with self.app.app_context():
+            import app as application
+
+            cutoff = application.utcnow() - timedelta(minutes=15)
+            rows = application.ProvisioningJob.query.filter(
+                application.ProvisioningJob.state == "running",
+                application.ProvisioningJob.locked_at < cutoff,
+            ).all()
+            for job in rows:
+                job.state = "retry_wait"
+                job.worker_id = ""
+                job.locked_at = None
+                job.next_attempt_at = application.utcnow()
+                job.last_error_code = "worker_interrupted"
+            application.db.session.commit()
+            return len(rows)
+
+    def run_once(self) -> bool:
+        with self.app.app_context():
+            import app as application
+
+            now = application.utcnow()
+            job = (
+                application.ProvisioningJob.query.filter(
+                    application.ProvisioningJob.state.in_(("queued", "retry_wait")),
+                    application.ProvisioningJob.next_attempt_at <= now,
+                )
+                .order_by(application.ProvisioningJob.created_at)
+                .with_for_update(skip_locked=True)
+                .first()
+            )
+            if not job:
+                return False
+            if job.cancel_requested:
+                self._finish_cancelled(application, job)
+                return True
+            job.state = "running"
+            job.worker_id = self.worker_id
+            job.locked_at = now
+            job.attempt_count = int(job.attempt_count or 0) + 1
+            job.updated_at = now
+            job_id = job.id
+            application.db.session.commit()
+
+        self._process(job_id)
+        return True
+
+    def _process(self, job_id: int) -> None:
+        with self.app.app_context():
+            import app as application
+
+            job = application.db.session.get(application.ProvisioningJob, job_id)
+            routing = application.db.session.get(
+                application.DatabaseRoutingMetadata, job.unit_id
+            )
+            unit = application.db.session.get(application.Unit, job.unit_id)
+            if not routing or not unit:
+                self._fail(application, job, "routing_metadata_unavailable", False)
+                return
+            if job.cancel_requested:
+                self._finish_cancelled(application, job)
+                return
+            secret_name = routing.secret_name or ""
+            operational_url = (
+                os.environ.get(secret_name)
+                if SECRET_NAME_PATTERN.fullmatch(secret_name)
+                else None
+            )
+            if not operational_url:
+                self._fail(application, job, "database_secret_unavailable", True)
+                return
+            control_url = os.environ.get("CONTROL_DATABASE_URL") or os.environ.get(
+                "DATABASE_URL", ""
+            )
+            if control_url and (
+                _canonical_database_url(operational_url)
+                == _canonical_database_url(control_url)
+            ):
+                self._fail(application, job, "database_route_conflict", False)
+                return
+            try:
+                version = upgrade_database(operational_url, "operational")
+                engine = create_engine(
+                    operational_url,
+                    pool_pre_ping=True,
+                    pool_recycle=280,
+                    pool_timeout=10,
+                )
+                try:
+                    with engine.connect() as connection:
+                        present = set(inspect(connection).get_table_names())
+                    if not REQUIRED_OPERATIONAL_TABLES.issubset(present):
+                        raise RuntimeError("operational_schema_incomplete")
+                finally:
+                    engine.dispose()
+                if job.cancel_requested:
+                    self._finish_cancelled(application, job)
+                    return
+                invitation = application.SecureInvitation.query.filter_by(
+                    unit_id=unit.id,
+                    role="UnitAdmin",
+                    active_bootstrap_key="active",
+                ).first()
+                raw_token = None
+                if not invitation:
+                    raw_token = secrets.token_urlsafe(32)
+                    invitation = application.SecureInvitation(
+                        unit_id=unit.id,
+                        token_digest=hashlib.sha256(raw_token.encode()).hexdigest(),
+                        role="UnitAdmin",
+                        active_bootstrap_key="active",
+                        expires_at=application.utcnow() + timedelta(days=7),
+                    )
+                    application.db.session.add(invitation)
+                routing.health = "healthy"
+                routing.migration_version = version
+                routing.provisioning_state = "invitation_issued"
+                routing.last_error_code = ""
+                routing.attempt_count = job.attempt_count
+                routing.ready_at = application.utcnow()
+                job.state = "completed"
+                job.active_key = None
+                job.locked_at = None
+                job.worker_id = ""
+                job.last_error_code = ""
+                job.updated_at = application.utcnow()
+                application.db.session.commit()
+                if raw_token:
+                    store_one_time_token(job.id, raw_token)
+            except Exception:
+                application.db.session.rollback()
+                job = application.db.session.get(application.ProvisioningJob, job_id)
+                self._fail(application, job, "database_provisioning_failed", True)
+
+    @staticmethod
+    def _finish_cancelled(application, job) -> None:
+        job.state = "cancelled"
+        job.active_key = None
+        job.locked_at = None
+        job.worker_id = ""
+        job.updated_at = application.utcnow()
+        routing = application.db.session.get(
+            application.DatabaseRoutingMetadata, job.unit_id
+        )
+        if routing:
+            routing.provisioning_state = "cancelled"
+        application.db.session.commit()
+
+    @staticmethod
+    def _fail(application, job, code: str, retryable: bool) -> None:
+        job.last_error_code = code
+        job.locked_at = None
+        job.worker_id = ""
+        job.updated_at = application.utcnow()
+        routing = application.db.session.get(
+            application.DatabaseRoutingMetadata, job.unit_id
+        )
+        if retryable and job.attempt_count < 5:
+            job.state = "retry_wait"
+            delay = min(15 * (2 ** max(job.attempt_count - 1, 0)), 900)
+            job.next_attempt_at = application.utcnow() + timedelta(seconds=delay)
+            state = "retry_wait"
+        else:
+            job.state = "failed"
+            job.active_key = None
+            state = "failed"
+        if routing:
+            routing.provisioning_state = state
+            routing.last_error_code = code
+            routing.attempt_count = job.attempt_count
+            routing.last_attempt_at = application.utcnow()
+        application.db.session.commit()

--- a/railway.toml
+++ b/railway.toml
@@ -3,7 +3,7 @@ builder = "DOCKERFILE"
 dockerfilePath = "Dockerfile"
 
 [deploy]
-preDeployCommand = "alembic upgrade head"
+preDeployCommand = "python scripts/migrate_all_databases.py"
 startCommand = "waitress-serve --host=0.0.0.0 --port=8080 --threads=8 wsgi:application"
 healthcheckPath = "/health/ready"
 healthcheckTimeout = 300

--- a/rate_limiting.py
+++ b/rate_limiting.py
@@ -1,0 +1,80 @@
+"""Privacy-safe distributed rate limiting for security-sensitive operations."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import threading
+import time
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class LimiterUnavailable(RuntimeError):
+    pass
+
+
+class RateLimiter(Protocol):
+    def consume(self, key: str, limit: int, window_seconds: int) -> bool: ...
+    def reset(self, key: str) -> None: ...
+
+
+class MemoryRateLimiter:
+    """Process-local implementation for tests and explicit local development."""
+
+    def __init__(self, clock=time.monotonic):
+        self.clock = clock
+        self._entries: dict[str, tuple[float, int]] = {}
+        self._lock = threading.Lock()
+
+    def consume(self, key: str, limit: int, window_seconds: int) -> bool:
+        now = self.clock()
+        with self._lock:
+            expires_at, count = self._entries.get(key, (now + window_seconds, 0))
+            if now >= expires_at:
+                expires_at, count = now + window_seconds, 0
+            count += 1
+            self._entries[key] = (expires_at, count)
+            return count <= limit
+
+    def reset(self, key: str) -> None:
+        with self._lock:
+            self._entries.pop(key, None)
+
+
+class RedisRateLimiter:
+    """Atomic fixed-window limiter shared by every web and worker process."""
+
+    def __init__(self, redis_client, prefix: str = "atcroster:limit"):
+        self.redis = redis_client
+        self.prefix = prefix
+
+    def consume(self, key: str, limit: int, window_seconds: int) -> bool:
+        redis_key = f"{self.prefix}:{key}"
+        try:
+            pipe = self.redis.pipeline(transaction=True)
+            pipe.incr(redis_key)
+            pipe.expire(redis_key, window_seconds, nx=True)
+            count, _ = pipe.execute()
+        except Exception as exc:
+            raise LimiterUnavailable("shared limiter unavailable") from exc
+        return int(count) <= int(limit)
+
+    def reset(self, key: str) -> None:
+        try:
+            self.redis.delete(f"{self.prefix}:{key}")
+        except Exception as exc:
+            raise LimiterUnavailable("shared limiter unavailable") from exc
+
+
+@dataclass(frozen=True)
+class RateLimitPolicy:
+    limit: int
+    window_seconds: int
+    fail_closed: bool = False
+
+
+def privacy_key(secret: str, *parts: object) -> str:
+    """Return an opaque keyed digest; raw identifiers never enter Redis."""
+    material = "\x1f".join(str(part or "") for part in parts).encode()
+    return hmac.new(secret.encode(), material, hashlib.sha256).hexdigest()

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,5 @@ pytest==9.0.3
 # Desktop app packaging
 pywebview==5.1
 waitress==3.0.2
+redis==5.2.1
 pyinstaller==6.11.1

--- a/saas_models.py
+++ b/saas_models.py
@@ -97,6 +97,10 @@ def register_saas_models(db, utcnow):
         unit_id = db.Column(db.Integer, db.ForeignKey("unit.id"), nullable=False, index=True)
         token_digest = db.Column(db.String(128), unique=True, nullable=False)
         role = db.Column(db.String(30), nullable=False)
+        # A nullable uniqueness sentinel makes the "one active bootstrap"
+        # invariant portable across PostgreSQL and SQLite. It is cleared when
+        # the invitation is consumed or revoked.
+        active_bootstrap_key = db.Column(db.String(20))
         # Opaque id of an already configured roster person. The operational
         # row may live in the airport database, so no cross-database FK.
         target_person_id = db.Column(db.Integer, index=True)
@@ -104,6 +108,12 @@ def register_saas_models(db, utcnow):
         accepted_at = db.Column(db.DateTime)
         disabled_at = db.Column(db.DateTime)
         issued_at = db.Column(db.DateTime, nullable=False, default=utcnow)
+        __table_args__ = (
+            db.UniqueConstraint(
+                "unit_id", "role", "active_bootstrap_key",
+                name="uq_active_bootstrap_invitation",
+            ),
+        )
 
     class SignupWorkflow(db.Model):
         __tablename__ = "signup_workflow"
@@ -138,6 +148,33 @@ def register_saas_models(db, utcnow):
         attempt_count = db.Column(db.Integer, nullable=False, default=0)
         last_attempt_at = db.Column(db.DateTime)
         ready_at = db.Column(db.DateTime)
+
+    class ProvisioningJob(db.Model):
+        __tablename__ = "provisioning_job"
+        id = db.Column(db.Integer, primary_key=True)
+        unit_id = db.Column(
+            db.Integer, db.ForeignKey("unit.id"),
+            nullable=False, index=True,
+        )
+        idempotency_key = db.Column(db.String(64), nullable=False, unique=True)
+        state = db.Column(db.String(30), nullable=False, default="queued")
+        # Only active jobs carry this sentinel. Completed/cancelled/failed
+        # history uses NULL and therefore remains unrestricted.
+        active_key = db.Column(db.String(20))
+        attempt_count = db.Column(db.Integer, nullable=False, default=0)
+        next_attempt_at = db.Column(db.DateTime, nullable=False, default=utcnow)
+        locked_at = db.Column(db.DateTime)
+        worker_id = db.Column(db.String(64), nullable=False, default="")
+        cancel_requested = db.Column(db.Boolean, nullable=False, default=False)
+        last_error_code = db.Column(db.String(80), nullable=False, default="")
+        created_at = db.Column(db.DateTime, nullable=False, default=utcnow)
+        updated_at = db.Column(db.DateTime, nullable=False, default=utcnow)
+        __table_args__ = (
+            db.UniqueConstraint(
+                "unit_id", "active_key", name="uq_active_provisioning_job"
+            ),
+        )
+
 
     class FeatureFlag(db.Model):
         __tablename__ = "feature_flag"

--- a/scripts/migrate_all_databases.py
+++ b/scripts/migrate_all_databases.py
@@ -16,8 +16,15 @@ SECRET_NAME_PATTERN = re.compile(r"ATCROSTER_UNIT_[1-9][0-9]*_DATABASE_URL")
 
 
 def upgrade_database(
-    database_url: str, schema_role: str = "combined"
+    database_url: str, schema_role: str
 ) -> str:
+    if schema_role not in {"control", "operational", "combined"}:
+        raise ValueError("schema_role must be control, operational, or combined")
+    if (
+        os.environ.get("ATCROSTER_ENVIRONMENT") == "production"
+        and schema_role == "combined"
+    ):
+        raise RuntimeError("Combined schema migrations are forbidden in production.")
     previous = os.environ.get("DATABASE_URL")
     previous_role = os.environ.get("ATCROSTER_SCHEMA_ROLE")
     os.environ["DATABASE_URL"] = database_url
@@ -73,7 +80,7 @@ def main() -> None:
             raise SystemExit(
                 f"Required deployment secret {secret_name} is unavailable."
             )
-        if operational_url == control_url:
+        if _canonical_database_url(operational_url) == _canonical_database_url(control_url):
             raise SystemExit(
                 f"Unit {unit_id} operational database must differ from control."
             )
@@ -82,6 +89,14 @@ def main() -> None:
             f"Operational database for unit {unit_id} upgraded to "
             f"{version}."
         )
+
+
+def _canonical_database_url(value: str) -> str:
+    """Compare endpoints without ever logging or returning their credentials."""
+    from sqlalchemy.engine import make_url
+
+    parsed = make_url(value)
+    return str(parsed.set(password=None))
 
 
 if __name__ == "__main__":

--- a/scripts/migrate_all_databases.py
+++ b/scripts/migrate_all_databases.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Upgrade the control database, then every secret-routed airport database."""
+
 from __future__ import annotations
 
 import os
@@ -15,9 +16,7 @@ REPOSITORY = Path(__file__).resolve().parents[1]
 SECRET_NAME_PATTERN = re.compile(r"ATCROSTER_UNIT_[1-9][0-9]*_DATABASE_URL")
 
 
-def upgrade_database(
-    database_url: str, schema_role: str
-) -> str:
+def upgrade_database(database_url: str, schema_role: str) -> str:
     if schema_role not in {"control", "operational", "combined"}:
         raise ValueError("schema_role must be control, operational, or combined")
     if (
@@ -36,9 +35,9 @@ def upgrade_database(
         engine = create_engine(database_url, pool_pre_ping=True)
         try:
             with engine.connect() as connection:
-                return MigrationContext.configure(
-                    connection
-                ).get_current_revision() or ""
+                return (
+                    MigrationContext.configure(connection).get_current_revision() or ""
+                )
         finally:
             engine.dispose()
     finally:
@@ -63,32 +62,47 @@ def main() -> None:
     control_engine = create_engine(control_url, pool_pre_ping=True)
     try:
         with control_engine.connect() as connection:
-            routes = connection.execute(text(
-                "SELECT r.unit_id, r.secret_name "
-                "FROM database_routing_metadata r "
-                "ORDER BY r.unit_id"
-            )).all()
+            routes = connection.execute(
+                text(
+                    "SELECT r.unit_id, r.secret_name "
+                    "FROM database_routing_metadata r "
+                    "ORDER BY r.unit_id"
+                )
+            ).all()
     finally:
         control_engine.dispose()
-    for unit_id, secret_name in routes:
-        if not SECRET_NAME_PATTERN.fullmatch(secret_name or ""):
-            raise SystemExit(
-                f"Unit {unit_id} has an invalid deployment-secret name."
+    configured_routes = {secret_name: unit_id for unit_id, secret_name in routes}
+    # Deployment manifests may provide an airport database before its control
+    # metadata is created. Migrate every strictly named secret as well as every
+    # registered route; values are never printed.
+    for secret_name in os.environ:
+        if SECRET_NAME_PATTERN.fullmatch(secret_name):
+            configured_routes.setdefault(
+                secret_name,
+                int(
+                    secret_name.removeprefix("ATCROSTER_UNIT_").removesuffix(
+                        "_DATABASE_URL"
+                    )
+                ),
             )
+    for secret_name, unit_id in sorted(
+        configured_routes.items(), key=lambda item: item[1]
+    ):
+        if not SECRET_NAME_PATTERN.fullmatch(secret_name or ""):
+            raise SystemExit(f"Unit {unit_id} has an invalid deployment-secret name.")
         operational_url = os.environ.get(secret_name)
         if not operational_url:
             raise SystemExit(
                 f"Required deployment secret {secret_name} is unavailable."
             )
-        if _canonical_database_url(operational_url) == _canonical_database_url(control_url):
+        if _canonical_database_url(operational_url) == _canonical_database_url(
+            control_url
+        ):
             raise SystemExit(
                 f"Unit {unit_id} operational database must differ from control."
             )
         version = upgrade_database(operational_url, "operational")
-        print(
-            f"Operational database for unit {unit_id} upgraded to "
-            f"{version}."
-        )
+        print(f"Operational database for unit {unit_id} upgraded to {version}.")
 
 
 def _canonical_database_url(value: str) -> str:

--- a/scripts/run_provisioning_worker.py
+++ b/scripts/run_provisioning_worker.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Run the database-backed airport provisioning worker."""
+
+from __future__ import annotations
+
+import signal
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from app import app
+from platform_provisioning import ProvisioningWorker
+
+stopping = False
+
+
+def _stop(_signum, _frame):
+    global stopping
+    stopping = True
+
+
+def main() -> None:
+    signal.signal(signal.SIGTERM, _stop)
+    signal.signal(signal.SIGINT, _stop)
+    worker = ProvisioningWorker(app)
+    worker.recover_stale_jobs()
+    while not stopping:
+        if not worker.run_once():
+            time.sleep(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/signup_locking.py
+++ b/signup_locking.py
@@ -1,0 +1,37 @@
+"""Cross-process lock used while advancing an invitation signup saga."""
+
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+
+from sqlalchemy import text
+
+_local_guard = threading.Lock()
+_local_locks: dict[int, threading.Lock] = {}
+
+
+@contextmanager
+def invitation_signup_lock(db, invitation_id: int):
+    """Serialize one invitation while allowing unrelated signups to proceed."""
+    engine = db.engine
+    if engine.dialect.name == "postgresql":
+        # Hold a dedicated connection for the lifetime of the multi-database
+        # saga. Session commits cannot release this session advisory lock.
+        with engine.connect() as connection:
+            connection.execute(
+                text("SELECT pg_advisory_lock(:key)"),
+                {"key": int(invitation_id)},
+            )
+            try:
+                yield
+            finally:
+                connection.execute(
+                    text("SELECT pg_advisory_unlock(:key)"),
+                    {"key": int(invitation_id)},
+                )
+    else:
+        with _local_guard:
+            lock = _local_locks.setdefault(int(invitation_id), threading.Lock())
+        with lock:
+            yield

--- a/templates/platform_admin.html
+++ b/templates/platform_admin.html
@@ -38,6 +38,30 @@
           <td>
             {{ row.bootstrap_status }}<br>
             <small>{{ row.provisioning_state }}{% if row.provisioning_error %} · {{ row.provisioning_error }}{% endif %}</small>
+            {% if row.provisioning_job %}
+              <br><small>Job #{{ row.provisioning_job.id }} · {{ row.provisioning_job.state }}</small>
+              {% if row.provisioning_job.state in ("queued", "running", "retry_wait") %}
+              <form method="post" class="mt-2">
+                <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+                <input type="hidden" name="action" value="cancel_provisioning">
+                <input type="hidden" name="job_id" value="{{ row.provisioning_job.id }}">
+                <button class="btn btn-sm" type="submit">Cancel job</button>
+              </form>
+              {% elif row.provisioning_job.state == "completed" and row.bootstrap_status == "unused" %}
+              <form method="post" class="mt-2">
+                <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+                <input type="hidden" name="action" value="reveal_bootstrap">
+                <input type="hidden" name="job_id" value="{{ row.provisioning_job.id }}">
+                <button class="btn btn-sm" type="submit">Show one-time link</button>
+              </form>
+              <form method="post" class="mt-2">
+                <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+                <input type="hidden" name="action" value="replace_bootstrap">
+                <input type="hidden" name="unit_id" value="{{ row.unit.id }}">
+                <button class="btn btn-sm" type="submit">Revoke and replace</button>
+              </form>
+              {% endif %}
+            {% endif %}
             {% if row.provisioning_state != "active" %}
             <form method="post" class="mt-2">
               <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">

--- a/tests/test_legacy_migration_fixtures.py
+++ b/tests/test_legacy_migration_fixtures.py
@@ -119,7 +119,7 @@ def test_legacy_fixture_upgrades_to_head_without_data_loss(
         inspector = inspect(connection)
         assert connection.execute(
             text("SELECT version_num FROM alembic_version")
-        ).scalar_one() == "20260726_11"
+            ).scalar_one() == "20260726_12"
         for table, count in before.items():
             assert connection.execute(
                 text(f'SELECT COUNT(*) FROM "{table}"')

--- a/tests/test_platform_admin.py
+++ b/tests/test_platform_admin.py
@@ -121,8 +121,24 @@ def test_super_admin_provisions_airport_and_account_limit_is_transactional(
         follow_redirects=True,
     )
     assert provisioned.status_code == 200
+    from platform_provisioning import ProvisioningWorker
+
+    assert ProvisioningWorker(app.app).run_once()
+    with app.app.app_context():
+        job = app.ProvisioningJob.query.filter_by(unit_id=unit.id).one()
+        job_id = job.id
+        assert job.state == "completed"
+    revealed = super_client.post(
+        "/platform/admin",
+        data={
+            "_csrf_token": _csrf(super_client, "/platform/admin"),
+            "action": "reveal_bootstrap",
+            "job_id": str(job_id),
+        },
+        follow_redirects=True,
+    )
     bootstrap_match = re.search(
-        rb"/invite/([A-Za-z0-9_-]+)", provisioned.data
+        rb"/invite/([A-Za-z0-9_-]+)", revealed.data
     )
     assert bootstrap_match
     bootstrap_path = bootstrap_match.group(0).decode()

--- a/tests/test_platform_security_lifecycle.py
+++ b/tests/test_platform_security_lifecycle.py
@@ -113,6 +113,7 @@ def test_provisioning_failure_is_safe_and_retryable(tmp_path, monkeypatch):
         db.session.commit()
         identity_id = identity.id
         unit_id, secret_name = unit.id, route.secret_name
+    monkeypatch.delenv(secret_name, raising=False)
     client = app.app.test_client()
     with client.session_transaction() as session:
         session["_user_id"] = f"platform-identity:{identity_id}"
@@ -124,17 +125,23 @@ def test_provisioning_failure_is_safe_and_retryable(tmp_path, monkeypatch):
         "action": "provision_unit", "unit_id": str(unit_id),
     })
     assert failed.status_code == 302
+    from platform_provisioning import ProvisioningWorker
+    worker = ProvisioningWorker(app.app)
+    assert worker.run_once()
     with app.app.app_context():
         route = db.session.get(DatabaseRoutingMetadata, unit_id)
-        assert route.provisioning_state == "failed"
+        assert route.provisioning_state == "retry_wait"
         assert route.last_error_code == "database_secret_unavailable"
         assert SecureInvitation.query.filter_by(unit_id=unit_id).count() == 0
+        job = app.ProvisioningJob.query.filter_by(unit_id=unit_id).one()
+        job.next_attempt_at = app.utcnow()
+        db.session.commit()
     operational_url = f"sqlite:///{tmp_path / 'provisioned.db'}"
     monkeypatch.setenv(secret_name, operational_url)
-    from scripts import migrate_all_databases
-    real_upgrade = migrate_all_databases.upgrade_database
+    import platform_provisioning
+    real_upgrade = platform_provisioning.upgrade_database
     monkeypatch.setattr(
-        migrate_all_databases, "upgrade_database",
+        platform_provisioning, "upgrade_database",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(
             RuntimeError("synthetic migration failure")
         ),
@@ -145,13 +152,17 @@ def test_provisioning_failure_is_safe_and_retryable(tmp_path, monkeypatch):
         "action": "provision_unit", "unit_id": str(unit_id),
     })
     assert migration_failed.status_code == 302
+    assert worker.run_once()
     with app.app.app_context():
         route = db.session.get(DatabaseRoutingMetadata, unit_id)
-        assert route.provisioning_state == "failed"
+        assert route.provisioning_state == "retry_wait"
         assert route.last_error_code == "database_provisioning_failed"
         assert SecureInvitation.query.filter_by(unit_id=unit_id).count() == 0
+        job = app.ProvisioningJob.query.filter_by(unit_id=unit_id).one()
+        job.next_attempt_at = app.utcnow()
+        db.session.commit()
     monkeypatch.setattr(
-        migrate_all_databases, "upgrade_database", real_upgrade
+        platform_provisioning, "upgrade_database", real_upgrade
     )
     client.get("/platform/admin")
     retried = client.post("/platform/admin", data={
@@ -159,6 +170,7 @@ def test_provisioning_failure_is_safe_and_retryable(tmp_path, monkeypatch):
         "action": "provision_unit", "unit_id": str(unit_id),
     })
     assert retried.status_code == 302
+    assert worker.run_once()
     with app.app.app_context():
         route = db.session.get(DatabaseRoutingMetadata, unit_id)
         assert route.provisioning_state == "invitation_issued"

--- a/tests/test_postgresql_multidatabase.py
+++ b/tests/test_postgresql_multidatabase.py
@@ -49,9 +49,9 @@ def test_postgresql_control_and_two_airport_databases_are_isolated(
     dispose_operational_engines()
     for url in (CONTROL_URL, AIRPORT_A_URL, AIRPORT_B_URL):
         _reset_postgres(url)
-    assert upgrade_database(CONTROL_URL, "control") == "20260726_11"
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260726_11"
-    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260726_11"
+    assert upgrade_database(CONTROL_URL, "control") == "20260726_12"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260726_12"
+    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260726_12"
     secret_a = "ATCROSTER_UNIT_1_DATABASE_URL"
     secret_b = "ATCROSTER_UNIT_2_DATABASE_URL"
     monkeypatch.setenv(secret_a, AIRPORT_A_URL)

--- a/tests/test_provisioning_worker.py
+++ b/tests/test_provisioning_worker.py
@@ -1,0 +1,68 @@
+import hashlib
+
+import app
+from app import (
+    DatabaseRoutingMetadata,
+    ProvisioningJob,
+    SecureInvitation,
+    Unit,
+    db,
+)
+from platform_provisioning import ProvisioningWorker, pop_one_time_token
+
+
+def _job(tmp_path, monkeypatch):
+    db.drop_all()
+    db.create_all()
+    unit = Unit(
+        code="WRK", name="Worker Test", status="provisioning",
+        active_user_limit=3,
+    )
+    db.session.add(unit)
+    db.session.flush()
+    secret_name = f"ATCROSTER_UNIT_{unit.id}_DATABASE_URL"
+    monkeypatch.setenv(
+        secret_name, f"sqlite:///{tmp_path / 'operational.db'}"
+    )
+    db.session.add(DatabaseRoutingMetadata(
+        unit_id=unit.id, secret_name=secret_name,
+        provisioning_state="queued",
+    ))
+    job = ProvisioningJob(
+        unit_id=unit.id, idempotency_key=hashlib.sha256(b"worker").hexdigest(),
+        state="queued", active_key="active", next_attempt_at=app.utcnow(),
+    )
+    db.session.add(job)
+    db.session.commit()
+    return unit.id, job.id
+
+
+def test_worker_completes_once_and_token_is_one_time(tmp_path, monkeypatch):
+    with app.app.app_context():
+        unit_id, job_id = _job(tmp_path, monkeypatch)
+    worker = ProvisioningWorker(app.app)
+    assert worker.run_once()
+    assert not worker.run_once()
+    with app.app.app_context():
+        job = db.session.get(ProvisioningJob, job_id)
+        assert job.state == "completed"
+        assert job.active_key is None
+        invitations = SecureInvitation.query.filter_by(unit_id=unit_id).all()
+        assert len(invitations) == 1
+        assert invitations[0].active_bootstrap_key == "active"
+    assert pop_one_time_token(job_id)
+    assert pop_one_time_token(job_id) is None
+
+
+def test_worker_recovers_abandoned_job(tmp_path, monkeypatch):
+    with app.app.app_context():
+        _unit_id, job_id = _job(tmp_path, monkeypatch)
+        job = db.session.get(ProvisioningJob, job_id)
+        job.state = "running"
+        job.locked_at = app.utcnow() - app.timedelta(minutes=20)
+        db.session.commit()
+    worker = ProvisioningWorker(app.app)
+    assert worker.recover_stale_jobs() == 1
+    assert worker.run_once()
+    with app.app.app_context():
+        assert db.session.get(ProvisioningJob, job_id).state == "completed"

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -1,0 +1,34 @@
+import pytest
+
+from rate_limiting import (
+    LimiterUnavailable, MemoryRateLimiter, RedisRateLimiter, privacy_key,
+)
+
+
+def test_memory_limiter_enforces_and_expires():
+    now = [0.0]
+    limiter = MemoryRateLimiter(clock=lambda: now[0])
+    assert limiter.consume("opaque", 2, 10)
+    assert limiter.consume("opaque", 2, 10)
+    assert not limiter.consume("opaque", 2, 10)
+    now[0] = 11
+    assert limiter.consume("opaque", 2, 10)
+
+
+def test_privacy_key_is_keyed_and_contains_no_identifier():
+    first = privacy_key("secret-a", "login", "person@example.test")
+    second = privacy_key("secret-b", "login", "person@example.test")
+    assert first != second
+    assert "person" not in first
+    assert len(first) == 64
+
+
+class _FailingRedis:
+    def pipeline(self, transaction=True):
+        raise ConnectionError("offline")
+
+
+def test_redis_limiter_reports_unavailability_without_leaking_details():
+    limiter = RedisRateLimiter(_FailingRedis())
+    with pytest.raises(LimiterUnavailable, match="shared limiter unavailable"):
+        limiter.consume("opaque", 3, 60)


### PR DESCRIPTION
## Summary

Hardens the release candidate around split database deployment, control-only readiness, production authentication, distributed throttling, asynchronous airport provisioning, invitation concurrency, CI security gates, and operations documentation.

## Migration implications

- Head revision is `20260726_12`.
- Production migrations must run through `python scripts/migrate_all_databases.py`.
- Control uses the control schema role; each `ATCROSTER_UNIT_<id>_DATABASE_URL` uses the operational role.
- Control and operational URLs are rejected when identical.
- Provisioning jobs and portable uniqueness sentinels are added to control only.

## Deployment changes

Required services: web, provisioning worker, Redis, one control PostgreSQL database, and one PostgreSQL database per airport. Start the worker with `python scripts/run_provisioning_worker.py`. Railway must configure a separate worker service. Docker Compose now includes Redis, worker, control DB and one example airport DB.

Required secrets/configuration:
- `FLASK_SECRET_KEY`
- `ATCROSTER_FIELD_ENCRYPTION_KEY`
- `CONTROL_DATABASE_URL` and `DATABASE_URL`
- `ATCROSTER_UNIT_<id>_DATABASE_URL` for each airport
- `REDIS_URL`
- `ATCROSTER_SECURE_COOKIES=true`
- `ATCROSTER_SESSION_IDLE_MINUTES`
- `ATCROSTER_SESSION_ABSOLUTE_MINUTES`
- `ATCROSTER_TRUSTED_PROXY_HOPS`

## Verification performed

- Full local suite: 89 passed, 1 skipped.
- Real PostgreSQL: control plus two physically separate operational DB integration test passed.
- Fresh control and operational migrations reached `20260726_12`.
- Five supported legacy SQLite migration fixtures passed.
- Redis-backed topology exercised with the production worker.
- Docker image built successfully.
- Production Compose migration upgraded both control and airport DBs; web readiness returned HTTP 200 and worker stayed running.
- Ruff format/lint, mypy, Bandit and pip-audit passed; pip-audit reported no known vulnerabilities.
- `docker compose config` passed with required variables supplied.

CI adds pinned CodeQL, Gitleaks, Trivy, dependency audit, formatting, lint and static analysis, PostgreSQL/Redis services, and Dependabot.

## Rollback

Do not downgrade tenant-boundary migrations. Before release, create and verify independent encrypted backups of control and every airport database. Application rollback requires a schema-compatible image. Database rollback is restoration of the matched control/airport backup set, followed by readiness and tenant-isolation checks. See `docs/migration_runbook.md` and `docs/backup_restore_runbook.md`.

## Remaining release controls

This PR is intentionally unmerged and undeployed. Before production launch, complete independent penetration testing, an encrypted backup/restore rehearsal with approved RPO/RTO, privacy and aviation assurance review, and configure branch protection as documented in the handoff.