### PR TITLE
Refine roster annotation display and detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,12 @@ definitions. Watch and deputy watch managers receive only their explicitly
 configured permissions. Unit-Admin-only annotations return a permission error
 for other roles.
 
+On the roster, the annotation selector returns to **—** after each action and
+the applied code appears once as a compact yellow label beneath the shift.
+Select the pencil beside that label to add or edit optional detail; the detail
+is shown when the code is hovered or keyboard-focused. Use **Remove [code]**
+in the selector to clear an applied annotation.
+
 Application/removal and definition changes are audited. TOIL updates and the
 annotation assignment occur in one database transaction. Optional transaction
 keys make retries idempotent so TOIL is not applied twice.

--- a/app.py
+++ b/app.py
@@ -1355,6 +1355,8 @@ class Assignment(db.Model):
     note = db.Column(db.String(140), default="")
     # Annotation code (managed via AnnotationType, optional suffix like A6M)
     annotation = db.Column(db.String(20), default="")
+    # User-facing detail for the annotation. Kept separate from system notes.
+    annotation_note = db.Column(db.String(140), default="")
     __table_args__ = (db.UniqueConstraint(
         "unit_id", "staff_id", "day", name="uniq_unit_staff_day"),)
 
@@ -1945,14 +1947,17 @@ def _load_month_roster_core(unit_id: int, y: int, m: int):
             Assignment.day,
             Assignment.code,
             Assignment.source,
-            Assignment.annotation
+            Assignment.annotation,
+            Assignment.annotation_note,
         )
             .filter(Assignment.day >= start, Assignment.day < end)
             .all())
 
         a_map = {}
-        for sid, d, code, source, ann in rows:
-            a_map.setdefault(sid, {})[d] = (code, source, ann)
+        for sid, d, code, source, ann, ann_note in rows:
+            a_map.setdefault(sid, {})[d] = (
+                code, source, ann, ann_note or ""
+            )
 
         req = Requirement.query.filter_by(year=y, month=m).first()
         if not req:
@@ -4542,17 +4547,21 @@ def roster_month(ym):
         return 0 if getattr(person, "is_wm", False) else (1 if getattr(person, "is_dwm", False) else 2)
 
     # Build code_map (what the template expects) and ann_map from the tuples
-    # a_map_tuples[sid][day] = (code, source, annotation)
+    # a_map_tuples[sid][day] = (code, source, annotation, annotation note)
     a_map: dict[int, dict[date, str]] = {}
     ann_map: dict[int, dict[date, str]] = {}
+    ann_note_map: dict[int, dict[date, str]] = {}
     for sid, dmap in a_map_tuples.items():
         codes = {}
         anns = {}
-        for d, (code, _src, ann) in dmap.items():
+        ann_notes = {}
+        for d, (code, _src, ann, ann_note) in dmap.items():
             codes[d] = code
             anns[d] = ann or ""
+            ann_notes[d] = ann_note or ""
         a_map[sid] = codes
         ann_map[sid] = anns
+        ann_note_map[sid] = ann_notes
 
     # Prev/next month strings
     py, pm = _month_add(year, month, -1)
@@ -4717,6 +4726,7 @@ def roster_month(ym):
         staff=staff,
         a_map=a_map,
         ann_map=ann_map,             # <<< required by template
+        ann_note_map=ann_note_map,
         counters=counters,
         req=req,                     # <<< ensure 'req' exists for template
         requirement=req,             # <<< keep this if any blocks expect 'requirement'
@@ -4805,30 +4815,33 @@ def assign_cell(staff_id, ym, day):
             abort(403)
         old = a.annotation or ""
         newv = (annot or "").strip().upper()
+        if newv == "__REMOVE__":
+            newv = ""
+        note_was_posted = "annotation_detail_update" in request.form
+        annotation_note = (
+            request.form.get("annotation_note") or ""
+        ).strip()[:140]
+        parsed = parse_annotation(newv) if newv else None
+        ann_def = None
+        if parsed:
+            ann_def = AnnotationType.query.filter_by(
+                unit_id=unit_id, code=parsed["type"]
+            ).first()
+        if newv and (not parsed or not ann_def):
+            flash(f"Unknown annotation '{newv}'.", "error")
+            return redirect(url_for("roster_month", ym=ym))
+        if ann_def and not ann_def.is_active and old != newv:
+            flash(
+                f"{ann_def.code} is inactive and cannot be newly applied.",
+                "error",
+            )
+            return redirect(url_for("roster_month", ym=ym))
+        if ann_def and ann_def.admin_only and not is_admin_user(current_user):
+            abort(403)
+        if ann_def and ann_def.note_required and not annotation_note:
+            flash(f"{ann_def.code} requires a note.", "error")
+            return redirect(url_for("roster_month", ym=ym))
         if old != newv:
