### PR TITLE
Prevent fatigue warnings on rest days

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,8 +359,9 @@ the current airport’s qualification records only.
 ### Fatigue monitoring
 
 Automatic fatigue findings remain visible on the affected roster cells, with
-the rule explanation available from the cell warning. The standalone
-Compliance Centre is not part of the application navigation.
+the rule explanation available from the cell warning. Rest days and any other
+shift marked non-working are never displayed as fatigue-warning cells. The
+standalone Compliance Centre is not part of the application navigation.
 
 Unit Admins use **Admin → Fatigue rules** (`/admin/fatigue-rules`) to control
 roster monitoring:

--- a/app.py
+++ b/app.py
@@ -2985,6 +2985,28 @@ def fatigue_flags_for_range(staff: Staff, day_list, lookback_days=30):
     }
 
 
+def roster_fatigue_flags_for_range(
+    staff: Staff,
+    day_list,
+    code_by_day: dict[date, str],
+    unit_id: int | None = None,
+) -> dict[date, list[str]]:
+    """Expose fatigue warnings only on active working-duty roster cells."""
+    resolved_unit_id = int(unit_id or staff.unit_id)
+    findings = fatigue_flags_for_range(staff, day_list)
+    return {
+        finding_day: messages
+        for finding_day, messages in findings.items()
+        if (
+            (shift := get_shift(
+                code_by_day.get(finding_day), resolved_unit_id
+            ))
+            and shift.is_active
+            and shift.is_working
+        )
+    }
+
+
 def would_trigger_fatigue(staff: Staff, day: date, code: str):
     sh = get_shift(code)
     if not _is_working(sh):
@@ -4613,7 +4635,12 @@ def roster_month(ym):
     # Fatigue flags keyed by staff id -> {date -> [flags]}
     # Assumes you have a helper like fatigue_flags_for_range(person, days)
     try:
-        fatigue = {s.id: fatigue_flags_for_range(s, days) for s in staff}
+        fatigue = {
+            s.id: roster_fatigue_flags_for_range(
+                s, days, a_map.get(s.id, {}), unit_id
+            )
+            for s in staff
+        }
     except NameError:
         # If your helper is named differently, fall back to empty flags.
         # (Prevents NameError, but you should wire the real helper.)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1138,6 +1138,34 @@ def test_counter_requires_created_shift_and_respects_closed_nights(client):
         assert app.shift_counter_group("UNCREATED", 1) == ""
 
 
+def test_roster_never_shows_fatigue_warning_on_off_shift(
+    client, monkeypatch
+):
+    warning_day = date(2025, 4, 1)
+    with app.app.app_context():
+        person = Staff.query.filter_by(unit_id=1).first()
+        assert person is not None
+        monkeypatch.setattr(
+            app,
+            "fatigue_flags_for_range",
+            lambda *_args, **_kwargs: {
+                warning_day: ["stale warning must not appear"]
+            },
+        )
+
+        visible = app.roster_fatigue_flags_for_range(
+            person, [warning_day], {warning_day: "OFF"}, 1
+        )
+        assert visible == {}
+
+        visible_working = app.roster_fatigue_flags_for_range(
+            person, [warning_day], {warning_day: "M"}, 1
+        )
+        assert visible_working == {
+            warning_day: ["stale warning must not appear"]
+        }
+
+
 def test_manual_toil_form_submits_and_can_add_or_deduct(client):
     login(client)
     with app.app.app_context():


### PR DESCRIPTION
## Summary
- filter roster fatigue warnings against the cell current shift definition
- never render a warning on OFF, inactive, or other non-working shifts
- retain all working-duty fatigue calculations and hover explanations
- document the invariant and add regression coverage

## Verification
- `pytest -q` (108 passed, 2 skipped)
- targeted OFF/working-shift fatigue tests
- `git diff --check`