### PR TITLE
Fix watch pattern phasing and night counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,9 @@ Configure the repeating roster in **Admin → Roster setup**:
 2. Select the weekdays on which the unit operates a night duty. An `N` that
    falls on a closed night is displayed as `OFF` without shifting the
    underlying cycle.
-3. Add and name the required watches. A watch may inherit the unit pattern or
-   define its own pattern and day-1 date.
+3. Add and name the required watches. Every watch has its own day-1 date,
+   which phases the inherited unit pattern; a watch may instead define a
+   different pattern while retaining that watch-specific phase.
 
 Pattern precedence is **personal ATCO override → effective watch pattern →
 unit base pattern**. Personal patterns are configured on the ATCO profile and
@@ -157,7 +158,9 @@ The roster footer does not infer custom codes by their first letter. In
 **Admin → Shifts → Roster count mapping**, explicitly map each operational
 shift to `M`, `D`, `A`, or `N`; map leave, training, standby and support codes
 to **Not counted**. The same mapping is used by the on-screen totals, CSV
-export, coverage heatmap and publication readiness checks.
+export, coverage heatmap and publication readiness checks. A pattern letter
+does not count unless the airport has created the corresponding working shift,
+and Night totals are suppressed on weekdays when night operations are closed.
 
 To move an ATCO, open their Admin profile and use **Schedule a watch move**.
 On the effective date, roster generation picks up the new watch and its

--- a/app.py
+++ b/app.py
@@ -1666,14 +1666,37 @@ def shift_counter_group(
     value = (code or "").strip().upper()
     if not value:
         return ""
-    mapping = get_shift_counter_map(unit_id)
+    resolved_unit_id = int(unit_id or _current_unit_id() or 1)
+    mapping = get_shift_counter_map(resolved_unit_id)
     if value in mapping:
         return mapping[value]
+    # Legacy default grouping is only valid for a working shift that actually
+    # exists for this airport. Pattern letters are not, by themselves, enough
+    # to claim that somebody is covering that staffing group.
+    shift = get_shift(value, resolved_unit_id)
+    if (
+        not shift
+        or not shift.is_active
+        or not shift.is_working
+        or shift.is_training
+    ):
+        return ""
     if value == "EM":
         return "M"
     if value == "LA":
         return "A"
     return value if value in {"M", "D", "A", "N"} else ""
+
+
+def shift_counter_group_for_day(
+    code: str | None, on_date: date, unit_id: int | None = None
+) -> str:
+    """Return the staffing group, suppressing nights when the unit is closed."""
+    resolved_unit_id = int(unit_id or _current_unit_id() or 1)
+    group = shift_counter_group(code, resolved_unit_id)
+    if group == "N" and not _night_active_on(resolved_unit_id, on_date):
+        return ""
+    return group
 
 
 @lru_cache(maxsize=128)
@@ -2179,12 +2202,18 @@ def _pattern_context(staff: Staff, on_date: date) -> tuple[list[str], date]:
         personal = _validated_pattern(staff.pattern_csv)
         if personal:
             return personal, staff.pattern_anchor or on_date
+    unit_pattern, unit_anchor = _unit_pattern_context(staff.unit_id)
     watch = _effective_watch(staff, on_date)
     if watch:
         watch_pattern = _validated_pattern(watch.pattern_csv)
-        if watch_pattern:
-            return watch_pattern, watch.pattern_anchor or on_date
-    return _unit_pattern_context(staff.unit_id)
+        # A watch anchor phases both a watch-specific pattern and the inherited
+        # unit pattern. This is what makes two watches on the same base cycle
+        # start on different cycle days.
+        return (
+            watch_pattern or unit_pattern,
+            watch.pattern_anchor or unit_anchor,
+        )
+    return unit_pattern, unit_anchor
 
 
 def pattern_for(staff: Staff, on_date: date | None = None):
@@ -4246,8 +4275,8 @@ def _publication_preflight(year: int, month: int) -> dict:
                 shift and shift.is_working and not shift.is_training
                 and assignment.code not in get_exclude_from_counters()
             ):