-            parsed = parse_annotation(newv) if newv else None
-            ann_def = None
-            if parsed:
-                ann_def = AnnotationType.query.filter_by(
-                    unit_id=unit_id, code=parsed["type"]
-                ).first()
-            if newv and (not parsed or not ann_def):
-                flash(f"Unknown annotation '{newv}'.", "error")
-                return redirect(url_for("roster_month", ym=ym))
-            if ann_def and not ann_def.is_active:
-                flash(
-                    f"{ann_def.code} is inactive and cannot be newly applied.",
-                    "error",
-                )
-                return redirect(url_for("roster_month", ym=ym))
-            if ann_def and ann_def.admin_only and not is_admin_user(current_user):
-                abort(403)
-            annotation_note = (
-                request.form.get("annotation_note") or ""
-            ).strip()
-            if ann_def and ann_def.note_required and not annotation_note:
-                flash(f"{ann_def.code} requires a note.", "error")
-                return redirect(url_for("roster_month", ym=ym))
             transaction_key = (request.form.get("transaction_key") or "").strip()[:64]
             if transaction_key and AnnotationAudit.query.filter_by(
                 unit_id=unit_id, transaction_key=transaction_key
@@ -4837,8 +4850,7 @@ def assign_cell(staff_id, ym, day):
             _apply_toil_annotation_delta(
                 staff=st, old_annot=old, new_annot=newv)
             a.annotation = newv
-            if annotation_note:
-                a.note = annotation_note[:140]
+            a.annotation_note = annotation_note if newv else ""
             if ann_def:
                 ann_def.has_been_used = True
             db.session.flush()
@@ -4849,6 +4861,8 @@ def assign_cell(staff_id, ym, day):
                 old_value=old, new_value=newv,
                 transaction_key=transaction_key or None,
             ))
+        elif note_was_posted:
+            a.annotation_note = annotation_note
 
     db.session.commit()
     return redirect(url_for("roster_month", ym=ym))

--- a/migrations/versions/20260727_16_annotation_detail.py
+++ b/migrations/versions/20260727_16_annotation_detail.py
@@ -1,0 +1,37 @@
+"""Store user-facing annotation detail separately from assignment notes."""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision = "20260727_16"
+down_revision = "20260727_15"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    inspector = inspect(op.get_bind())
+    if "assignment" not in inspector.get_table_names():
+        return
+    columns = {column["name"] for column in inspector.get_columns("assignment")}
+    if "annotation_note" not in columns:
+        with op.batch_alter_table("assignment") as batch:
+            batch.add_column(
+                sa.Column(
+                    "annotation_note",
+                    sa.String(length=140),
+                    nullable=False,
+                    server_default="",
+                )
+            )
+
+
+def downgrade():
+    inspector = inspect(op.get_bind())
+    if "assignment" not in inspector.get_table_names():
+        return
+    columns = {column["name"] for column in inspector.get_columns("assignment")}
+    if "annotation_note" in columns:
+        with op.batch_alter_table("assignment") as batch:
+            batch.drop_column("annotation_note")

