### PR TITLE
Add copy-below staffing requirements action

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ attention. It is divided into focused sections:
 - **Roster setup** defines the unit base cycle, the weekdays on which night
   duties operate, and the unit's named watches.
 - **Staffing levels** edits monthly Morning, Day, Afternoon, and Night minimums
-  across a rolling 24-month planning window.
+  across a rolling 24-month planning window. **Copy below** repeats one
+  month's four values into every later row for review before saving.
 - **Shifts** creates shift definitions and keeps existing definitions collapsed
   until an administrator chooses one to edit. Its **Roster count mapping**
   assigns every created shift to the Morning, Day, Afternoon, Night, or

--- a/static/styles.css
+++ b/static/styles.css
@@ -1360,6 +1360,15 @@ tfoot td{background:var(--card); font-weight:bold; color:var(--text);}
 
 .table-scroll table{min-width:620px;}
 
+.requirements-copy-button{font-size:.78rem; padding:.34rem .5rem;}
+.requirements-copy-button:disabled{opacity:.38; cursor:not-allowed;}
+.requirements-row--copied{background:rgba(108,179,255,.055);}
+.requirements-copy-status{
+  margin:-.55rem 0 0;
+  color:var(--text-muted);
+  font-size:.84rem;
+}
+
 .inline-form{display:flex; flex-wrap:wrap; gap:.5rem 1rem; align-items:center;}
 
 .inline-form--tight{gap:.4rem .75rem; justify-content:flex-start;}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -129,21 +129,30 @@
       <input type="hidden" name="form" value="req">
       <div class="table-scroll admin-requirements-table">
         <table class="mini admin-table">
-          <thead><tr><th>Month</th><th>Morning (M)</th><th>Day (D)</th><th>Afternoon (A)</th><th>Night (N)</th></tr></thead>
+          <thead><tr><th>Month</th><th>Morning (M)</th><th>Day (D)</th><th>Afternoon (A)</th><th>Night (N)</th><th>Apply</th></tr></thead>
           <tbody>
           {% for y,m in months %}
             {% set r = requirements_by_month.get((y,m)) %}
-            <tr>
+            <tr data-requirement-row>
               <td class="table-label"><input type="hidden" name="ym" value="{{ '%04d-%02d'|format(y,m) }}">{{ ['January','February','March','April','May','June','July','August','September','October','November','December'][m-1] }} {{ y }}</td>
               <td><input type="number" min="0" name="req_m" value="{{ r.req_m if r else 0 }}" class="table-input" aria-label="Morning requirement for {{ '%04d-%02d'|format(y,m) }}"></td>
               <td><input type="number" min="0" name="req_d" value="{{ r.req_d if r else 0 }}" class="table-input" aria-label="Day requirement for {{ '%04d-%02d'|format(y,m) }}"></td>
               <td><input type="number" min="0" name="req_a" value="{{ r.req_a if r else 0 }}" class="table-input" aria-label="Afternoon requirement for {{ '%04d-%02d'|format(y,m) }}"></td>
               <td><input type="number" min="0" name="req_n" value="{{ r.req_n if r else 0 }}" class="table-input" aria-label="Night requirement for {{ '%04d-%02d'|format(y,m) }}"></td>
+              <td class="table-actions">
+                <button type="button" class="btn btn-sm requirements-copy-button"
+                        data-copy-requirements-below
+                        aria-label="Copy {{ ['January','February','March','April','May','June','July','August','September','October','November','December'][m-1] }} {{ y }} requirements to every month below"
+                        {% if loop.last %}disabled title="There are no months below this row"{% endif %}>
+                  <i class="fa-solid fa-arrow-down" aria-hidden="true"></i> Copy below
+                </button>
+              </td>
             </tr>
           {% endfor %}
           </tbody>
         </table>
       </div>
+      <p class="requirements-copy-status" data-requirements-copy-status aria-live="polite">Copied values are not saved until you select Save requirements.</p>
       <div class="admin-sticky-actions"><span>Changes apply to this airport only.</span><button class="btn btn-primary" type="submit">Save requirements</button></div>
     </form>
   </section>
@@ -324,6 +333,39 @@
       if (matches) visible++;
     });
     if (empty) empty.hidden = visible !== 0;
+  });
+  const requirementRows = [
+    ...document.querySelectorAll('[data-requirement-row]')
+  ];
+  const requirementFields = ['req_m', 'req_d', 'req_a', 'req_n'];
+  const copyStatus = document.querySelector(
+    '[data-requirements-copy-status]'
+  );
+  requirementRows.forEach((row, rowIndex) => {
+    const button = row.querySelector('[data-copy-requirements-below]');
+    button?.addEventListener('click', () => {
+      const sourceValues = Object.fromEntries(
+        requirementFields.map(name => [
+          name, row.querySelector(`[name="${name}"]`).value
+        ])
+      );
+      const laterRows = requirementRows.slice(rowIndex + 1);
+      laterRows.forEach(laterRow => {
+        requirementFields.forEach(name => {
+          const input = laterRow.querySelector(`[name="${name}"]`);
+          input.value = sourceValues[name];
+          input.dispatchEvent(new Event('input', { bubbles: true }));
+        });
+        laterRow.classList.add('requirements-row--copied');
+      });
+      if (copyStatus) {
+        const month = row.querySelector('[name="ym"]').value;
+        copyStatus.textContent = (
+          `Copied ${month} requirements to ${laterRows.length} month` +
+          `${laterRows.length === 1 ? '' : 's'} below. Review and save.`
+        );
+      }
+    });
   });
   document.querySelectorAll('[data-pattern-builder]').forEach(builder => {
     const input = builder.querySelector('[data-pattern-value]');

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1106,6 +1106,17 @@ def test_admin_can_map_created_shifts_to_roster_counts(client):
         app.refresh_roster_settings_cache()
 
 
+def test_staffing_requirements_rows_offer_copy_below(client):
+    login(client)
+    page = client.get("/admin")
+    assert page.status_code == 200
+    assert page.data.count(b"<tr data-requirement-row>") == 24
+    assert page.data.count(b'aria-label="Copy ') == 24
+    assert b"Copy below" in page.data
+    assert b"data-requirements-copy-status" in page.data
+    assert b"requirementRows.slice(rowIndex + 1)" in page.data
+
+
 def test_counter_requires_created_shift_and_respects_closed_nights(client):
     monday = date(2026, 7, 27)
     tuesday = date(2026, 7, 28)


### PR DESCRIPTION
## Summary
- add Copy below to every monthly staffing-requirements row
- copy M/D/A/N values into every later month without auto-saving
- provide accessible labels, live feedback, and disabled final-row state
- update the user manual and regression coverage

## Verification
- `pytest -q` (109 passed, 2 skipped)
- requirements-table markup and behaviour contract regression test
- `git diff --check`