-                group = shift_counter_group(
-                    assignment.code, _current_unit_id()
+                group = shift_counter_group_for_day(
+                    assignment.code, day, _current_unit_id()
                 )
                 if group:
                     counts[day][group] += 1
@@ -4255,7 +4284,15 @@ def _publication_preflight(year: int, month: int) -> dict:
     coverage_gaps = []
     for day in days:
         for group in ("M", "D", "A", "N"):
-            needed = int(getattr(requirement, f"req_{group.lower()}", 0) or 0)
+            needed = (
+                0
+                if group == "N" and not _night_active_on(
+                    _current_unit_id(), day
+                )
+                else int(
+                    getattr(requirement, f"req_{group.lower()}", 0) or 0
+                )
+            )
             available = counts[day][group]
             if available < needed:
                 coverage_gaps.append({
@@ -4592,7 +4629,7 @@ def roster_month(ym):
             # Explicit exclusions
             if c in ("AL", "NOPS"):
                 continue
-            grp = shift_counter_group(c, unit_id)
+            grp = shift_counter_group_for_day(c, d, unit_id)
             if grp:
                 counters[d][grp] += 1
     rag = {}
@@ -4863,7 +4900,9 @@ def roster_export_csv(ym):
             sh = get_shift(c) if c else None
             if not c or not sh or sh.is_training:
                 continue
-            grp = shift_counter_group(c, _current_unit_id())
+            grp = shift_counter_group_for_day(
+                c, d, _current_unit_id()
+            )
             if grp:
                 counters[d][grp] += 1
 
@@ -4874,7 +4913,13 @@ def roster_export_csv(ym):
         rag[d] = {}
         for code in ("M", "D", "A", "N"):
             have = counters[d][code]
-            need = getattr(req, f"req_{code.lower()}") if req else 0
+            need = (
+                0
+                if code == "N" and not _night_active_on(
+                    _current_unit_id(), d
+                )
+                else getattr(req, f"req_{code.lower()}") if req else 0
+            )
             rag[d][code] = (
                 "green" if have >= need
                 else ("amber" if have >= max(0, need - 1) else "red")
@@ -9484,8 +9529,8 @@ def coverage_heatmap(ym):
         shift = ShiftType.query.filter_by(
             unit_id=_current_unit_id(), code=assignment.code
         ).first()
-        group = shift_counter_group(
-            assignment.code, _current_unit_id()
+        group = shift_counter_group_for_day(
+            assignment.code, assignment.day, _current_unit_id()
         )
         if not group:
             continue

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -85,7 +85,7 @@
               <button type="button" class="btn btn-sm" data-clear-pattern>Use unit pattern</button>
             </div>
           </div>
-          <label>Pattern day 1 starts on<input type="date" name="pattern_anchor" value="{{ watch.pattern_anchor.isoformat() if watch.pattern_anchor else '' }}"><small>Required only when this watch has its own pattern.</small></label>
+          <label>Pattern day 1 starts on<input type="date" name="pattern_anchor" value="{{ watch.pattern_anchor.isoformat() if watch.pattern_anchor else '' }}"><small>This phases the watch even when it inherits the unit pattern.</small></label>
           <button class="btn btn-primary" type="submit">Save {{ watch.name }}</button>
         </form>
         <form method="post" class="admin-danger-action" data-confirm="Delete {{ watch.name }}?">
@@ -113,7 +113,7 @@
               <button type="button" class="btn btn-sm" data-clear-pattern>Clear</button>
             </div>
           </div>
-          <label>Pattern day 1 starts on<input type="date" name="pattern_anchor"></label>
+          <label>Pattern day 1 starts on<input type="date" name="pattern_anchor"><small>This phases either the unit pattern or the optional watch pattern.</small></label>
           <button class="btn btn-primary" type="submit">Add watch</button>
         </form>
       </article>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1105,6 +1105,38 @@ def test_admin_can_map_created_shifts_to_roster_counts(client):
         app.refresh_roster_settings_cache()
 
 
+def test_counter_requires_created_shift_and_respects_closed_nights(client):
+    monday = date(2026, 7, 27)
+    tuesday = date(2026, 7, 28)
+    with app.app.app_context():
+        night_setting = app.RosterSetting.query.filter_by(
+            unit_id=1, key="night_active_weekdays"
+        ).first()
+        if not night_setting:
+            night_setting = app.RosterSetting(
+                unit_id=1, key="night_active_weekdays"
+            )
+            db.session.add(night_setting)
+        night_setting.value = "0"
+        mapping_setting = app.RosterSetting.query.filter_by(
+            unit_id=1, key="shift_counter_map"
+        ).first()
+        if not mapping_setting:
+            mapping_setting = app.RosterSetting(
+                unit_id=1, key="shift_counter_map"
+            )
+            db.session.add(mapping_setting)
+        mapping = json.loads(mapping_setting.value or "{}")
+        mapping["N"] = "N"
+        mapping_setting.value = json.dumps(mapping)
+        db.session.commit()
+        app.refresh_roster_settings_cache()
+
+        assert app.shift_counter_group_for_day("N", monday, 1) == "N"
+        assert app.shift_counter_group_for_day("N", tuesday, 1) == ""
+        assert app.shift_counter_group("UNCREATED", 1) == ""
+
+
 def test_manual_toil_form_submits_and_can_add_or_deduct(client):
     login(client)
     with app.app.app_context():
@@ -1299,9 +1331,15 @@ def test_unit_watch_and_personal_pattern_inheritance(client):
         )
         person.set_password("password123")
         db.session.add(person)
-        db.session.add(app.RosterSetting(
-            unit_id=1, key="night_active_weekdays", value="0"
-        ))
+        night_setting = app.RosterSetting.query.filter_by(
+            unit_id=1, key="night_active_weekdays"
+        ).first()
+        if not night_setting:
+            night_setting = app.RosterSetting(
+                unit_id=1, key="night_active_weekdays"
+            )
+            db.session.add(night_setting)
+        night_setting.value = "0"
         db.session.commit()
         app.refresh_roster_settings_cache()
 
@@ -1315,6 +1353,26 @@ def test_unit_watch_and_personal_pattern_inheritance(client):
             effective_date=date(2026, 7, 28),
         ))
         db.session.commit()
+        assert app.code_from_pattern(
+            person, date(2026, 7, 28)
+        ) == "A"
+
+        watch_a.pattern_csv = ""
+        watch_a.pattern_anchor = anchor
+        for key, value in (
+            ("base_pattern_csv", "M,A,OFF"),
+            ("base_pattern_anchor", "2026-07-26"),
+        ):
+            setting = app.RosterSetting.query.filter_by(
+                unit_id=1, key=key
+            ).first()
+            if not setting:
+                setting = app.RosterSetting(unit_id=1, key=key)
+                db.session.add(setting)
+            setting.value = value
+        db.session.commit()
+        app.refresh_roster_settings_cache()
+        assert app.code_from_pattern(person, anchor) == "M"
         assert app.code_from_pattern(
             person, date(2026, 7, 28)
         ) == "A"


### PR DESCRIPTION
## Summary
- phase inherited unit patterns from each watch start date
- count only created working shifts and suppress nights when the unit is closed
- apply the same counter rules to roster, CSV, coverage, and publication checks
- document the corrected setup behaviour

## Verification
- `pytest -q` (107 passed, 2 skipped)
- targeted regression tests for watch inheritance and closed-night counters
- `git diff --check`