### PR TITLE
Fix post-hardening production regressions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
 ATCROSTER_ENVIRONMENT=production
 ATCROSTER_SECURE_COOKIES=true
 FLASK_SECRET_KEY=replace-with-at-least-32-random-characters
-ATCROSTER_FIELD_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
-POSTGRES_PASSWORD=replace-with-a-unique-database-password
-DATABASE_URL=postgresql+psycopg://atcroster:password@database:5432/atcroster
+ATCROSTER_FIELD_ENCRYPTION_KEYS=v1:replace-with-a-fernet-key
+ATCROSTER_TOKEN_ENCRYPTION_KEYS=v1:replace-with-a-different-fernet-key
+ATCROSTER_TRUSTED_HOSTS=localhost,127.0.0.1
+ATCROSTER_TRUSTED_PROXY_HOPS=0
+CONTROL_POSTGRES_PASSWORD=replace-with-a-unique-control-database-password
+AIRPORT_1_POSTGRES_PASSWORD=replace-with-a-unique-airport-database-password
+AIRPORT_2_POSTGRES_PASSWORD=replace-with-another-unique-airport-database-password
+DATABASE_URL=postgresql+psycopg://atcroster:password@control-database:5432/atcroster_control

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,48 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 6
+    groups:
+      production-runtime:
+        patterns:
+          - Flask*
+          - SQLAlchemy
+          - alembic
+          - psycopg*
+          - Werkzeug
+          - cryptography
+          - redis
+          - waitress
+      development-tools:
+        patterns:
+          - pytest
+          - ruff
+          - mypy
+          - bandit
+          - pip-audit
+      desktop-packaging:
+        patterns:
+          - pywebview
+          - pyinstaller
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: python
+        update-types:
+          - version-update:semver-major
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 3
+    groups:
+      codeql:
+        patterns:
+          - github/codeql-action/*
+      docker-build-actions:
+        patterns:
+          - docker/setup-buildx-action
+          - docker/build-push-action

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,8 +15,8 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: python
-      - uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -17,22 +17,27 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-      - run: pip install -r requirements.txt
-      - run: pip install ruff==0.12.5 mypy==1.17.0 pip-audit==2.9.0 bandit==1.8.6
+      - run: pip install -r requirements-dev.txt
       - name: Formatting, lint and static analysis
         run: |
           ruff format --check rate_limiting.py platform_provisioning.py signup_locking.py scripts/migrate_all_databases.py scripts/run_provisioning_worker.py
           ruff check rate_limiting.py platform_provisioning.py signup_locking.py scripts/migrate_all_databases.py scripts/run_provisioning_worker.py
           mypy --ignore-missing-imports rate_limiting.py signup_locking.py
-      - run: pip-audit -r requirements.txt
+      - run: pip-audit -r requirements-prod.txt
       - run: bandit -q -r rate_limiting.py platform_provisioning.py signup_locking.py
       - run: python -m compileall -q app.py saas_models.py tenancy.py account_limits.py scripts
       - run: python -m pytest -q
+      - name: Verify fresh split migrations
+        run: |
+          control_db="$(mktemp -u).db"
+          operational_db="$(mktemp -u).db"
+          ATCROSTER_SCHEMA_ROLE=control DATABASE_URL="sqlite:///$control_db" alembic upgrade head
+          ATCROSTER_SCHEMA_ROLE=operational DATABASE_URL="sqlite:///$operational_db" alembic upgrade head
 
   container:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
@@ -85,7 +90,7 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-      - run: pip install -r requirements.txt
+      - run: pip install -r requirements-dev.txt
       - name: Create isolated integration databases
         run: |
           python - <<'PY'
@@ -102,7 +107,7 @@ jobs:
               connection.execute(f'CREATE DATABASE "{name}"')
           connection.close()
           PY
-      - run: python -m pytest -q tests/test_postgresql_multidatabase.py
+      - run: python -m pytest -q tests/test_postgresql_multidatabase.py tests/test_redis_integration.py
 
   secret-scan:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim-bookworm
+FROM python:3.12-slim-bookworm@sha256:d50fb7611f86d04a3b0471b46d7557818d88983fc3136726336b2a4c657aa30b
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -8,8 +8,8 @@ WORKDIR /srv/atcroster
 
 RUN addgroup --system atcroster && adduser --system --ingroup atcroster atcroster
 
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+COPY requirements-prod.txt .
+RUN pip install --no-cache-dir -r requirements-prod.txt
 
 COPY . .
 RUN chown -R atcroster:atcroster /srv/atcroster

--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ testing is complete.
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements-dev.txt
 export FLASK_SECRET_KEY="$(python -c 'import secrets; print(secrets.token_hex(32))')"
 export DATABASE_URL="sqlite:///instance/roster.db"
 flask --app app.py run
@@ -549,6 +549,22 @@ flask --app app.py run
 
 The development server defaults to `127.0.0.1`. Never use the checked-in
 fallback secret in production.
+
+### Supported Python versions
+
+Python 3.12 is the production and CI runtime. A newer Python major version
+must not be adopted through an automated dependency update: it requires a
+dedicated compatibility pull request that builds the production image and
+passes the complete web, PostgreSQL, Redis, worker and desktop test matrix.
+
+Dependency surfaces are deliberately separate:
+
+- `requirements-prod.txt` — production web, database, security and worker;
+- `requirements-dev.txt` — production dependencies plus test/security tools;
+- `requirements-desktop.txt` — production dependencies plus desktop packaging;
+- `requirements.txt` — compatibility entry point containing all surfaces.
+
+Production containers install only `requirements-prod.txt`.
 
 ### PostgreSQL production
 
@@ -790,7 +806,7 @@ Before release also run:
 ```bash
 python -m compileall -q app.py tenancy.py saas_models.py account_limits.py scripts
 python scripts/scale_assurance.py
-pip-audit -r requirements.txt
+pip-audit -r requirements-prod.txt
 ```
 
 For production, add integration tests against PostgreSQL and the deployment’s
@@ -854,5 +870,5 @@ database.
 Activate the intended virtual environment and reinstall:
 
 ```bash
-python -m pip install -r requirements.txt
+python -m pip install -r requirements-dev.txt
 ```

--- a/app.py
+++ b/app.py
@@ -75,7 +75,20 @@ app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {
     "pool_recycle": 280,
     "pool_size": 5,
     "max_overflow": 5,
+    "pool_timeout": int(os.environ.get("ATCROSTER_DB_POOL_TIMEOUT_SECONDS", "10")),
 }
+if str(app.config["SQLALCHEMY_DATABASE_URI"]).startswith("postgresql"):
+    app.config["SQLALCHEMY_ENGINE_OPTIONS"]["connect_args"] = {
+        "connect_timeout": int(
+            os.environ.get("ATCROSTER_DB_CONNECT_TIMEOUT_SECONDS", "5")
+        ),
+        "options": (
+            "-c statement_timeout="
+            + str(int(os.environ.get(
+                "ATCROSTER_DB_STATEMENT_TIMEOUT_MS", "15000"
+            )))
+        ),
+    }
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 app.config["MAX_CONTENT_LENGTH"] = int(
     os.environ.get("ATCROSTER_MAX_REQUEST_BYTES", 2 * 1024 * 1024)
@@ -98,6 +111,8 @@ app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(
 # Make external URLs prefer https behind PA’s proxy
 app.config["PREFERRED_URL_SCHEME"] = "https"
 _trusted_proxy_hops = int(os.environ.get("ATCROSTER_TRUSTED_PROXY_HOPS", "0"))
+if not 0 <= _trusted_proxy_hops <= 3:
+    raise RuntimeError("ATCROSTER_TRUSTED_PROXY_HOPS must be between 0 and 3.")
 if _trusted_proxy_hops:
     app.wsgi_app = ProxyFix(
         app.wsgi_app, x_for=_trusted_proxy_hops,
@@ -106,7 +121,20 @@ if _trusted_proxy_hops:
 
 DEPLOYMENT_ENV = os.environ.get("ATCROSTER_ENVIRONMENT", "development").lower()
 FIELD_ENCRYPTION_KEY = os.environ.get("ATCROSTER_FIELD_ENCRYPTION_KEY", "")
+FIELD_ENCRYPTION_KEYS = os.environ.get("ATCROSTER_FIELD_ENCRYPTION_KEYS", "")
 if DEPLOYMENT_ENV == "production":
+    trusted_hosts = [
+        host.strip()
+        for host in os.environ.get("ATCROSTER_TRUSTED_HOSTS", "").split(",")
+        if host.strip()
+    ]
+    if not trusted_hosts:
+        raise RuntimeError("Production requires ATCROSTER_TRUSTED_HOSTS.")
+    app.config["TRUSTED_HOSTS"] = trusted_hosts
+    if "ATCROSTER_TRUSTED_PROXY_HOPS" not in os.environ:
+        raise RuntimeError(
+            "Production requires an explicit ATCROSTER_TRUSTED_PROXY_HOPS value."
+        )
     if app.config["SECRET_KEY"] == "fallback-change-me" or len(
         app.config["SECRET_KEY"]
     ) < 32:
@@ -119,25 +147,25 @@ if DEPLOYMENT_ENV == "production":
         raise RuntimeError(
             "Production requires ATCROSTER_SECURE_COOKIES=true."
         )
-    if not FIELD_ENCRYPTION_KEY:
+    if not FIELD_ENCRYPTION_KEY and not FIELD_ENCRYPTION_KEYS:
         raise RuntimeError(
-            "Production requires ATCROSTER_FIELD_ENCRYPTION_KEY."
+            "Production requires ATCROSTER_FIELD_ENCRYPTION_KEYS."
         )
-    try:
-        Fernet(FIELD_ENCRYPTION_KEY.encode())
-    except (ValueError, TypeError) as exc:
-        raise RuntimeError(
-            "ATCROSTER_FIELD_ENCRYPTION_KEY must be a valid Fernet key."
-        ) from exc
+    if not FIELD_ENCRYPTION_KEYS:
+        FIELD_ENCRYPTION_KEYS = f"legacy:{FIELD_ENCRYPTION_KEY}"
     if not os.environ.get("REDIS_URL"):
         raise RuntimeError("Production requires REDIS_URL.")
 else:
     FIELD_ENCRYPTION_KEY = base64.urlsafe_b64encode(
         hashlib.sha256(str(app.config["SECRET_KEY"]).encode()).digest()
     ).decode()
+    FIELD_ENCRYPTION_KEYS = f"dev:{FIELD_ENCRYPTION_KEY}"
 
 if DEPLOYMENT_ENV == "production":
     import redis
+    from platform_provisioning import validate_token_encryption_config
+
+    validate_token_encryption_config()
     _rate_limiter = RedisRateLimiter(redis.from_url(
         os.environ["REDIS_URL"], socket_connect_timeout=2,
         socket_timeout=2, decode_responses=True,
@@ -146,8 +174,46 @@ else:
     _rate_limiter = MemoryRateLimiter()
 
 
-def _field_cipher() -> Fernet:
-    return Fernet(FIELD_ENCRYPTION_KEY.encode())
+def _field_ciphers() -> list[tuple[str, Fernet]]:
+    result = []
+    for item in FIELD_ENCRYPTION_KEYS.split(","):
+        version, separator, key = item.strip().partition(":")
+        if not separator or not re.fullmatch(r"[A-Za-z0-9_-]{1,20}", version):
+            raise RuntimeError("Invalid field-encryption key version.")
+        try:
+            result.append((version, Fernet(key.encode())))
+        except (ValueError, TypeError) as exc:
+            raise RuntimeError("Invalid field-encryption key material.") from exc
+    if not result:
+        raise RuntimeError("At least one field-encryption key is required.")
+    return result
+
+
+def _encrypt_field(value: str) -> str:
+    version, cipher = _field_ciphers()[0]
+    return f"{version}.{cipher.encrypt(value.encode()).decode()}"
+
+
+def _decrypt_field(value: str) -> str:
+    version, separator, ciphertext = value.partition(".")
+    if separator:
+        candidates = [
+            cipher for candidate, cipher in _field_ciphers()
+            if candidate == version
+        ]
+    else:
+        ciphertext = value
+        candidates = [cipher for _version, cipher in _field_ciphers()]
+    for cipher in candidates:
+        try:
+            return cipher.decrypt(ciphertext.encode()).decode()
+        except InvalidToken:
+            continue
+    raise ValueError("Encrypted field cannot be decrypted with configured keys.")
+
+
+# Validate configured material during startup rather than at first MFA use.
+_field_ciphers()
 
 # Jinja helper
 app.jinja_env.globals['now'] = lambda: datetime.now()
@@ -217,6 +283,13 @@ def _validate_csrf() -> None:
 app.jinja_env.globals["csrf_token"] = csrf_token
 
 
+def csp_nonce() -> str:
+    return getattr(g, "csp_nonce", "")
+
+
+app.jinja_env.globals["csp_nonce"] = csp_nonce
+
+
 @app.before_request
 def _start_request_tenant_boundary():
     clear_request_context()
@@ -263,7 +336,7 @@ def health_ready():
             not CONTROL_TABLES.issubset(present)
             or (
                 DEPLOYMENT_ENV == "production"
-                and revision != "20260726_12"
+                and revision != "20260726_13"
             )
         ):
             return jsonify({"status": "not_ready"}), 503
@@ -408,6 +481,7 @@ login_manager.login_view = "login"
 def _bind_tenant_context():
     clear_request_context()
     g.request_id = request.headers.get("X-Request-ID") or secrets.token_hex(12)
+    g.csp_nonce = secrets.token_urlsafe(18)
     g.tenant_context_token = None
     g.platform_control_token = None
     if current_user.is_authenticated:
@@ -416,11 +490,52 @@ def _bind_tenant_context():
             os.environ.get("ATCROSTER_SESSION_IDLE_MINUTES", "30")
         ) * 60
         last_seen = int(session.get("_last_seen_epoch") or now_epoch)
-        if now_epoch - last_seen > idle_limit:
+        absolute_limit = int(
+            os.environ.get("ATCROSTER_SESSION_ABSOLUTE_MINUTES", "720")
+        ) * 60
+        started_raw = session.get("_session_started_at")
+        try:
+            started_epoch = int(
+                datetime.fromisoformat(str(started_raw)).timestamp()
+            )
+        except (TypeError, ValueError):
+            started_epoch = now_epoch
+            session["_session_started_at"] = utcnow().isoformat()
+        expiry_reason = (
+            "absolute" if now_epoch - started_epoch > absolute_limit
+            else "idle" if now_epoch - last_seen > idle_limit
+            else ""
+        )
+        if expiry_reason:
+            _security_event(
+                "session_expired", reason=expiry_reason,
+                principal=hashlib.sha256(
+                    str(current_user.get_id()).encode()
+                ).hexdigest()[:16],
+            )
             logout_user()
             session.clear()
-            flash("Your session expired due to inactivity.", "error")
+            flash("Your secure session has expired. Sign in again.", "error")
             return redirect(url_for("login"))
+        expected_stamp = session.get("_auth_stamp")
+        current_stamp = _current_auth_stamp(current_user)
+        if expected_stamp and not secrets.compare_digest(
+            str(expected_stamp), current_stamp
+        ):
+            _security_event(
+                "session_forced_invalidation",
+                principal=hashlib.sha256(
+                    str(current_user.get_id()).encode()
+                ).hexdigest()[:16],
+            )
+            logout_user()
+            session.clear()
+            flash(
+                "Your account security or permissions changed. Sign in again.",
+                "error",
+            )
+            return redirect(url_for("login"))
+        session["_auth_stamp"] = current_stamp
         session["_last_seen_epoch"] = now_epoch
     if (
         current_user.is_authenticated
@@ -433,6 +548,7 @@ def _bind_tenant_context():
             return redirect(url_for("login"))
         allowed_platform_endpoints = {
             "platform_admin", "logout", "password_change",
+            "platform_worker_health",
             "static", "favicon", "health_live", "health_ready",
         }
         if request.endpoint == "index":
@@ -492,7 +608,8 @@ def _security_headers(response):
         "font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; "
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com "
         "https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; "
-        "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
+        f"script-src 'self' 'nonce-{getattr(g, 'csp_nonce', '')}' "
+        "https://cdn.jsdelivr.net",
     )
     if request.is_secure or DEPLOYMENT_ENV == "production":
         response.headers.setdefault(
@@ -1210,6 +1327,7 @@ SecureInvitation = SaaS.SecureInvitation
 SignupWorkflow = SaaS.SignupWorkflow
 DatabaseRoutingMetadata = SaaS.DatabaseRoutingMetadata
 ProvisioningJob = SaaS.ProvisioningJob
+WorkerHeartbeat = SaaS.WorkerHeartbeat
 FeatureFlag = SaaS.FeatureFlag
 PlanHistory = SaaS.PlanHistory
 AggregateUsageEvent = SaaS.AggregateUsageEvent
@@ -7609,7 +7727,7 @@ def platform_admin():
             ).first_or_404()
             from platform_provisioning import pop_one_time_token
 
-            raw_token = pop_one_time_token(job.id)
+            raw_token = pop_one_time_token(job.id, job.unit_id)
             if raw_token:
                 invite_url = url_for(
                     "accept_invitation", token=raw_token, _external=True
@@ -7797,6 +7915,31 @@ def platform_admin():
         "platform_admin.html", rows=rows,
         feature_keys=sorted(PLATFORM_FEATURE_FLAGS),
     )
+
+
+@app.get("/platform/worker-health")
+@login_required
+def platform_worker_health():
+    if getattr(current_user, "role", "") != "superadmin":
+        abort(403)
+    cutoff = utcnow() - timedelta(
+        seconds=max(
+            60,
+            int(os.environ.get("ATCROSTER_PROVISIONING_LEASE_SECONDS", "120"))
+            * 2,
+        )
+    )
+    active = WorkerHeartbeat.query.filter(
+        WorkerHeartbeat.last_seen_at >= cutoff
+    ).count()
+    stale = WorkerHeartbeat.query.filter(
+        WorkerHeartbeat.last_seen_at < cutoff
+    ).count()
+    return jsonify({
+        "status": "ready" if active else "unavailable",
+        "active_workers": active,
+        "stale_workers": stale,
+    }), 200 if active else 503
 
 
 @app.route("/unit/accounts", methods=["GET", "POST"])
@@ -9338,6 +9481,41 @@ def _security_event(event: str, **safe_fields) -> None:
     ))
 
 
+def _current_auth_stamp(user) -> str:
+    """Bind a session to mutable authentication and authorisation state."""
+    parts = [
+        str(getattr(user, "password_hash", "")),
+        str(getattr(user, "role", "")),
+        str(getattr(user, "membership_status", "")),
+    ]
+    if getattr(user, "role", "") == "superadmin":
+        credential = PlatformMfaCredential.query.filter_by(
+            identity_id=user.id
+        ).first()
+    else:
+        # Airport MFA lives in the operational database and is deliberately
+        # excluded from this control-plane stamp. Its reset workflow revokes
+        # the affected login directly; querying it here would make the stamp
+        # dependent on request routing state.
+        credential = None
+    parts.extend([
+        str(bool(credential and credential.enabled)),
+        str(bool(getattr(credential, "reset_required", False))),
+    ])
+    return hashlib.sha256("\x1f".join(parts).encode()).hexdigest()
+
+
+def _initialize_authenticated_session(user, *, platform_mfa=False) -> None:
+    """Regenerate authenticated session state after the final auth factor."""
+    session.permanent = True
+    session["_session_nonce"] = secrets.token_urlsafe(24)
+    session["_session_started_at"] = utcnow().isoformat()
+    session["_last_seen_epoch"] = int(utcnow().timestamp())
+    session["_auth_stamp"] = _current_auth_stamp(user)
+    if platform_mfa:
+        session["_platform_mfa_verified"] = True
+
+
 def _central_security_event(
     event_type: str, outcome: str, identity_id: int | None = None,
     principal: str = "", detail: str = "",
@@ -9475,8 +9653,7 @@ def signin_form():   # function name can be anything; endpoint is 'login'
                 )
                 return redirect(url_for("mfa_challenge"))
             login_user(user)
-            session.permanent = True
-            session["_session_started_at"] = utcnow().isoformat()
+            _initialize_authenticated_session(user)
             _security_event(
                 "login_succeeded",
                 principal=rate_key[-16:],
@@ -9500,10 +9677,8 @@ def signin_form():   # function name can be anything; endpoint is 'login'
 
 def _decrypt_mfa_secret(credential) -> str:
     try:
-        return _field_cipher().decrypt(
-            credential.encrypted_secret.encode()
-        ).decode()
-    except (InvalidToken, ValueError) as exc:
+        return _decrypt_field(credential.encrypted_secret)
+    except ValueError as exc:
         raise RuntimeError("MFA credential cannot be decrypted.") from exc
 
 
@@ -9533,9 +9708,7 @@ def _complete_platform_login(identity, user, recovery_used=False):
     next_url = session.get("_platform_mfa_next", "")
     session.clear()
     login_user(user)
-    session.permanent = True
-    session["_session_started_at"] = utcnow().isoformat()
-    session["_platform_mfa_verified"] = True
+    _initialize_authenticated_session(user, platform_mfa=True)
     identity.last_active_at = utcnow()
     _central_security_event(
         "platform_recovery_code_used" if recovery_used
@@ -9605,9 +9778,7 @@ def platform_mfa_setup():
                 identity_id=identity.id, encrypted_secret=""
             )
             db.session.add(credential)
-        credential.encrypted_secret = _field_cipher().encrypt(
-            pending.encode()
-        ).decode()
+        credential.encrypted_secret = _encrypt_field(pending)
         credential.enabled = True
         credential.reset_required = False
         credential.enrolled_at = utcnow()
@@ -9731,13 +9902,10 @@ def mfa_challenge():
                 credential.recovery_codes_digest = json.dumps(digests)
                 accepted = True
         if accepted:
-            next_url = session.pop("_mfa_next", "")
-            session.pop("_mfa_user_id", None)
-            session.pop("_mfa_unit_id", None)
+            next_url = session.get("_mfa_next", "")
+            session.clear()
             login_user(user)
-            session.permanent = True
-            session["_session_started_at"] = utcnow().isoformat()
-            session.pop("_mfa_rate_key", "")
+            _initialize_authenticated_session(user)
             _security_event(
                 "mfa_login_succeeded",
                 principal=hashlib.sha256(
@@ -9796,9 +9964,7 @@ def mfa_setup():
                 encrypted_secret="",
             )
             db.session.add(credential)
-        credential.encrypted_secret = _field_cipher().encrypt(
-            pending.encode()
-        ).decode()
+        credential.encrypted_secret = _encrypt_field(pending)
         credential.enabled = True
         credential.enrolled_at = utcnow()
         credential.recovery_codes_digest = json.dumps([
@@ -9807,6 +9973,7 @@ def mfa_setup():
         ])
         db.session.commit()
         session.pop("_pending_mfa_secret", None)
+        session["_auth_stamp"] = _current_auth_stamp(current_user)
         return render_template(
             "mfa_setup.html", enabled=True, recovery_codes=recovery_codes
         )
@@ -9949,6 +10116,41 @@ def reconcile_signups(apply_changes, confirm):
             row.last_error_code = "compensated_retry_required"
             db.session.commit()
     click.echo(f"{len(rows)} incomplete signup workflow(s) inspected.")
+
+
+@app.cli.command("rotate-field-encryption")
+@click.option(
+    "--confirm", default="",
+    help="Required: enter ROTATE-FIELD-ENCRYPTION",
+)
+def rotate_field_encryption(confirm):
+    """Re-encrypt MFA secrets with the first configured versioned key."""
+    if confirm != "ROTATE-FIELD-ENCRYPTION":
+        raise click.UsageError(
+            "--confirm ROTATE-FIELD-ENCRYPTION is required"
+        )
+    rotated = 0
+    for credential in PlatformMfaCredential.query.filter(
+        PlatformMfaCredential.encrypted_secret != ""
+    ).all():
+        credential.encrypted_secret = _encrypt_field(
+            _decrypt_field(credential.encrypted_secret)
+        )
+        rotated += 1
+    db.session.commit()
+    for routing in DatabaseRoutingMetadata.query.order_by(
+        DatabaseRoutingMetadata.unit_id
+    ).all():
+        with operational_unit_context(routing.unit_id, routing.secret_name):
+            for credential in MfaCredential.query.filter(
+                MfaCredential.encrypted_secret != ""
+            ).all():
+                credential.encrypted_secret = _encrypt_field(
+                    _decrypt_field(credential.encrypted_secret)
+                )
+                rotated += 1
+            db.session.commit()
+    click.echo(f"Rotated {rotated} encrypted credential(s).")
 
 
 # -------------------- DB init (single, safe block) --------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,21 @@ services:
       timeout: 5s
       retries: 10
 
+  airport-2-database:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: atcroster_airport_2
+      POSTGRES_USER: atcroster
+      POSTGRES_PASSWORD: ${AIRPORT_2_POSTGRES_PASSWORD:?set AIRPORT_2_POSTGRES_PASSWORD}
+    volumes:
+      - atcroster_airport_2_db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U atcroster -d atcroster_airport_2"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
   redis:
     image: redis:7-alpine
     restart: unless-stopped
@@ -47,16 +62,22 @@ services:
       ATCROSTER_ENVIRONMENT: production
       ATCROSTER_SECURE_COOKIES: "true"
       FLASK_SECRET_KEY: ${FLASK_SECRET_KEY:?set FLASK_SECRET_KEY}
-      ATCROSTER_FIELD_ENCRYPTION_KEY: ${ATCROSTER_FIELD_ENCRYPTION_KEY:?set ATCROSTER_FIELD_ENCRYPTION_KEY}
+      ATCROSTER_FIELD_ENCRYPTION_KEYS: ${ATCROSTER_FIELD_ENCRYPTION_KEYS:?set ATCROSTER_FIELD_ENCRYPTION_KEYS}
+      ATCROSTER_TOKEN_ENCRYPTION_KEYS: ${ATCROSTER_TOKEN_ENCRYPTION_KEYS:?set ATCROSTER_TOKEN_ENCRYPTION_KEYS}
+      ATCROSTER_TRUSTED_HOSTS: ${ATCROSTER_TRUSTED_HOSTS:-localhost,127.0.0.1}
+      ATCROSTER_TRUSTED_PROXY_HOPS: ${ATCROSTER_TRUSTED_PROXY_HOPS:-0}
       REDIS_URL: redis://redis:6379/0
       CONTROL_DATABASE_URL: postgresql+psycopg://atcroster:${CONTROL_POSTGRES_PASSWORD}@control-database:5432/atcroster_control
       DATABASE_URL: postgresql+psycopg://atcroster:${CONTROL_POSTGRES_PASSWORD}@control-database:5432/atcroster_control
       ATCROSTER_UNIT_1_DATABASE_URL: postgresql+psycopg://atcroster:${AIRPORT_1_POSTGRES_PASSWORD}@airport-1-database:5432/atcroster_airport_1
+      ATCROSTER_UNIT_2_DATABASE_URL: postgresql+psycopg://atcroster:${AIRPORT_2_POSTGRES_PASSWORD}@airport-2-database:5432/atcroster_airport_2
     command: ["python", "scripts/migrate_all_databases.py"]
     depends_on:
       control-database:
         condition: service_healthy
       airport-1-database:
+        condition: service_healthy
+      airport-2-database:
         condition: service_healthy
       redis:
         condition: service_healthy
@@ -100,4 +121,5 @@ services:
 volumes:
   atcroster_control_db:
   atcroster_airport_1_db:
+  atcroster_airport_2_db:
   atcroster_redis:

--- a/docs/manual_acceptance_test.md
+++ b/docs/manual_acceptance_test.md
@@ -27,7 +27,7 @@ These commands create a dedicated SQLite acceptance database. The command
 refuses to overwrite an existing database unless `--reset` is present.
 
 ```bash
-python -m pip install -r requirements.txt
+python -m pip install -r requirements-dev.txt
 python scripts/seed_acceptance_data.py --reset
 export DATABASE_URL="sqlite:///instance/acceptance.db"
 export FLASK_SECRET_KEY="local-acceptance-secret"

--- a/docs/production_runbook.md
+++ b/docs/production_runbook.md
@@ -79,7 +79,11 @@ receive the same encrypted variables:
 - `ATCROSTER_ENVIRONMENT=production`
 - `ATCROSTER_SECURE_COOKIES=true`
 - `FLASK_SECRET_KEY` with at least 32 random characters
-- `ATCROSTER_FIELD_ENCRYPTION_KEY` generated with Fernet
+- `ATCROSTER_FIELD_ENCRYPTION_KEYS` as an ordered versioned key ring, for
+  example `v2:<new-fernet-key>,v1:<old-fernet-key>`
+- `ATCROSTER_TOKEN_ENCRYPTION_KEYS` as a separate ordered key ring for
+  temporary bootstrap-token envelopes
+- `ATCROSTER_BOOTSTRAP_TOKEN_TTL_SECONDS` (default 900)
 - `DATABASE_URL` using the PostgreSQL service's private connection variables
 - `CONTROL_DATABASE_URL` using the control PostgreSQL service
 - `ATCROSTER_UNIT_<id>_DATABASE_URL` for every airport database
@@ -87,6 +91,12 @@ receive the same encrypted variables:
 - `ATCROSTER_SESSION_IDLE_MINUTES` and
   `ATCROSTER_SESSION_ABSOLUTE_MINUTES`
 - `ATCROSTER_TRUSTED_PROXY_HOPS` matching the verified proxy topology
+- `ATCROSTER_TRUSTED_HOSTS` as a comma-separated allowlist
+- `ATCROSTER_PROVISIONING_LEASE_SECONDS` (minimum 30; default 120)
+- `ATCROSTER_DB_CONNECT_TIMEOUT_SECONDS`,
+  `ATCROSTER_DB_STATEMENT_TIMEOUT_MS`, `ATCROSTER_DB_POOL_TIMEOUT_SECONDS`,
+  `ATCROSTER_OPERATIONAL_POOL_SIZE` and
+  `ATCROSTER_OPERATIONAL_MAX_OVERFLOW`
 
 The web service uses the repository `railway.toml`. Configure the worker
 service start command as `python scripts/run_provisioning_worker.py` and no
@@ -94,6 +104,17 @@ public endpoint. The pre-deploy command upgrades control first and then all
 configured operational databases. After the first healthy deployment, run
 `flask --app app bootstrap-platform` once with a unique administrator
 password. Do not upload acceptance data or local environment files.
+
+For field-key rotation, prepend the new version, retain previous decrypt keys,
+take verified backups, and run:
+
+```bash
+flask --app app rotate-field-encryption \
+  --confirm ROTATE-FIELD-ENCRYPTION
+```
+
+Retire old field keys only after verification. Token-envelope key versions
+must overlap for at least the configured bootstrap-token TTL.
 
 ## Reverse proxy
 

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -10,7 +10,7 @@ production release.
 - [x] Super Admin privacy tests pass.
 - [x] Account-limit, request, annotation and publication tests pass.
 - [x] Clean SQLite fixtures and PostgreSQL 16 reach Alembic `20260725_08`.
-- [x] `pip-audit -r requirements.txt` reports no known vulnerabilities.
+- [x] `pip-audit -r requirements-prod.txt` reports no known vulnerabilities.
 - [x] Changed-file and correctness/security lint checks pass; remaining legacy
   style debt is recorded as non-blocking.
 - [x] 30-airport/108,000-assignment smoke test passes locally.

--- a/docs/repository_protection.md
+++ b/docs/repository_protection.md
@@ -1,0 +1,17 @@
+# GitHub repository protection handoff
+
+Configure the `main` branch ruleset manually in GitHub:
+
+- require pull requests and at least one approval;
+- dismiss stale approvals when new commits are pushed;
+- require every Quality job and the complete CodeQL workflow;
+- require branches to be current before merging;
+- require all review conversations to be resolved;
+- block force pushes and branch deletion;
+- restrict direct pushes to authorised release maintainers;
+- do not allow Dependabot to bypass these protections.
+
+Enable Dependabot security updates in repository settings. Automated updates
+must not be auto-merged. Python major versions and material database, security,
+container or workflow-runtime updates require a dedicated compatibility pull
+request with the complete production verification matrix.

--- a/migrations/fresh_schema.py
+++ b/migrations/fresh_schema.py
@@ -9,7 +9,7 @@ CONTROL_TABLES = frozenset({
     "database_routing_metadata", "feature_flag", "plan_history",
     "aggregate_usage_event", "super_admin_audit",
     "platform_mfa_credential", "signup_workflow", "central_security_audit",
-    "provisioning_job",
+    "provisioning_job", "worker_heartbeat",
 })
 
 

--- a/migrations/versions/20260726_13_provisioning_leases.py
+++ b/migrations/versions/20260726_13_provisioning_leases.py
@@ -1,0 +1,60 @@
+"""Add renewable provisioning leases and worker heartbeat.
+
+Revision ID: 20260726_13
+Revises: 20260726_12
+"""
+
+import os
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260726_13"
+down_revision = "20260726_12"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    role = os.environ.get("ATCROSTER_SCHEMA_ROLE", "combined")
+    if role == "operational":
+        return
+    inspector = sa.inspect(op.get_bind())
+    tables = set(inspector.get_table_names())
+    if "provisioning_job" in tables:
+        columns = {
+            column["name"] for column in inspector.get_columns("provisioning_job")
+        }
+        with op.batch_alter_table("provisioning_job") as batch:
+            if "lease_owner" not in columns:
+                batch.add_column(
+                    sa.Column(
+                        "lease_owner", sa.String(64), nullable=False, server_default=""
+                    )
+                )
+            if "lease_expires_at" not in columns:
+                batch.add_column(sa.Column("lease_expires_at", sa.DateTime()))
+                batch.create_index(
+                    "ix_provisioning_job_lease_expires_at", ["lease_expires_at"]
+                )
+    if "worker_heartbeat" not in tables:
+        op.create_table(
+            "worker_heartbeat",
+            sa.Column("worker_id", sa.String(64), primary_key=True),
+            sa.Column(
+                "process_type",
+                sa.String(30),
+                nullable=False,
+                server_default="provisioning",
+            ),
+            sa.Column(
+                "state", sa.String(30), nullable=False, server_default="starting"
+            ),
+            sa.Column("last_seen_at", sa.DateTime(), nullable=False),
+            sa.Column("started_at", sa.DateTime(), nullable=False),
+        )
+
+
+def downgrade():
+    raise RuntimeError("Provisioning lease history cannot be safely removed.")

--- a/platform_provisioning.py
+++ b/platform_provisioning.py
@@ -8,12 +8,16 @@ codes in the control database.
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import re
 import secrets
 import socket
+import threading
+from contextlib import contextmanager
 from datetime import timedelta
 
+from cryptography.fernet import Fernet, InvalidToken
 from sqlalchemy import create_engine, inspect
 
 from scripts.migrate_all_databases import (
@@ -25,6 +29,40 @@ ACTIVE_STATES = ("queued", "running", "retry_wait")
 SECRET_NAME_PATTERN = re.compile(r"ATCROSTER_UNIT_[1-9][0-9]*_DATABASE_URL")
 REQUIRED_OPERATIONAL_TABLES = frozenset({"staff", "assignment", "shift_type"})
 _development_tokens: dict[int, str] = {}
+
+
+class TokenEnvelopeError(RuntimeError):
+    pass
+
+
+def _token_keys() -> list[tuple[str, Fernet]]:
+    configured = os.environ.get("ATCROSTER_TOKEN_ENCRYPTION_KEYS", "")
+    if not configured:
+        if os.environ.get("ATCROSTER_ENVIRONMENT", "development") == "production":
+            raise TokenEnvelopeError("token_encryption_key_unavailable")
+        secret = os.environ.get("FLASK_SECRET_KEY", "development-only")
+        import base64
+
+        key = base64.urlsafe_b64encode(
+            hashlib.sha256(secret.encode()).digest()
+        ).decode()
+        configured = f"dev:{key}"
+    result = []
+    for item in configured.split(","):
+        version, separator, key = item.strip().partition(":")
+        if not separator or not re.fullmatch(r"[A-Za-z0-9_-]{1,20}", version):
+            raise TokenEnvelopeError("token_encryption_key_invalid")
+        try:
+            result.append((version, Fernet(key.encode())))
+        except (TypeError, ValueError) as exc:
+            raise TokenEnvelopeError("token_encryption_key_invalid") from exc
+    if not result:
+        raise TokenEnvelopeError("token_encryption_key_unavailable")
+    return result
+
+
+def validate_token_encryption_config() -> None:
+    _token_keys()
 
 
 def _token_cache():
@@ -43,24 +81,44 @@ def _token_cache():
     )
 
 
-def store_one_time_token(job_id: int, raw_token: str) -> None:
+def store_one_time_token(job_id: int, unit_id: int, raw_token: str) -> None:
+    version, cipher = _token_keys()[0]
+    payload = json.dumps(
+        {"job_id": job_id, "unit_id": unit_id, "token": raw_token},
+        separators=(",", ":"),
+    ).encode()
+    ciphertext = f"{version}.{cipher.encrypt(payload).decode()}"
     cache = _token_cache()
     if cache is None:
-        _development_tokens[job_id] = raw_token
+        _development_tokens[job_id] = ciphertext
         return
-    cache.set(f"atcroster:provisioning-token:{job_id}", raw_token, ex=3600)
+    ttl = max(60, int(os.environ.get("ATCROSTER_BOOTSTRAP_TOKEN_TTL_SECONDS", "900")))
+    if not cache.set(f"atcroster:provisioning-token:{job_id}", ciphertext, ex=ttl):
+        raise TokenEnvelopeError("token_envelope_store_failed")
 
 
-def pop_one_time_token(job_id: int) -> str | None:
+def pop_one_time_token(job_id: int, unit_id: int) -> str | None:
     cache = _token_cache()
     if cache is None:
-        return _development_tokens.pop(job_id, None)
-    key = f"atcroster:provisioning-token:{job_id}"
-    pipeline = cache.pipeline(transaction=True)
-    pipeline.get(key)
-    pipeline.delete(key)
-    value, _deleted = pipeline.execute()
-    return value
+        value = _development_tokens.pop(job_id, None)
+    else:
+        value = cache.getdel(f"atcroster:provisioning-token:{job_id}")
+    if not value:
+        return None
+    version, separator, ciphertext = value.partition(".")
+    if not separator:
+        raise TokenEnvelopeError("token_envelope_invalid")
+    keys = dict(_token_keys())
+    cipher = keys.get(version)
+    if not cipher:
+        raise TokenEnvelopeError("token_encryption_version_unknown")
+    try:
+        payload = json.loads(cipher.decrypt(ciphertext.encode()).decode())
+    except (InvalidToken, UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+        raise TokenEnvelopeError("token_envelope_invalid") from exc
+    if payload.get("job_id") != job_id or payload.get("unit_id") != unit_id:
+        raise TokenEnvelopeError("token_envelope_binding_invalid")
+    return str(payload["token"])
 
 
 class ProvisioningWorker:
@@ -69,20 +127,39 @@ class ProvisioningWorker:
         self.worker_id = hashlib.sha256(
             f"{socket.gethostname()}:{os.getpid()}:{secrets.token_hex(8)}".encode()
         ).hexdigest()[:32]
+        self.lease_seconds = max(
+            30, int(os.environ.get("ATCROSTER_PROVISIONING_LEASE_SECONDS", "120"))
+        )
+
+    def heartbeat(self, state: str = "idle") -> None:
+        with self.app.app_context():
+            import app as application
+
+            row = application.db.session.get(
+                application.WorkerHeartbeat, self.worker_id
+            )
+            if not row:
+                row = application.WorkerHeartbeat(worker_id=self.worker_id)
+                application.db.session.add(row)
+            row.state = state[:30]
+            row.last_seen_at = application.utcnow()
+            application.db.session.commit()
 
     def recover_stale_jobs(self) -> int:
         """Release jobs abandoned by a worker that stopped unexpectedly."""
         with self.app.app_context():
             import app as application
 
-            cutoff = application.utcnow() - timedelta(minutes=15)
             rows = application.ProvisioningJob.query.filter(
                 application.ProvisioningJob.state == "running",
-                application.ProvisioningJob.locked_at < cutoff,
+                application.ProvisioningJob.lease_expires_at.is_not(None),
+                application.ProvisioningJob.lease_expires_at < application.utcnow(),
             ).all()
             for job in rows:
                 job.state = "retry_wait"
                 job.worker_id = ""
+                job.lease_owner = ""
+                job.lease_expires_at = None
                 job.locked_at = None
                 job.next_attempt_at = application.utcnow()
                 job.last_error_code = "worker_interrupted"
@@ -110,101 +187,199 @@ class ProvisioningWorker:
                 return True
             job.state = "running"
             job.worker_id = self.worker_id
+            job.lease_owner = self.worker_id
+            job.lease_expires_at = now + timedelta(seconds=self.lease_seconds)
             job.locked_at = now
             job.attempt_count = int(job.attempt_count or 0) + 1
             job.updated_at = now
             job_id = job.id
             application.db.session.commit()
 
-        self._process(job_id)
+        self.heartbeat("busy")
+        try:
+            self._process(job_id)
+        finally:
+            self.heartbeat("idle")
         return True
 
     def _process(self, job_id: int) -> None:
+        stop_renewal = threading.Event()
+        renewal = None
         with self.app.app_context():
             import app as application
 
             job = application.db.session.get(application.ProvisioningJob, job_id)
-            routing = application.db.session.get(
-                application.DatabaseRoutingMetadata, job.unit_id
-            )
-            unit = application.db.session.get(application.Unit, job.unit_id)
-            if not routing or not unit:
-                self._fail(application, job, "routing_metadata_unavailable", False)
+            if not self._owns_lease(job):
                 return
+            if application.db.engine.dialect.name == "postgresql":
+                renewal = threading.Thread(
+                    target=self._renew_lease_until,
+                    args=(job_id, stop_renewal),
+                    daemon=True,
+                )
+                renewal.start()
+            try:
+                with self._airport_advisory_lock(application, job.unit_id) as acquired:
+                    if not acquired:
+                        self._defer_lock_contention(application, job)
+                        return
+                    self._process_with_lock(application, job)
+            finally:
+                stop_renewal.set()
+                if renewal:
+                    renewal.join(timeout=5)
+
+    def _process_with_lock(self, application, job) -> None:
+        routing = application.db.session.get(
+            application.DatabaseRoutingMetadata, job.unit_id
+        )
+        unit = application.db.session.get(application.Unit, job.unit_id)
+        if not routing or not unit:
+            self._fail(application, job, "routing_metadata_unavailable", False)
+            return
+        if job.cancel_requested:
+            self._finish_cancelled(application, job)
+            return
+        secret_name = routing.secret_name or ""
+        operational_url = (
+            os.environ.get(secret_name)
+            if SECRET_NAME_PATTERN.fullmatch(secret_name)
+            else None
+        )
+        if not operational_url:
+            self._fail(application, job, "database_secret_unavailable", True)
+            return
+        control_url = os.environ.get("CONTROL_DATABASE_URL") or os.environ.get(
+            "DATABASE_URL", ""
+        )
+        if control_url and (
+            _canonical_database_url(operational_url)
+            == _canonical_database_url(control_url)
+        ):
+            self._fail(application, job, "database_route_conflict", False)
+            return
+        try:
+            version = upgrade_database(operational_url, "operational")
+            application.db.session.expire(job)
+            if not self._owns_lease(job):
+                return
+            engine = create_engine(
+                operational_url,
+                pool_pre_ping=True,
+                pool_recycle=280,
+                pool_timeout=10,
+            )
+            try:
+                with engine.connect() as connection:
+                    present = set(inspect(connection).get_table_names())
+                if not REQUIRED_OPERATIONAL_TABLES.issubset(present):
+                    raise RuntimeError("operational_schema_incomplete")
+            finally:
+                engine.dispose()
             if job.cancel_requested:
                 self._finish_cancelled(application, job)
                 return
-            secret_name = routing.secret_name or ""
-            operational_url = (
-                os.environ.get(secret_name)
-                if SECRET_NAME_PATTERN.fullmatch(secret_name)
-                else None
-            )
-            if not operational_url:
-                self._fail(application, job, "database_secret_unavailable", True)
-                return
-            control_url = os.environ.get("CONTROL_DATABASE_URL") or os.environ.get(
-                "DATABASE_URL", ""
-            )
-            if control_url and (
-                _canonical_database_url(operational_url)
-                == _canonical_database_url(control_url)
-            ):
-                self._fail(application, job, "database_route_conflict", False)
-                return
-            try:
-                version = upgrade_database(operational_url, "operational")
-                engine = create_engine(
-                    operational_url,
-                    pool_pre_ping=True,
-                    pool_recycle=280,
-                    pool_timeout=10,
-                )
-                try:
-                    with engine.connect() as connection:
-                        present = set(inspect(connection).get_table_names())
-                    if not REQUIRED_OPERATIONAL_TABLES.issubset(present):
-                        raise RuntimeError("operational_schema_incomplete")
-                finally:
-                    engine.dispose()
-                if job.cancel_requested:
-                    self._finish_cancelled(application, job)
-                    return
-                invitation = application.SecureInvitation.query.filter_by(
+            invitation = application.SecureInvitation.query.filter_by(
+                unit_id=unit.id,
+                role="UnitAdmin",
+                active_bootstrap_key="active",
+            ).first()
+            raw_token = None
+            if not invitation:
+                raw_token = secrets.token_urlsafe(32)
+                invitation = application.SecureInvitation(
                     unit_id=unit.id,
+                    token_digest=hashlib.sha256(raw_token.encode()).hexdigest(),
                     role="UnitAdmin",
                     active_bootstrap_key="active",
-                ).first()
-                raw_token = None
-                if not invitation:
-                    raw_token = secrets.token_urlsafe(32)
-                    invitation = application.SecureInvitation(
-                        unit_id=unit.id,
-                        token_digest=hashlib.sha256(raw_token.encode()).hexdigest(),
-                        role="UnitAdmin",
-                        active_bootstrap_key="active",
-                        expires_at=application.utcnow() + timedelta(days=7),
-                    )
-                    application.db.session.add(invitation)
-                routing.health = "healthy"
-                routing.migration_version = version
-                routing.provisioning_state = "invitation_issued"
-                routing.last_error_code = ""
-                routing.attempt_count = job.attempt_count
-                routing.ready_at = application.utcnow()
-                job.state = "completed"
-                job.active_key = None
-                job.locked_at = None
-                job.worker_id = ""
-                job.last_error_code = ""
-                job.updated_at = application.utcnow()
-                application.db.session.commit()
-                if raw_token:
-                    store_one_time_token(job.id, raw_token)
-            except Exception:
-                application.db.session.rollback()
-                job = application.db.session.get(application.ProvisioningJob, job_id)
+                    expires_at=application.utcnow() + timedelta(days=7),
+                )
+                application.db.session.add(invitation)
+            routing.health = "healthy"
+            routing.migration_version = version
+            routing.provisioning_state = "invitation_issued"
+            routing.last_error_code = ""
+            routing.attempt_count = job.attempt_count
+            routing.ready_at = application.utcnow()
+            job.state = "completed"
+            job.active_key = None
+            job.locked_at = None
+            job.worker_id = ""
+            job.lease_owner = ""
+            job.lease_expires_at = None
+            job.last_error_code = ""
+            job.updated_at = application.utcnow()
+            if raw_token:
+                store_one_time_token(job.id, unit.id, raw_token)
+            application.db.session.commit()
+        except Exception:
+            application.db.session.rollback()
+            job = application.db.session.get(application.ProvisioningJob, job.id)
+            if self._owns_lease(job):
                 self._fail(application, job, "database_provisioning_failed", True)
+
+    def _renew_lease_until(self, job_id: int, stop: threading.Event) -> None:
+        interval = max(5, self.lease_seconds // 3)
+        while not stop.wait(interval):
+            with self.app.app_context():
+                import app as application
+
+                updated = application.ProvisioningJob.query.filter_by(
+                    id=job_id, state="running", lease_owner=self.worker_id
+                ).update(
+                    {
+                        "lease_expires_at": (
+                            application.utcnow() + timedelta(seconds=self.lease_seconds)
+                        ),
+                        "updated_at": application.utcnow(),
+                    }
+                )
+                if updated != 1:
+                    application.db.session.rollback()
+                    return
+                application.db.session.commit()
+            self.heartbeat("busy")
+
+    def _owns_lease(self, job) -> bool:
+        return bool(
+            job
+            and job.state == "running"
+            and job.lease_owner == self.worker_id
+            and job.lease_expires_at
+        )
+
+    @contextmanager
+    def _airport_advisory_lock(self, application, unit_id: int):
+        if application.db.engine.dialect.name != "postgresql":
+            yield True
+            return
+        with application.db.engine.connect() as connection:
+            acquired = bool(
+                connection.execute(
+                    application.text("SELECT pg_try_advisory_lock(:key)"),
+                    {"key": int(unit_id)},
+                ).scalar()
+            )
+            try:
+                yield acquired
+            finally:
+                if acquired:
+                    connection.execute(
+                        application.text("SELECT pg_advisory_unlock(:key)"),
+                        {"key": int(unit_id)},
+                    )
+
+    def _defer_lock_contention(self, application, job) -> None:
+        if not self._owns_lease(job):
+            return
+        job.state = "retry_wait"
+        job.worker_id = ""
+        job.lease_owner = ""
+        job.lease_expires_at = None
+        job.locked_at = None
+        job.next_attempt_at = application.utcnow() + timedelta(seconds=15)
+        job.last_error_code = "airport_lock_busy"
+        application.db.session.commit()
 
     @staticmethod
     def _finish_cancelled(application, job) -> None:
@@ -212,6 +387,8 @@ class ProvisioningWorker:
         job.active_key = None
         job.locked_at = None
         job.worker_id = ""
+        job.lease_owner = ""
+        job.lease_expires_at = None
         job.updated_at = application.utcnow()
         routing = application.db.session.get(
             application.DatabaseRoutingMetadata, job.unit_id
@@ -225,6 +402,8 @@ class ProvisioningWorker:
         job.last_error_code = code
         job.locked_at = None
         job.worker_id = ""
+        job.lease_owner = ""
+        job.lease_expires_at = None
         job.updated_at = application.utcnow()
         routing = application.db.session.get(
             application.DatabaseRoutingMetadata, job.unit_id

--- a/requirements-desktop.txt
+++ b/requirements-desktop.txt
@@ -1,0 +1,4 @@
+-r requirements-prod.txt
+
+pywebview==5.1
+pyinstaller==6.11.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+-r requirements-prod.txt
+
+pytest==9.1.1
+ruff==0.12.5
+mypy==1.17.0
+bandit==1.8.6
+pip-audit==2.9.0

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -1,0 +1,24 @@
+# Web framework
+Flask==3.1.3
+Flask-SQLAlchemy==3.1.1
+Flask-Login==0.6.3
+
+# Database and migrations
+SQLAlchemy==2.0.51
+alembic==1.13.3
+Flask-Migrate==4.0.7
+psycopg[binary]==3.3.4
+
+# Security and MFA
+Werkzeug==3.1.8
+cryptography==48.0.1
+pyotp==2.9.0
+qrcode==8.2
+itsdangerous==2.2.0
+
+# Runtime utilities and servers
+Jinja2==3.1.6
+click==8.4.2
+python-dateutil==2.9.0.post0
+waitress==3.0.2
+redis==5.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,34 +1,5 @@
-# Core framework
-Flask==3.1.3
-Flask-SQLAlchemy==3.1.1
-Flask-Login==0.6.3
-
-# Database
-SQLAlchemy==2.0.51
-alembic==1.13.3
-Flask-Migrate==4.0.7
-psycopg[binary]==3.3.4
-
-# Security / password hashing
-Werkzeug==3.1.8
-cryptography==48.0.1
-pyotp==2.9.0
-qrcode==8.2
-
-# Utilities
-itsdangerous==2.2.0
-Jinja2==3.1.6
-click==8.4.2
-
-# For date/time handling (stdlib datetime used but pendulum is useful)
-python-dateutil==2.9.0.post0
-
-# Optional: if you export CSV/ICS you don’t need extras, stdlib handles that
-# Optional: if you later add testing
-pytest==9.1.1
-
-# Desktop app packaging
-pywebview==5.1
-waitress==3.0.2
-redis==5.2.1
-pyinstaller==6.11.1
+# Compatibility entry point for contributors who need every supported surface.
+# Production images must install requirements-prod.txt only.
+-r requirements-prod.txt
+-r requirements-dev.txt
+-r requirements-desktop.txt

--- a/saas_models.py
+++ b/saas_models.py
@@ -165,6 +165,8 @@ def register_saas_models(db, utcnow):
         next_attempt_at = db.Column(db.DateTime, nullable=False, default=utcnow)
         locked_at = db.Column(db.DateTime)
         worker_id = db.Column(db.String(64), nullable=False, default="")
+        lease_owner = db.Column(db.String(64), nullable=False, default="")
+        lease_expires_at = db.Column(db.DateTime, index=True)
         cancel_requested = db.Column(db.Boolean, nullable=False, default=False)
         last_error_code = db.Column(db.String(80), nullable=False, default="")
         created_at = db.Column(db.DateTime, nullable=False, default=utcnow)
@@ -174,6 +176,14 @@ def register_saas_models(db, utcnow):
                 "unit_id", "active_key", name="uq_active_provisioning_job"
             ),
         )
+
+    class WorkerHeartbeat(db.Model):
+        __tablename__ = "worker_heartbeat"
+        worker_id = db.Column(db.String(64), primary_key=True)
+        process_type = db.Column(db.String(30), nullable=False, default="provisioning")
+        state = db.Column(db.String(30), nullable=False, default="starting")
+        last_seen_at = db.Column(db.DateTime, nullable=False, default=utcnow)
+        started_at = db.Column(db.DateTime, nullable=False, default=utcnow)
 
 
     class FeatureFlag(db.Model):

--- a/scripts/run_provisioning_worker.py
+++ b/scripts/run_provisioning_worker.py
@@ -25,9 +25,12 @@ def main() -> None:
     signal.signal(signal.SIGINT, _stop)
     worker = ProvisioningWorker(app)
     worker.recover_stale_jobs()
+    worker.heartbeat("idle")
     while not stopping:
         if not worker.run_once():
+            worker.heartbeat("idle")
             time.sleep(2)
+    worker.heartbeat("stopping")
 
 
 if __name__ == "__main__":

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -150,7 +150,7 @@
           <label>Pattern day 1 starts on<input type="date" name="pattern_anchor" value="{{ watch.pattern_anchor.isoformat() if watch.pattern_anchor else '' }}"><small>Required only when this watch has its own pattern.</small></label>
           <button class="btn btn-primary" type="submit">Save {{ watch.name }}</button>
         </form>
-        <form method="post" class="admin-danger-action" onsubmit="return confirm('Delete {{ watch.name }}?');">
+        <form method="post" class="admin-danger-action" data-confirm="Delete {{ watch.name }}?">
           <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
           <input type="hidden" name="form" value="watch_delete">
           <input type="hidden" name="watch_id" value="{{ watch.id }}">
@@ -285,7 +285,7 @@
             </div>
             <div class="form-actions"><button class="btn btn-primary" type="submit">Save {{ sh.code }}</button></div>
           </form>
-          <form method="post" class="admin-danger-action" onsubmit="return confirm('Delete shift {{ sh.code }}?');">
+          <form method="post" class="admin-danger-action" data-confirm="Delete shift {{ sh.code }}?">
             <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="form" value="shift_delete"><input type="hidden" name="shift_id" value="{{ sh.id }}">
             <button class="btn" type="submit">Delete shift</button>
@@ -351,7 +351,7 @@
   </section>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce() }}">
 (() => {
   const tabs = [...document.querySelectorAll('[data-admin-section]')];
   const panels = [...document.querySelectorAll('[data-admin-panel]')];

--- a/templates/admin_fatigue_rules.html
+++ b/templates/admin_fatigue_rules.html
@@ -101,7 +101,7 @@
           <label class="checkbox"><input type="checkbox" name="enabled" {% if rule.enabled %}checked{% endif %}> Active</label>
           <div class="form-actions"><button class="btn btn-primary" type="submit">Save rule</button></div>
         </form>
-        <form method="post" class="admin-danger-action" onsubmit="return confirm('Remove {{ rule.name }}?');">
+        <form method="post" class="admin-danger-action" data-confirm="Remove {{ rule.name }}?">
           <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
           <input type="hidden" name="action" value="delete_custom">
           <input type="hidden" name="code" value="{{ rule.code }}">
@@ -115,7 +115,7 @@
   </div>
 </section>
 
-<script>
+<script nonce="{{ csp_nonce() }}">
 (() => {
   const select = document.querySelector('[data-fatigue-rule-type]');
   const form = select?.closest('form');

--- a/templates/admin_reference.html
+++ b/templates/admin_reference.html
@@ -96,7 +96,7 @@
                   <input type="hidden" name="annotation_id" value="{{ ann.id }}">
                   <button class="btn" type="submit">Save</button>
                 </form>
-                <form method="post" class="inline-form" onsubmit="return confirm('Remove annotation {{ ann.code }}?');">
+                <form method="post" class="inline-form" data-confirm="Remove annotation {{ ann.code }}?">
                   <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
                   <input type="hidden" name="form" value="annotation_delete">
                   <input type="hidden" name="annotation_id" value="{{ ann.id }}">

--- a/templates/base.html
+++ b/templates/base.html
@@ -143,8 +143,38 @@
     </div>
   </footer>
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
-  <script>
+  <script nonce="{{ csp_nonce() }}" src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+  <script nonce="{{ csp_nonce() }}">
+    document.addEventListener('submit', (event) => {
+      const form = event.target.closest('form[data-confirm]');
+      if (form && !window.confirm(form.dataset.confirm)) event.preventDefault();
+    });
+    document.addEventListener('change', (event) => {
+      if (event.target.matches('[data-auto-submit]')) event.target.form?.submit();
+      if (event.target.dataset.command === 'fatigue-hide-clear') {
+        window.toggleNoIssueRows?.('hideNoIssues', 'fatigueTable');
+      }
+      if (event.target.dataset.command === 'fatigue-only-days') {
+        window.showOnlyDaysWithFindings?.('onlyDays', 'fatigueTable');
+      }
+    });
+    document.addEventListener('click', (event) => {
+      const target = event.target.closest('[data-command], [data-roster-zoom]');
+      if (!target) return;
+      if (target.dataset.confirm && !window.confirm(target.dataset.confirm)) {
+        event.preventDefault();
+        return;
+      }
+      if (target.dataset.rosterZoom) {
+        window.setRosterZoomPreset?.(target.dataset.rosterZoom);
+      } else if (target.dataset.command === 'history-back') {
+        history.back();
+      } else if (target.dataset.command === 'print-roster') {
+        window.printRoster?.();
+      } else if (target.dataset.command === 'print-fatigue') {
+        window.doPrint?.();
+      }
+    });
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => navigator.serviceWorker.register('/static/service-worker.js'));
     }

--- a/templates/error.html
+++ b/templates/error.html
@@ -9,7 +9,7 @@
     <p>{{ error_message or 'The event has been recorded. Do not repeat safety-critical changes until you have confirmed whether the first attempt succeeded.' }}</p>
     {% if request_id %}<p>Reference: <code>{{ request_id }}</code></p>{% endif %}
     <div class="action-buttons">
-      <button class="btn ghost" type="button" onclick="history.back()">Go back</button>
+      <button class="btn ghost" type="button" data-command="history-back">Go back</button>
       <a class="btn btn-primary" href="{{ home_url or url_for('index') }}">{{ home_label or 'Return to roster' }}</a>
     </div>
   </div></section>

--- a/templates/leave.html
+++ b/templates/leave.html
@@ -23,7 +23,7 @@
       <p class="text-muted">These choices belong only to this airport. Removing a type keeps its historical records but hides it from new entries and reports.</p>
       <div class="d-flex flex-wrap gap-2 mb-3">
         {% for item in absence_types if item.active %}
-          <form method="post" onsubmit="return confirm('Remove {{ item.label }} from this airport?');">
+          <form method="post" data-confirm="Remove {{ item.label }} from this airport?">
             <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="form" value="absence_type_delete">
             <input type="hidden" name="code" value="{{ item.code }}">
@@ -166,7 +166,7 @@
                 <button class="btn btn-sm btn-secondary" type="submit">Save</button>
               </form>
               <form class="d-inline ms-1" method="post"
-                    onsubmit="return confirm('Delete this sickness record?');">
+                    data-confirm="Delete this sickness record?">
                 <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
                 <input type="hidden" name="form" value="sick_delete">
                 <input type="hidden" name="staff_id" value="{{ a.staff_id }}">
@@ -217,7 +217,7 @@
                 <button class="btn btn-sm btn-secondary" type="submit">Save</button>
               </form>
               <form class="d-inline ms-1" method="post"
-                    onsubmit="return confirm('Delete this leave record?');">
+                    data-confirm="Delete this leave record?">
                 <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
                 <input type="hidden" name="form" value="leave_delete">
                 <input type="hidden" name="leave_id" value="{{ lv.id }}">

--- a/templates/messages.html
+++ b/templates/messages.html
@@ -12,7 +12,7 @@
 <section class="card">
   <div class="card-hd">Compose message</div>
   <div class="card-bd">
-    <form method="post" class="publication-release-form" onsubmit="return confirm('Send this SMS message now?');">
+    <form method="post" class="publication-release-form" data-confirm="Send this SMS message now?">
       <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
       <label>Recipients
         <select name="scope" id="message-scope">

--- a/templates/publication_centre.html
+++ b/templates/publication_centre.html
@@ -142,7 +142,7 @@
         <small>Published {{ publication.published_at.strftime('%d %b %Y %H:%M') if publication.published_at else 'Not published' }}{% if publication.superseded_at %} · superseded {{ publication.superseded_at.strftime('%d %b %Y %H:%M') }}{% endif %}</small>
         <small>{% if publication_diffs.get(publication.id) is not none %}{{ publication_diffs.get(publication.id) }} difference(s) from the active version{% else %}Comparison unavailable{% endif %}</small>
         {% if is_admin and publication.state == 'superseded' %}
-          <form method="post" onsubmit="return confirm('Restore version {{ publication.version }} as a new controlled release?');">
+          <form method="post" data-confirm="Restore version {{ publication.version }} as a new controlled release?">
             <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="action" value="rollback">
             <input type="hidden" name="publication_id" value="{{ publication.id }}">

--- a/templates/report_fatigue.html
+++ b/templates/report_fatigue.html
@@ -37,7 +37,7 @@
     thead th { background:#fff; }
   }
 </style>
-<script>
+<script nonce="{{ csp_nonce() }}">
   function doPrint(){ window.print(); }
 
   function toggleNoIssueRows(cbId, tableId){
@@ -86,12 +86,12 @@
 
   <div class="actions">
     <a href="{{ url_for('roster_month', ym=ym) }}">← Back to roster</a>
-    <button type="button" onclick="doPrint()">🖨 Print</button>
+    <button type="button" data-command="print-fatigue">🖨 Print</button>
   </div>
 
   <div class="controls">
-    <label><input type="checkbox" id="hideNoIssues" onchange="toggleNoIssueRows('hideNoIssues','fatigueTable')"> Hide people with no findings</label>
-    <label><input type="checkbox" id="onlyDays" onchange="showOnlyDaysWithFindings('onlyDays','fatigueTable')"> Show only days with any findings</label>
+    <label><input type="checkbox" id="hideNoIssues" data-command="fatigue-hide-clear"> Hide people with no findings</label>
+    <label><input type="checkbox" id="onlyDays" data-command="fatigue-only-days"> Show only days with any findings</label>
     <div class="legend">
       <span class="chip ok">0</span>
       <span class="chip warn">1–2</span>

--- a/templates/requests.html
+++ b/templates/requests.html
@@ -96,7 +96,7 @@
                   <td>
                     {% if not is_locked(day.year, day.month) and (req.status or 'pending') == 'pending' %}
                       <form method="post" class="d-inline"
-                            onsubmit="return confirm('Cancel this pending shift request?');">
+                            data-confirm="Cancel this pending shift request?">
                         <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
                         <input type="hidden" name="form" value="del">
                         <input type="hidden" name="rid" value="{{ req.id }}">

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -74,18 +74,18 @@
 
   <a class="btn" href="{{ url_for('roster_export_csv', ym=ym) }}" style="margin-left:1rem">Export CSV</a>
   {% if can_edit %}<a class="btn ghost" href="{{ url_for('bulk_annotations') }}">Bulk annotations</a>{% endif %}
-  <button class="btn" onclick="printRoster()">Print</button>
+  <button class="btn" data-command="print-roster">Print</button>
 
   <div class="roster-zoom-controls" role="group" aria-label="Roster zoom">
     <span class="roster-zoom-label">Zoom</span>
     <button type="button" class="btn ghost roster-zoom-btn" data-roster-zoom="0.75"
-            onclick="setRosterZoomPreset('0.75')">75%</button>
+            >75%</button>
     <button type="button" class="btn ghost roster-zoom-btn" data-roster-zoom="0.90"
-            onclick="setRosterZoomPreset('0.90')">90%</button>
+            >90%</button>
     <button type="button" class="btn ghost roster-zoom-btn" data-roster-zoom="1"
-            onclick="setRosterZoomPreset('1')">100%</button>
+            >100%</button>
     <button type="button" class="btn ghost roster-zoom-btn" data-roster-zoom="fit"
-            onclick="setRosterZoomPreset('fit')">Fit width</button>
+            >Fit width</button>
   </div>
 
 </div>
@@ -158,7 +158,7 @@
               <select
                 name="code"
                 class="code-input code-len-{{ code|length }} {% if code %}{{ code|lower }} group-{{ prefix }}{% endif %}"
-                onchange="this.form.submit()"
+                data-auto-submit="true"
                 {% if (not can_edit) or readonly %}disabled{% endif %}
                 {% if f %}title="{{ ', '.join(f) }}"{% endif %}
                 aria-label="{{ s.name }} shift on {{ d.strftime('%d %B %Y') }}"
@@ -203,7 +203,7 @@
               <select
                 name="annotation"
                 class="annot-select {% if ann %}has-annotation{% endif %}"
-                onchange="this.form.submit()"
+                data-auto-submit="true"
                 {% if (not can_edit) or readonly %}disabled{% endif %}
                 title="Annotate"
                 aria-label="{{ s.name }} annotation on {{ d.strftime('%d %B %Y') }}"
@@ -255,7 +255,7 @@
 </table>
 </div> <!-- /#roster -->
 
-<script>
+<script nonce="{{ csp_nonce() }}">
   function printRoster(){ window.print(); }
 </script>
 {% endblock %}

--- a/templates/staff_edit.html
+++ b/templates/staff_edit.html
@@ -174,14 +174,14 @@
         </form>
         <form method="post" action="{{ url_for('admin_watch_move_delete', hid=h.id) }}" class="d-inline">
           <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
-          <button class="btn btn-sm btn-danger" onclick="return confirm('Delete this watch move?')">Delete</button>
+          <button class="btn btn-sm btn-danger" data-confirm="Delete this watch move?">Delete</button>
         </form>
       </article>
     {% endfor %}
   </div></div></section>
 {% endif %}
 
-<script>
+<script nonce="{{ csp_nonce() }}">
 (() => {
   const toggle = document.querySelector('[data-personal-pattern-toggle]');
   const personal = document.querySelector('[data-personal-pattern]');

--- a/templates/staff_profile.html
+++ b/templates/staff_profile.html
@@ -105,7 +105,7 @@
           <a href="{{ google_link }}" class="btn">Google Calendar</a>
         </div>
         <details><summary>Manual subscription URL</summary><code class="profile-calendar-url">{{ cal_link }}</code></details>
-        <form method="post" action="{{ url_for('calendar_token_create', sid=staff.id) }}" class="mt-3" onsubmit="return confirm('Generate a new link? The old calendar subscription will stop updating.');">
+        <form method="post" action="{{ url_for('calendar_token_create', sid=staff.id) }}" class="mt-3" data-confirm="Generate a new link? The old calendar subscription will stop updating.">
           <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
           <button class="btn btn-sm" type="submit">Replace private link</button>
         </form>

--- a/templates/unit_accounts.html
+++ b/templates/unit_accounts.html
@@ -65,7 +65,7 @@
         <td>
           {% if membership.status == "active" and membership.person_id != current_user.id %}
           <form method="post"
-                onsubmit="return confirm('Deactivate this account? The user will no longer be able to sign in.');">
+                data-confirm="Deactivate this account? The user will no longer be able to sign in.">
             <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="action" value="deactivate">
             <input type="hidden" name="membership_id" value="{{ membership.id }}">

--- a/tenancy.py
+++ b/tenancy.py
@@ -74,8 +74,31 @@ class OperationalDatabaseRouter:
         if not database_url:
             raise RuntimeError(f"Deployment secret {route.secret_name!r} is unavailable")
         if unit_id not in self._engines:
+            options = {
+                "pool_pre_ping": True,
+                "pool_recycle": 280,
+                "pool_size": int(os.environ.get("ATCROSTER_OPERATIONAL_POOL_SIZE", "5")),
+                "max_overflow": int(
+                    os.environ.get("ATCROSTER_OPERATIONAL_MAX_OVERFLOW", "5")
+                ),
+                "pool_timeout": int(
+                    os.environ.get("ATCROSTER_DB_POOL_TIMEOUT_SECONDS", "10")
+                ),
+            }
+            if database_url.startswith("postgresql"):
+                options["connect_args"] = {
+                    "connect_timeout": int(
+                        os.environ.get("ATCROSTER_DB_CONNECT_TIMEOUT_SECONDS", "5")
+                    ),
+                    "options": (
+                        "-c statement_timeout="
+                        + str(int(os.environ.get(
+                            "ATCROSTER_DB_STATEMENT_TIMEOUT_MS", "15000"
+                        )))
+                    ),
+                }
             self._engines[unit_id] = create_engine(
-                database_url, pool_pre_ping=True, pool_recycle=280
+                database_url, **options
             )
         return self._engines[unit_id]
 

--- a/tests/test_legacy_migration_fixtures.py
+++ b/tests/test_legacy_migration_fixtures.py
@@ -119,7 +119,7 @@ def test_legacy_fixture_upgrades_to_head_without_data_loss(
         inspector = inspect(connection)
         assert connection.execute(
             text("SELECT version_num FROM alembic_version")
-            ).scalar_one() == "20260726_12"
+            ).scalar_one() == "20260726_13"
         for table, count in before.items():
             assert connection.execute(
                 text(f'SELECT COUNT(*) FROM "{table}"')

--- a/tests/test_postgresql_multidatabase.py
+++ b/tests/test_postgresql_multidatabase.py
@@ -1,5 +1,7 @@
 """PostgreSQL-only proof of the physical control/airport boundary."""
 import os
+import hashlib
+import threading
 
 import pytest
 from sqlalchemy import create_engine, inspect, text
@@ -22,11 +24,14 @@ import app  # noqa: E402
 from app import (  # noqa: E402
     DatabaseRoutingMetadata,
     PlatformIdentity,
+    ProvisioningJob,
     Unit,
     UnitMembership,
     db,
 )
 from scripts.migrate_all_databases import upgrade_database  # noqa: E402
+import platform_provisioning  # noqa: E402
+from platform_provisioning import ProvisioningWorker  # noqa: E402
 from tenancy import dispose_operational_engines  # noqa: E402
 from tests.test_physical_database_isolation import (  # noqa: E402
     _seed_operational_unit,
@@ -49,9 +54,9 @@ def test_postgresql_control_and_two_airport_databases_are_isolated(
     dispose_operational_engines()
     for url in (CONTROL_URL, AIRPORT_A_URL, AIRPORT_B_URL):
         _reset_postgres(url)
-    assert upgrade_database(CONTROL_URL, "control") == "20260726_12"
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260726_12"
-    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260726_12"
+    assert upgrade_database(CONTROL_URL, "control") == "20260726_13"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260726_13"
+    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260726_13"
     secret_a = "ATCROSTER_UNIT_1_DATABASE_URL"
     secret_b = "ATCROSTER_UNIT_2_DATABASE_URL"
     monkeypatch.setenv(secret_a, AIRPORT_A_URL)
@@ -125,4 +130,44 @@ def test_postgresql_control_and_two_airport_databases_are_isolated(
     assert "staff" in airport_a_tables and "staff" in airport_b_tables
     assert "platform_identity" not in airport_a_tables
     assert "unit" not in airport_a_tables
+
+    # Two independent workers use separate PostgreSQL sessions. The second
+    # cannot claim or migrate the airport while the first owns its lease.
+    with app.app.app_context():
+        job = ProvisioningJob(
+            unit_id=1,
+            idempotency_key=hashlib.sha256(b"postgres-concurrency").hexdigest(),
+            state="queued", active_key="active", next_attempt_at=app.utcnow(),
+        )
+        db.session.add(job)
+        db.session.commit()
+    migration_started = threading.Event()
+    release_migration = threading.Event()
+    calls = []
+    real_upgrade = platform_provisioning.upgrade_database
+
+    def slow_upgrade(url, role):
+        calls.append((url, role))
+        migration_started.set()
+        assert release_migration.wait(10)
+        return real_upgrade(url, role)
+
+    monkeypatch.setattr(platform_provisioning, "upgrade_database", slow_upgrade)
+    first = ProvisioningWorker(app.app)
+    second = ProvisioningWorker(app.app)
+    thread = threading.Thread(target=first.run_once)
+    thread.start()
+    assert migration_started.wait(10)
+    assert second.run_once() is False
+    release_migration.set()
+    thread.join(timeout=20)
+    assert not thread.is_alive()
+    assert len(calls) == 1
+    with app.app.app_context():
+        completed = ProvisioningJob.query.filter_by(
+            idempotency_key=hashlib.sha256(
+                b"postgres-concurrency"
+            ).hexdigest()
+        ).one()
+        assert completed.state == "completed"
     dispose_operational_engines()

--- a/tests/test_provisioning_worker.py
+++ b/tests/test_provisioning_worker.py
@@ -1,5 +1,8 @@
 import hashlib
 
+from cryptography.fernet import Fernet
+import pytest
+
 import app
 from app import (
     DatabaseRoutingMetadata,
@@ -8,29 +11,41 @@ from app import (
     Unit,
     db,
 )
-from platform_provisioning import ProvisioningWorker, pop_one_time_token
+import platform_provisioning
+from platform_provisioning import (
+    ProvisioningWorker,
+    TokenEnvelopeError,
+    pop_one_time_token,
+    store_one_time_token,
+)
 
 
 def _job(tmp_path, monkeypatch):
     db.drop_all()
     db.create_all()
     unit = Unit(
-        code="WRK", name="Worker Test", status="provisioning",
+        code="WRK",
+        name="Worker Test",
+        status="provisioning",
         active_user_limit=3,
     )
     db.session.add(unit)
     db.session.flush()
     secret_name = f"ATCROSTER_UNIT_{unit.id}_DATABASE_URL"
-    monkeypatch.setenv(
-        secret_name, f"sqlite:///{tmp_path / 'operational.db'}"
+    monkeypatch.setenv(secret_name, f"sqlite:///{tmp_path / 'operational.db'}")
+    db.session.add(
+        DatabaseRoutingMetadata(
+            unit_id=unit.id,
+            secret_name=secret_name,
+            provisioning_state="queued",
+        )
     )
-    db.session.add(DatabaseRoutingMetadata(
-        unit_id=unit.id, secret_name=secret_name,
-        provisioning_state="queued",
-    ))
     job = ProvisioningJob(
-        unit_id=unit.id, idempotency_key=hashlib.sha256(b"worker").hexdigest(),
-        state="queued", active_key="active", next_attempt_at=app.utcnow(),
+        unit_id=unit.id,
+        idempotency_key=hashlib.sha256(b"worker").hexdigest(),
+        state="queued",
+        active_key="active",
+        next_attempt_at=app.utcnow(),
     )
     db.session.add(job)
     db.session.commit()
@@ -50,8 +65,8 @@ def test_worker_completes_once_and_token_is_one_time(tmp_path, monkeypatch):
         invitations = SecureInvitation.query.filter_by(unit_id=unit_id).all()
         assert len(invitations) == 1
         assert invitations[0].active_bootstrap_key == "active"
-    assert pop_one_time_token(job_id)
-    assert pop_one_time_token(job_id) is None
+    assert pop_one_time_token(job_id, unit_id)
+    assert pop_one_time_token(job_id, unit_id) is None
 
 
 def test_worker_recovers_abandoned_job(tmp_path, monkeypatch):
@@ -59,10 +74,60 @@ def test_worker_recovers_abandoned_job(tmp_path, monkeypatch):
         _unit_id, job_id = _job(tmp_path, monkeypatch)
         job = db.session.get(ProvisioningJob, job_id)
         job.state = "running"
-        job.locked_at = app.utcnow() - app.timedelta(minutes=20)
+        job.lease_owner = "crashed-worker"
+        job.lease_expires_at = app.utcnow() - app.timedelta(seconds=1)
         db.session.commit()
     worker = ProvisioningWorker(app.app)
     assert worker.recover_stale_jobs() == 1
     assert worker.run_once()
     with app.app.app_context():
         assert db.session.get(ProvisioningJob, job_id).state == "completed"
+
+
+def test_unexpired_lease_is_not_recovered(tmp_path, monkeypatch):
+    with app.app.app_context():
+        _unit_id, job_id = _job(tmp_path, monkeypatch)
+        job = db.session.get(ProvisioningJob, job_id)
+        job.state = "running"
+        job.lease_owner = "live-worker"
+        job.lease_expires_at = app.utcnow() + app.timedelta(minutes=30)
+        db.session.commit()
+    assert ProvisioningWorker(app.app).recover_stale_jobs() == 0
+    with app.app.app_context():
+        assert db.session.get(ProvisioningJob, job_id).state == "running"
+
+
+def test_token_envelope_is_ciphertext_versioned_and_bound(monkeypatch):
+    key = Fernet.generate_key().decode()
+    monkeypatch.setenv("ATCROSTER_TOKEN_ENCRYPTION_KEYS", f"v7:{key}")
+    raw = "sensitive-bootstrap-token"
+    store_one_time_token(91, 17, raw)
+    stored = platform_provisioning._development_tokens[91]
+    assert stored.startswith("v7.")
+    assert raw not in stored
+    with pytest.raises(TokenEnvelopeError, match="binding"):
+        pop_one_time_token(91, 18)
+
+
+def test_token_envelope_rejects_unknown_key_version(monkeypatch):
+    first = Fernet.generate_key().decode()
+    second = Fernet.generate_key().decode()
+    monkeypatch.setenv("ATCROSTER_TOKEN_ENCRYPTION_KEYS", f"v1:{first}")
+    store_one_time_token(92, 17, "one-time")
+    monkeypatch.setenv("ATCROSTER_TOKEN_ENCRYPTION_KEYS", f"v2:{second}")
+    with pytest.raises(TokenEnvelopeError, match="version"):
+        pop_one_time_token(92, 17)
+
+
+def test_token_envelope_store_failure_is_safe(monkeypatch):
+    class FailedCache:
+        def set(self, *_args, **_kwargs):
+            return False
+
+    monkeypatch.setattr(platform_provisioning, "_token_cache", lambda: FailedCache())
+    monkeypatch.setenv(
+        "ATCROSTER_TOKEN_ENCRYPTION_KEYS",
+        f"v1:{Fernet.generate_key().decode()}",
+    )
+    with pytest.raises(TokenEnvelopeError, match="store"):
+        store_one_time_token(93, 17, "one-time")

--- a/tests/test_redis_integration.py
+++ b/tests/test_redis_integration.py
@@ -1,0 +1,27 @@
+import os
+import secrets
+
+import pytest
+
+from rate_limiting import RedisRateLimiter
+
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("REDIS_URL"),
+    reason="REDIS_URL is required for the distributed integration suite",
+)
+
+
+def test_rate_limit_is_shared_across_independent_instances():
+    import redis
+
+    client_a = redis.from_url(os.environ["REDIS_URL"], decode_responses=True)
+    client_b = redis.from_url(os.environ["REDIS_URL"], decode_responses=True)
+    prefix = f"atcroster:test:{secrets.token_hex(8)}"
+    first = RedisRateLimiter(client_a, prefix=prefix)
+    second = RedisRateLimiter(client_b, prefix=prefix)
+    assert first.consume("opaque-subject", 2, 60)
+    assert second.consume("opaque-subject", 2, 60)
+    assert not first.consume("opaque-subject", 2, 60)
+    second.reset("opaque-subject")
+    assert first.consume("opaque-subject", 2, 60)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -320,6 +320,9 @@ def test_security_headers_are_present(client):
     assert response.headers["Content-Security-Policy"].startswith(
         "default-src 'self'"
     )
+    policy = response.headers["Content-Security-Policy"]
+    assert "script-src 'self' 'nonce-" in policy
+    assert "script-src 'self' 'unsafe-inline'" not in policy
 
 
 def test_role_permission_matrix_and_cross_airport_isolation():
@@ -1247,7 +1250,7 @@ def test_mfa_challenge_completes_login(client):
         db.session.add(app.MfaCredential(
             unit_id=admin.unit_id,
             person_id=admin.id,
-            encrypted_secret=app._field_cipher().encrypt(secret.encode()).decode(),
+            encrypted_secret=app._encrypt_field(secret),
             enabled=True,
             enrolled_at=app.utcnow(),
         ))
@@ -1268,6 +1271,43 @@ def test_mfa_challenge_completes_login(client):
     )
     assert verified.status_code == 302
     assert "/roster/" in client.get("/", follow_redirects=False).headers["Location"]
+
+
+def test_continuous_activity_cannot_extend_absolute_session(client):
+    login(client)
+    with client.session_transaction() as session:
+        session["_last_seen_epoch"] = int(app.utcnow().timestamp())
+        session["_session_started_at"] = (
+            app.utcnow() - app.timedelta(minutes=721)
+        ).isoformat()
+    response = client.get("/", follow_redirects=False)
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+    with client.session_transaction() as session:
+        assert "_user_id" not in session
+
+
+def test_privilege_change_forces_existing_session_invalidation(client):
+    login(client)
+    with app.app.app_context():
+        admin = Staff.query.filter_by(
+            username=ADMIN_CREDENTIALS["username"]
+        ).one()
+        admin.role = "user"
+        db.session.commit()
+    try:
+        response = client.get("/", follow_redirects=False)
+        assert response.status_code == 302
+        assert "/login" in response.headers["Location"]
+        with client.session_transaction() as session:
+            assert "_user_id" not in session
+    finally:
+        with app.app.app_context():
+            admin = Staff.query.filter_by(
+                username=ADMIN_CREDENTIALS["username"]
+            ).one()
+            admin.role = "admin"
+            db.session.commit()
 
 
 def test_airport_absence_catalogue_and_calendar_token(client):


### PR DESCRIPTION
## Summary

- restores the digest-pinned Python 3.12 production runtime and separates production, development, and desktop dependencies
- repairs CodeQL action consistency and groups/limits Dependabot updates
- adds renewable provisioning leases, PostgreSQL advisory locking, worker heartbeat diagnostics, and encrypted one-time Redis bootstrap envelopes
- enforces idle and absolute session expiry, session regeneration and forced invalidation, nonce-based script CSP, trusted hosts/proxies, database timeouts, versioned field encryption, and rotation support
- expands the PostgreSQL/Redis integration coverage and documents repository protection and production operations

## Root cause

A Python 3.14 container update exceeded the supported dependency/runtime boundary, while earlier hardening left provisioning locks non-renewable, transient bootstrap tokens plaintext, absolute sessions unenforced, and several deployment controls incomplete.

## Validation

- Python 3.12: 95 passed, 2 external-service tests skipped in the ordinary suite
- PostgreSQL/Redis integration: 2 passed against one control DB, two physical airport DBs, and Redis
- legacy migration fixtures: 5 passed
- fresh control and operational migrations: both reached 20260726_13
- Ruff formatting/lint, mypy, Bandit: passed
- pip-audit: no known vulnerabilities
- production container build: passed; non-root and production-only dependency boundary verified
- Trivy HIGH/CRITICAL: 0 findings
- Docker Compose: control DB, two airport DBs, Redis, web, worker started; readiness HTTP 200 and worker heartbeat fresh

## Deployment impact

Run control and operational migrations before starting web/worker. Configure the new versioned field/token encryption key rings, trusted-host/proxy settings, two airport database secrets where using the reference Compose topology, and the documented pool/session settings. No deployment is performed by this PR.