--- a/static/styles.css
+++ b/static/styles.css
@@ -867,15 +867,6 @@ select.code-input{
 
 .annot-select:focus{outline:none;}
 
-.annot-select.has-annotation{
-  background:#ffeb3b !important;
-  color:#000 !important;
-  font-weight:800;
-  border-color:#f1c40f;
-  box-shadow:0 0 0 1px rgba(0,0,0,.25) inset, 0 0 8px rgba(255,235,59,.55);
-}
-
-.annot-select.has-annotation option{ background:#111; color:#fff; }
 .annotation-note{
   display:block;
   width:100%;
@@ -885,6 +876,59 @@ select.code-input{
   border:1px solid var(--border);
   border-radius:4px;
   font-size:10px;
+}
+.annotation-display{
+  min-height:16px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  gap:2px;
+  margin-top:1px;
+}
+.annotation-code{
+  display:inline-block;
+  max-width:calc(100% - 17px);
+  overflow:hidden;
+  text-overflow:ellipsis;
+  padding:1px 4px;
+  border:1px solid #d6bd1a;
+  border-radius:4px;
+  background:#ffeb3b;
+  color:#171717;
+  font-size:9px;
+  font-weight:800;
+  line-height:1.2;
+}
+.annotation-detail-editor{position:relative;}
+.annotation-detail-editor summary{
+  width:14px;
+  height:14px;
+  display:grid;
+  place-items:center;
+  border-radius:3px;
+  color:var(--text-muted);
+  font-size:10px;
+  cursor:pointer;
+  list-style:none;
+}
+.annotation-detail-editor summary::-webkit-details-marker{display:none;}
+.annotation-detail-editor[open] form{
+  position:absolute;
+  z-index:30;
+  right:0;
+  bottom:18px;
+  width:190px;
+  padding:6px;
+  border:1px solid var(--border);
+  border-radius:6px;
+  background:var(--card);
+  box-shadow:0 8px 24px rgba(0,0,0,.4);
+}
+.annotation-detail-editor textarea{
+  width:100%;
+  margin-bottom:4px;
+  resize:vertical;
+  font-size:11px;
 }
 
 tfoot td{background:var(--card); font-weight:bold; color:var(--text);}

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -138,7 +138,8 @@
         {% for d in days %}
           {% set code = a_map.get(s.id, {}).get(d, "") %}          
           {% set f = fatigue.get(s.id, {}).get(d) %}
-          {% set ann  = ann_map.get(s.id, {}).get(d, "") %}
+          {% set ann = ann_map.get(s.id, {}).get(d, "") %}
+          {% set ann_note = ann_note_map.get(s.id, {}).get(d, "") %}
           {% set prefix = ('m' if code == 'EM' else ('a' if code == 'LA' else code[:1]|lower)) %}
           <td class="cell {{ 'editable' if can_edit and not readonly else 'locked' }}{% if not s.is_operational %} nonop{% endif %}{% if f %} fatigue{% endif %}{% if d == today %} is-today{% endif %}{% if code in training_codes %} training{% endif %}">
             {% if f %}
@@ -157,7 +158,7 @@
               <select
                 name="code"
                 class="code-input code-len-{{ code|length }} {% if code %}{{ code|lower }} group-{{ prefix }}{% endif %}"
-                data-annotation-select
+                data-auto-submit="true"
                 {% if (not can_edit) or readonly %}disabled{% endif %}
                 {% if f %}title="{{ ', '.join(f) }}"{% endif %}
                 aria-label="{{ s.name }} shift on {{ d.strftime('%d %B %Y') }}"
@@ -197,22 +198,25 @@
             {% endif %}
 
             <!-- ANNOTATION -->
-            <form method="post" action="{{ url_for('assign_cell', staff_id=s.id, ym=ym, day=d.isoformat()) }}">
+            <form class="annotation-picker" method="post" action="{{ url_for('assign_cell', staff_id=s.id, ym=ym, day=d.isoformat()) }}">
               <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
               <select
                 name="annotation"
-                class="annot-select {% if ann %}has-annotation{% endif %}"
-                data-auto-submit="true"
+                class="annot-select"
+                data-annotation-select
                 {% if (not can_edit) or readonly %}disabled{% endif %}
                 title="Annotate"
                 aria-label="{{ s.name }} annotation on {{ d.strftime('%d %B %Y') }}"
               >
-                <option value="" {% if not ann %}selected{% endif %}>—</option>
+                <option value="" selected>—</option>
+                {% if ann %}
+                  <option value="__remove__">Remove {{ ann }}</option>
+                {% endif %}
                 {% for group, opts in annotation_groups.items() %}
                   {% if opts %}
                   <optgroup label="{{ group }}">
                     {% for opt in opts %}
-                      <option value="{{ opt.code }}" data-note-required="{{ 'yes' if opt.note_required else 'no' }}" {% if ann==opt.code %}selected{% endif %}>
+                      <option value="{{ opt.code }}" data-note-required="{{ 'yes' if opt.note_required else 'no' }}">
                         {{ opt.label }} ({{ opt.code }}){% if opt.toil_half_days %} · {{ "%+.1f"|format(opt.toil_half_days / 2) }} day TOIL{% endif %}{% if opt.description %} — {{ opt.description }}{% endif %}
                       </option>
                     {% endfor %}
@@ -220,13 +224,34 @@
                   {% endif %}
                 {% endfor %}
               </select>
-              {% if ann %}<small class="annotation-current">Current: {{ ann }}</small>{% endif %}
               <input name="annotation_note" class="annotation-note" hidden
                      maxlength="140" value=""
                      placeholder="Annotation note (when required)"
                      aria-label="{{ s.name }} annotation note on {{ d.strftime('%d %B %Y') }}">
               <button type="submit" class="btn btn-sm annotation-apply" hidden>Apply annotation</button>
             </form>
+            {% if ann %}
+              <div class="annotation-display">
+                <span class="annotation-code" tabindex="0"
+                      {% if ann_note %}title="{{ ann_note }}"{% endif %}
+                      aria-label="{{ ann }}{% if ann_note %}: {{ ann_note }}{% endif %}">{{ ann }}</span>
+                {% if can_edit and not readonly %}
+                  <details class="annotation-detail-editor">
+                    <summary title="{% if ann_note %}Edit annotation detail{% else %}Add annotation detail{% endif %}"
+                             aria-label="{% if ann_note %}Edit detail for {{ ann }}{% else %}Add detail for {{ ann }}{% endif %}">✎</summary>
+                    <form method="post" action="{{ url_for('assign_cell', staff_id=s.id, ym=ym, day=d.isoformat()) }}">
+                      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+                      <input type="hidden" name="annotation" value="{{ ann }}">
+                      <input type="hidden" name="annotation_detail_update" value="1">
+                      <textarea name="annotation_note" maxlength="140" rows="2"
+                                placeholder="Optional detail shown on hover"
+                                aria-label="Detail for {{ ann }}">{{ ann_note }}</textarea>
+                      <button type="submit" class="btn btn-sm">Save</button>
+                    </form>
+                  </details>
+                {% endif %}
+              </div>
+            {% endif %}
           </td>
         {% endfor %}
       </tr>

--- a/tests/test_legacy_migration_fixtures.py
+++ b/tests/test_legacy_migration_fixtures.py
@@ -119,7 +119,7 @@ def test_legacy_fixture_upgrades_to_head_without_data_loss(
         inspector = inspect(connection)
         assert connection.execute(
             text("SELECT version_num FROM alembic_version")
-                ).scalar_one() == "20260727_15"
+        ).scalar_one() == "20260727_16"
         for table, count in before.items():
             assert connection.execute(
                 text(f'SELECT COUNT(*) FROM "{table}"')

--- a/tests/test_postgresql_multidatabase.py
+++ b/tests/test_postgresql_multidatabase.py
@@ -54,9 +54,9 @@ def test_postgresql_control_and_two_airport_databases_are_isolated(
     dispose_operational_engines()
     for url in (CONTROL_URL, AIRPORT_A_URL, AIRPORT_B_URL):
         _reset_postgres(url)
-    assert upgrade_database(CONTROL_URL, "control") == "20260727_15"
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260727_15"
-    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260727_15"
+    assert upgrade_database(CONTROL_URL, "control") == "20260727_16"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260727_16"
+    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260727_16"
     secret_a = "ATCROSTER_UNIT_1_DATABASE_URL"
     secret_b = "ATCROSTER_UNIT_2_DATABASE_URL"
     monkeypatch.setenv(secret_a, AIRPORT_A_URL)

--- a/tests/test_shift_request_security.py
+++ b/tests/test_shift_request_security.py
@@ -592,6 +592,59 @@ def test_annotation_application_is_tenant_scoped_and_audited(secured_client):
     assert cross_write.status_code == 404
 
 
+def test_roster_shows_annotation_once_and_hover_detail_can_be_edited(
+    secured_client,
+):
+    with app.app.app_context():
+        definition = AnnotationType(
+            unit_id=1, code="NEAT", label="Neat annotation",
+            is_active=True,
+        )
+        target = Staff.query.filter_by(username="user-a").one()
+        db.session.add(definition)
+        db.session.commit()
+        target_id = target.id
+        refresh_annotation_cache()
+
+    token = login(secured_client, "admin-a")
+    endpoint = (
+        f"/assign/{target_id}/{request_day():%Y-%m}/"
+        f"{request_day():%Y-%m-%d}"
+    )
+    applied = secured_client.post(
+        endpoint,
+        data={"_csrf_token": token, "annotation": "NEAT"},
+    )
+    assert applied.status_code == 302
+
+    page = secured_client.get(f"/roster/{request_day():%Y-%m}")
+    assert page.status_code == 200
+    assert b'<option value="" selected>' in page.data
+    assert b'class="annotation-code"' in page.data
+    assert b"Current: NEAT" not in page.data
+
+    updated = secured_client.post(
+        endpoint,
+        data={
+            "_csrf_token": token,
+            "annotation": "NEAT",
+            "annotation_detail_update": "1",
+            "annotation_note": "Cover requested by tower",
+        },
+    )
+    assert updated.status_code == 302
+    with app.app.app_context():
+        assignment = Assignment.query.filter_by(
+            unit_id=1, staff_id=target_id, day=request_day()
+        ).one()
+        assert assignment.annotation_note == "Cover requested by tower"
+        assert assignment.note != "Cover requested by tower"
+
+    page = secured_client.get(f"/roster/{request_day():%Y-%m}")
+    assert b'title="Cover requested by tower"' in page.data
+    assert page.data.count(b">NEAT</span>") == 1
+
+
 def test_bulk_annotation_feature_is_removed(secured_client):
     token = login(secured_client, "admin-a")
     response = secured_client.post("/annotations/bulk", data={


### PR DESCRIPTION
## Summary\n- show applied annotations once as compact codes beneath each roster shift\n- keep the annotation selector at the neutral dash and provide an explicit removal action\n- store optional annotation detail separately and expose it on hover/focus\n- document the workflow and cover it with route and migration regression tests\n\n## Verification\n- ......................s.........s....................................... [ 64%]
........................................                                 [100%]
110 passed, 2 skipped in 25.66s (110 passed, 2 skipped)\n- 