### PR TITLE
Add weekend and special-date staffing requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,11 @@ attention. It is divided into focused sections:
 - **Roster setup** defines the unit base cycle, the weekdays on which night
   duties operate, and the unit's named watches.
 - **Staffing levels** edits monthly Morning, Day, Afternoon, and Night minimums
-  across a rolling 24-month planning window. **Copy below** repeats one
-  month's four values into every later row for review before saving.
+  for weekdays, Saturdays, and Sundays across a rolling 24-month planning
+  window. **Copy below** repeats all twelve values into every later row for
+  review before saving. A special-date calendar adds one-day overrides for
+  events such as Christmas Day; those dates are identified in a dedicated
+  section beneath the relevant monthly roster.
 - **Shifts** creates shift definitions and keeps existing definitions collapsed
   until an administrator chooses one to edit. Its **Roster count mapping**
   assigns every created shift to the Morning, Day, Afternoon, Night, or
@@ -196,7 +199,10 @@ two authorised unit users.
 
 Open a month from **Roster**. Each row represents a person and each column a
 date. Requirement indicators show whether coverage meets the configured
-minimum for Morning, Day, Afternoon, and Night duties.
+minimum for Morning, Day, Afternoon, and Night duties. Weekdays, Saturdays,
+and Sundays can use different monthly minimums. A date-specific special
+requirement takes priority over those defaults and is listed beneath the
+roster with its reason and required staffing.
 
 ### Editing a cell
 

--- a/app.py
+++ b/app.py
@@ -1320,8 +1320,35 @@ class Requirement(db.Model):
     req_d = db.Column(db.Integer, default=0)
     req_a = db.Column(db.Integer, default=0)
     req_n = db.Column(db.Integer, default=0)
+    req_sat_m = db.Column(db.Integer, default=0)
+    req_sat_d = db.Column(db.Integer, default=0)
+    req_sat_a = db.Column(db.Integer, default=0)
+    req_sat_n = db.Column(db.Integer, default=0)
+    req_sun_m = db.Column(db.Integer, default=0)
+    req_sun_d = db.Column(db.Integer, default=0)
+    req_sun_a = db.Column(db.Integer, default=0)
+    req_sun_n = db.Column(db.Integer, default=0)
     __table_args__ = (db.UniqueConstraint(
         "unit_id", "year", "month", name="uniq_unit_year_month"),)
+
+
+class SpecialRequirement(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    unit_id = db.Column(
+        db.Integer, db.ForeignKey("unit.id"), nullable=False,
+        default=1, index=True,
+    )
+    day = db.Column(db.Date, nullable=False, index=True)
+    label = db.Column(db.String(80), nullable=False, default="")
+    req_m = db.Column(db.Integer, nullable=False, default=0)
+    req_d = db.Column(db.Integer, nullable=False, default=0)
+    req_a = db.Column(db.Integer, nullable=False, default=0)
+    req_n = db.Column(db.Integer, nullable=False, default=0)
+    __table_args__ = (
+        db.UniqueConstraint(
+            "unit_id", "day", name="uniq_unit_special_requirement_day"
+        ),
+    )
 
 
 class Leave(db.Model):
@@ -1490,7 +1517,8 @@ from sqlalchemy.orm import Session as OrmSession, with_loader_criteria
 from tenancy import authenticated_unit_id
 
 TENANT_OPERATIONAL_MODELS = (
-    RosterSetting, AnnotationType, Watch, Staff, ShiftType, Requirement, Leave, Sickness,
+    RosterSetting, AnnotationType, Watch, Staff, ShiftType, Requirement,
+    SpecialRequirement, Leave, Sickness,
     Assignment, ShiftRequest, RequestAudit, Notification, AnnotationAudit,
     ChangeLog, StaffWatchHistory, QualificationType,
     PersonQualification, PersonQualificationHistory,
@@ -2355,11 +2383,38 @@ def ensure_month_requirement(year, month, default=(4, 4, 4, 2)):
             dd = 0
         else:
             dm, dd, da, dn = default
-        r = Requirement(year=year, month=month, req_m=dm,
-                        req_d=dd, req_a=da, req_n=dn)
+        r = Requirement(
+            year=year, month=month,
+            req_m=dm, req_d=dd, req_a=da, req_n=dn,
+            req_sat_m=dm, req_sat_d=dd, req_sat_a=da, req_sat_n=dn,
+            req_sun_m=dm, req_sun_d=dd, req_sun_a=da, req_sun_n=dn,
+        )
         db.session.add(r)
         db.session.commit()
     return r
+
+
+def requirements_for_day(
+    requirement: Requirement | None,
+    day: date,
+    special: SpecialRequirement | None = None,
+) -> dict[str, int]:
+    """Return the effective M/D/A/N requirement for one roster date."""
+    source = special or requirement
+    if not source:
+        return {code: 0 for code in ("M", "D", "A", "N")}
+    prefix = ""
+    if not special:
+        prefix = "sat_" if day.weekday() == 5 else (
+            "sun_" if day.weekday() == 6 else ""
+        )
+    return {
+        code: max(
+            0,
+            int(getattr(source, f"req_{prefix}{code.lower()}", 0) or 0),
+        )
+        for code in ("M", "D", "A", "N")
+    }
 
 # Idempotent month generation that preserves manual entries
 
@@ -4626,6 +4681,15 @@ def roster_month(ym):
                 counters[d][grp] += 1
     rag = {}
     night_active = {d: _night_active_on(unit_id, d) for d in days}
+    special_requirements = SpecialRequirement.query.filter(
+        SpecialRequirement.day >= start,
+        SpecialRequirement.day < month_end,
+    ).order_by(SpecialRequirement.day).all()
+    special_by_day = {row.day: row for row in special_requirements}
+    req_by_day = {
+        d: requirements_for_day(req, d, special_by_day.get(d))
+        for d in days
+    }
     for d in days:
         rag[d] = {}
         for code in ("M", "D", "A", "N"):
@@ -4633,7 +4697,7 @@ def roster_month(ym):
             need = (
                 0
                 if code == "N" and not night_active[d]
-                else getattr(req, f"req_{code.lower()}") if req else 0
+                else req_by_day[d][code]
             )
             # Green if we meet/beat requirement, Amber if short by 1, else Red
             rag[d][code] = (
@@ -4727,6 +4791,8 @@ def roster_month(ym):
         a_map=a_map,
         ann_map=ann_map,             # <<< required by template
         ann_note_map=ann_note_map,
+        req_by_day=req_by_day,
+        special_requirements=special_requirements,
         counters=counters,
         req=req,                     # <<< ensure 'req' exists for template
         requirement=req,             # <<< keep this if any blocks expect 'requirement'
@@ -4891,6 +4957,17 @@ def roster_export_csv(ym):
 
     # compute daily counters + RAG for footer (prefix grouping) — EXCLUDE training shifts & excluded codes
     req = Requirement.query.filter_by(year=year, month=month).first()
+    special_by_day = {
+        row.day: row
+        for row in SpecialRequirement.query.filter(
+            SpecialRequirement.day >= start,
+            SpecialRequirement.day < month_end,
+        ).all()
+    }
+    req_by_day = {
+        d: requirements_for_day(req, d, special_by_day.get(d))
+        for d in days
+    }
     counters = {d: Counter() for d in days}
     for s in staff:
         if not s.is_operational:
@@ -4920,7 +4997,7 @@ def roster_export_csv(ym):
                 if code == "N" and not _night_active_on(
                     _current_unit_id(), d
                 )
-                else getattr(req, f"req_{code.lower()}") if req else 0
+                else req_by_day[d][code]
             )
             rag[d][code] = (
                 "green" if have >= need
@@ -4940,10 +5017,10 @@ def roster_export_csv(ym):
 
     w.writerow([])
     w.writerow(["Totals (M/D/A/N)", "", ""] + [
-        f"M:{counters[d]['M']}/{getattr(req, 'req_m', 0)}-{rag[d]['M']} | "
-        f"D:{counters[d]['D']}/{getattr(req, 'req_d', 0)}-{rag[d]['D']} | "
-        f"A:{counters[d]['A']}/{getattr(req, 'req_a', 0)}-{rag[d]['A']} | "
-        f"N:{counters[d]['N']}/{getattr(req, 'req_n', 0)}-{rag[d]['N']}"
+        f"M:{counters[d]['M']}/{req_by_day[d]['M']}-{rag[d]['M']} | "
+        f"D:{counters[d]['D']}/{req_by_day[d]['D']}-{rag[d]['D']} | "
+        f"A:{counters[d]['A']}/{req_by_day[d]['A']}-{rag[d]['A']} | "
+        f"N:{counters[d]['N']}/{req_by_day[d]['N']}-{rag[d]['N']}"
         for d in days
     ])
 
@@ -5262,23 +5339,75 @@ def admin():
         # Save requirements grid (includes req_d)
         if form == "req":
             yms = request.form.getlist("ym")
-            req_m = request.form.getlist("req_m")
-            req_d = request.form.getlist("req_d")
-            req_a = request.form.getlist("req_a")
-            req_n = request.form.getlist("req_n")
+            field_names = [
+                f"req_{prefix}{code}"
+                for prefix in ("", "sat_", "sun_")
+                for code in ("m", "d", "a", "n")
+            ]
+            values = {
+                field: request.form.getlist(field)
+                for field in field_names
+            }
             for i in range(len(yms)):
                 y, m = [int(x) for x in yms[i].split("-")]
                 r = Requirement.query.filter_by(year=y, month=m).first()
                 if not r:
                     r = Requirement(year=y, month=m)
                     db.session.add(r)
-                r.req_m = int(req_m[i] or 0)
-                r.req_d = int(req_d[i] or 0)
-                r.req_a = int(req_a[i] or 0)
-                r.req_n = int(req_n[i] or 0)
+                for field in field_names:
+                    try:
+                        value = int(values[field][i] or 0)
+                    except (ValueError, IndexError):
+                        abort(400, f"Invalid staffing value for {field}.")
+                    setattr(r, field, max(0, value))
             db.session.commit()
             flash("Requirements saved.", "ok")
-            return redirect(url_for("admin"))
+            return redirect(url_for("admin") + "#requirements")
+
+        if form == "special_requirement":
+            try:
+                selected_day = date.fromisoformat(
+                    request.form.get("special_day") or ""
+                )
+            except ValueError:
+                flash("Choose a valid date for the special requirement.", "error")
+                return redirect(url_for("admin") + "#requirements")
+            label = (request.form.get("special_label") or "").strip()[:80]
+            if not label:
+                flash(
+                    "Describe the reason, for example Christmas Day.",
+                    "error",
+                )
+                return redirect(url_for("admin") + "#requirements")
+            row = SpecialRequirement.query.filter_by(day=selected_day).first()
+            if not row:
+                row = SpecialRequirement(day=selected_day)
+                db.session.add(row)
+            row.label = label
+            for code in ("m", "d", "a", "n"):
+                try:
+                    value = int(
+                        request.form.get(f"special_req_{code}") or 0
+                    )
+                except ValueError:
+                    abort(400, "Special staffing values must be numbers.")
+                setattr(row, f"req_{code}", max(0, value))
+            db.session.commit()
+            flash(
+                f"Special requirements saved for "
+                f"{selected_day.strftime('%d %B %Y')}.",
+                "ok",
+            )
+            return redirect(url_for("admin") + "#requirements")
+
+        if form == "special_requirement_delete":
+            row = SpecialRequirement.query.filter_by(
+                id=int(request.form.get("special_requirement_id") or 0)
+            ).first_or_404()
+            db.session.delete(row)
+            db.session.commit()
+            flash("Special requirement removed.", "ok")
+            return redirect(url_for("admin") + "#requirements")
 
         # (Legacy) Bulk TOIL seed still accepted server-side, but you won't use it in UI.
         if form == "toil_seed":
@@ -5341,6 +5470,9 @@ def admin():
         )
     requirements_by_month = {
         (r.year, r.month): r for r in Requirement.query.all()}
+    special_requirements = SpecialRequirement.query.order_by(
+        SpecialRequirement.day
+    ).all()
     leaves = Leave.query.order_by(Leave.start.desc()).all()
     roster_settings = _roster_settings_snapshot(_current_unit_id())
     base_pattern = ",".join(_validated_pattern(
@@ -5364,6 +5496,7 @@ def admin():
     return render_template("admin.html",
                            shifts=shifts, staff=staff, watches=watches,
                            months=months, requirements_by_month=requirements_by_month,
+                           special_requirements=special_requirements,
                            leaves=leaves,
                            qualification_types=qualification_types,
                            base_pattern=base_pattern,

--- a/migrations/fresh_schema.py
+++ b/migrations/fresh_schema.py
@@ -200,9 +200,30 @@ def create_fresh_schema():
         sa.Column('req_d', sa.Integer()),
         sa.Column('req_a', sa.Integer()),
         sa.Column('req_n', sa.Integer()),
+        sa.Column('req_sat_m', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('req_sat_d', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('req_sat_a', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('req_sat_n', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('req_sun_m', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('req_sun_d', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('req_sun_a', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('req_sun_n', sa.Integer(), nullable=False, server_default='0'),
         sa.UniqueConstraint('unit_id', 'year', 'month', name='uniq_unit_year_month'),
     )
     op.create_index('ix_requirement_unit_id', 'requirement', ['unit_id'], unique=False)
+    op.create_table('special_requirement',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('unit_id', sa.Integer(), sa.ForeignKey('unit.id'), nullable=False),
+        sa.Column('day', sa.Date(), nullable=False),
+        sa.Column('label', sa.String(80), nullable=False),
+        sa.Column('req_m', sa.Integer(), nullable=False),
+        sa.Column('req_d', sa.Integer(), nullable=False),
+        sa.Column('req_a', sa.Integer(), nullable=False),
+        sa.Column('req_n', sa.Integer(), nullable=False),
+        sa.UniqueConstraint('unit_id', 'day', name='uniq_unit_special_requirement_day'),
+    )
+    op.create_index('ix_special_requirement_unit_id', 'special_requirement', ['unit_id'], unique=False)
+    op.create_index('ix_special_requirement_day', 'special_requirement', ['day'], unique=False)
     op.create_table('roster_publication',
         sa.Column('id', sa.Integer(), primary_key=True),
         sa.Column('unit_id', sa.Integer(), sa.ForeignKey('unit.id'), nullable=False),

--- a/migrations/versions/20260727_17_weekend_special_requirements.py
+++ b/migrations/versions/20260727_17_weekend_special_requirements.py
@@ -1,0 +1,97 @@
+"""Add weekend defaults and date-specific staffing requirements."""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision = "20260727_17"
+down_revision = "20260727_16"
+branch_labels = None
+depends_on = None
+
+WEEKEND_COLUMNS = [
+    f"req_{day}_{code}"
+    for day in ("sat", "sun")
+    for code in ("m", "d", "a", "n")
+]
+
+
+def upgrade():
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    tables = set(inspector.get_table_names())
+    if "requirement" in tables:
+        columns = {
+            column["name"]
+            for column in inspector.get_columns("requirement")
+        }
+        with op.batch_alter_table("requirement") as batch:
+            for name in WEEKEND_COLUMNS:
+                if name not in columns:
+                    batch.add_column(
+                        sa.Column(
+                            name, sa.Integer(), nullable=False,
+                            server_default="0",
+                        )
+                    )
+        for day in ("sat", "sun"):
+            for code in ("m", "d", "a", "n"):
+                bind.execute(sa.text(
+                    f"UPDATE requirement SET req_{day}_{code} = req_{code}"
+                ))
+
+    inspector = inspect(bind)
+    if "special_requirement" not in inspector.get_table_names():
+        op.create_table(
+            "special_requirement",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "unit_id", sa.Integer(), sa.ForeignKey("unit.id"),
+                nullable=False,
+            ),
+            sa.Column("day", sa.Date(), nullable=False),
+            sa.Column(
+                "label", sa.String(length=80), nullable=False,
+                server_default="",
+            ),
+            sa.Column(
+                "req_m", sa.Integer(), nullable=False, server_default="0"
+            ),
+            sa.Column(
+                "req_d", sa.Integer(), nullable=False, server_default="0"
+            ),
+            sa.Column(
+                "req_a", sa.Integer(), nullable=False, server_default="0"
+            ),
+            sa.Column(
+                "req_n", sa.Integer(), nullable=False, server_default="0"
+            ),
+            sa.UniqueConstraint(
+                "unit_id", "day",
+                name="uniq_unit_special_requirement_day",
+            ),
+        )
+        op.create_index(
+            "ix_special_requirement_unit_id",
+            "special_requirement", ["unit_id"],
+        )
+        op.create_index(
+            "ix_special_requirement_day",
+            "special_requirement", ["day"],
+        )
+
+
+def downgrade():
+    inspector = inspect(op.get_bind())
+    if "special_requirement" in inspector.get_table_names():
+        op.drop_table("special_requirement")
+    inspector = inspect(op.get_bind())
+    if "requirement" in inspector.get_table_names():
+        columns = {
+            column["name"]
+            for column in inspector.get_columns("requirement")
+        }
+        with op.batch_alter_table("requirement") as batch:
+            for name in WEEKEND_COLUMNS:
+                if name in columns:
+                    batch.drop_column(name)

--- a/migrations/versions/20260727_17_weekend_special_requirements.py
+++ b/migrations/versions/20260727_17_weekend_special_requirements.py
@@ -1,5 +1,7 @@
 """Add weekend defaults and date-specific staffing requirements."""
 
+import os
+
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import inspect
@@ -17,6 +19,8 @@ WEEKEND_COLUMNS = [
 
 
 def upgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
     bind = op.get_bind()
     inspector = inspect(bind)
     tables = set(inspector.get_table_names())
@@ -42,13 +46,18 @@ def upgrade():
 
     inspector = inspect(bind)
     if "special_requirement" not in inspector.get_table_names():
-        op.create_table(
-            "special_requirement",
-            sa.Column("id", sa.Integer(), primary_key=True),
+        unit_column = (
             sa.Column(
                 "unit_id", sa.Integer(), sa.ForeignKey("unit.id"),
                 nullable=False,
-            ),
+            )
+            if "unit" in inspector.get_table_names()
+            else sa.Column("unit_id", sa.Integer(), nullable=False)
+        )
+        op.create_table(
+            "special_requirement",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            unit_column,
             sa.Column("day", sa.Date(), nullable=False),
             sa.Column(
                 "label", sa.String(length=80), nullable=False,
@@ -82,6 +91,8 @@ def upgrade():
 
 
 def downgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
     inspector = inspect(op.get_bind())
     if "special_requirement" in inspector.get_table_names():
         op.drop_table("special_requirement")

--- a/migrations/versions/20260727_18_special_requirement_role_cleanup.py
+++ b/migrations/versions/20260727_18_special_requirement_role_cleanup.py
@@ -1,0 +1,24 @@
+"""Remove operational special-requirement data structures from control DBs."""
+
+import os
+
+from alembic import op
+from sqlalchemy import inspect
+
+revision = "20260727_18"
+down_revision = "20260727_17"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") != "control":
+        return
+    if "special_requirement" in inspect(op.get_bind()).get_table_names():
+        op.drop_table("special_requirement")
+
+
+def downgrade():
+    # Revision 17 is role-aware for new installations. Recreating an
+    # operational table in a control database would violate that boundary.
+    pass

--- a/static/styles.css
+++ b/static/styles.css
@@ -1412,6 +1412,79 @@ tfoot td{background:var(--card); font-weight:bold; color:var(--text);}
   color:var(--text-muted);
   font-size:.84rem;
 }
+.requirements-matrix{min-width:1180px !important;}
+.requirements-matrix thead tr:first-child th:not(:first-child):not(:last-child){
+  text-align:center;
+  border-bottom:1px solid var(--control-border);
+}
+.requirements-matrix .table-input{min-width:48px; max-width:58px;}
+.special-requirements{
+  margin-top:1rem;
+  padding-top:1.25rem;
+  border-top:1px solid var(--control-border);
+}
+.special-requirements__intro h4,
+.special-requirements__intro p{margin:0;}
+.special-requirements__intro p{color:var(--text-muted);}
+.special-requirements__form{
+  display:grid;
+  grid-template-columns:minmax(145px,.8fr) minmax(220px,1.5fr) repeat(4,minmax(82px,.55fr)) auto;
+  gap:.75rem;
+  align-items:end;
+}
+.special-requirements__form label{display:grid; gap:.3rem;}
+.special-requirements__list{display:grid; gap:.5rem;}
+.special-requirement-row,
+.roster-special-requirements__list article{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  gap:1rem;
+  padding:.7rem .8rem;
+  border:1px solid var(--control-border);
+  border-radius:var(--radius-sm);
+  background:var(--panel-surface);
+}
+.special-requirement-row > div:first-child,
+.roster-special-requirements__list article > div:first-child{
+  display:grid;
+  gap:.1rem;
+}
+.special-requirement-row > div:first-child span,
+.roster-special-requirements__list article > div:first-child span{
+  color:var(--text-muted);
+  font-size:.84rem;
+}
+.special-requirement-values{display:flex; flex-wrap:wrap; gap:.35rem;}
+.special-requirement-values span{
+  min-width:38px;
+  padding:.2rem .4rem;
+  border:1px solid var(--control-border);
+  border-radius:4px;
+  text-align:center;
+  font-size:.8rem;
+}
+.roster-special-requirements{
+  display:grid;
+  grid-template-columns:minmax(180px,.35fr) minmax(0,1fr);
+  gap:1rem;
+  margin-top:1rem;
+  padding:1rem;
+  border:1px solid var(--control-border);
+  border-radius:var(--radius);
+  background:var(--panel-surface);
+}
+.roster-special-requirements h3{margin:.15rem 0 0;}
+.roster-special-requirements__list{display:grid; gap:.5rem;}
+@media (max-width:1100px){
+  .special-requirements__form{grid-template-columns:repeat(2,minmax(0,1fr));}
+}
+@media (max-width:700px){
+  .special-requirements__form,
+  .roster-special-requirements{grid-template-columns:1fr;}
+  .special-requirement-row,
+  .roster-special-requirements__list article{align-items:flex-start; flex-direction:column;}
+}
 
 .inline-form{display:flex; flex-wrap:wrap; gap:.5rem 1rem; align-items:center;}
 

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -128,17 +128,26 @@
       <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
       <input type="hidden" name="form" value="req">
       <div class="table-scroll admin-requirements-table">
-        <table class="mini admin-table">
-          <thead><tr><th>Month</th><th>Morning (M)</th><th>Day (D)</th><th>Afternoon (A)</th><th>Night (N)</th><th>Apply</th></tr></thead>
+        <table class="mini admin-table requirements-matrix">
+          <thead>
+            <tr><th rowspan="2">Month</th><th colspan="4">Monday–Friday</th><th colspan="4">Saturday</th><th colspan="4">Sunday</th><th rowspan="2">Apply</th></tr>
+            <tr>
+              {% for _group in range(3) %}
+                <th title="Morning">M</th><th title="Day">D</th><th title="Afternoon">A</th><th title="Night">N</th>
+              {% endfor %}
+            </tr>
+          </thead>
           <tbody>
           {% for y,m in months %}
             {% set r = requirements_by_month.get((y,m)) %}
             <tr data-requirement-row>
               <td class="table-label"><input type="hidden" name="ym" value="{{ '%04d-%02d'|format(y,m) }}">{{ ['January','February','March','April','May','June','July','August','September','October','November','December'][m-1] }} {{ y }}</td>
-              <td><input type="number" min="0" name="req_m" value="{{ r.req_m if r else 0 }}" class="table-input" aria-label="Morning requirement for {{ '%04d-%02d'|format(y,m) }}"></td>
-              <td><input type="number" min="0" name="req_d" value="{{ r.req_d if r else 0 }}" class="table-input" aria-label="Day requirement for {{ '%04d-%02d'|format(y,m) }}"></td>
-              <td><input type="number" min="0" name="req_a" value="{{ r.req_a if r else 0 }}" class="table-input" aria-label="Afternoon requirement for {{ '%04d-%02d'|format(y,m) }}"></td>
-              <td><input type="number" min="0" name="req_n" value="{{ r.req_n if r else 0 }}" class="table-input" aria-label="Night requirement for {{ '%04d-%02d'|format(y,m) }}"></td>
+              {% for prefix, day_name in [('', 'weekday'), ('sat_', 'Saturday'), ('sun_', 'Sunday')] %}
+                {% for code, duty_name in [('m', 'Morning'), ('d', 'Day'), ('a', 'Afternoon'), ('n', 'Night')] %}
+                  {% set field = 'req_' ~ prefix ~ code %}
+                  <td><input type="number" min="0" name="{{ field }}" value="{{ r|attr(field) if r else 0 }}" class="table-input" aria-label="{{ duty_name }} {{ day_name }} requirement for {{ '%04d-%02d'|format(y,m) }}"></td>
+                {% endfor %}
+              {% endfor %}
               <td class="table-actions">
                 <button type="button" class="btn btn-sm requirements-copy-button"
                         data-copy-requirements-below
@@ -155,6 +164,40 @@
       <p class="requirements-copy-status" data-requirements-copy-status aria-live="polite">Copied values are not saved until you select Save requirements.</p>
       <div class="admin-sticky-actions"><span>Changes apply to this airport only.</span><button class="btn btn-primary" type="submit">Save requirements</button></div>
     </form>
+
+    <div class="section-body special-requirements">
+      <div class="special-requirements__intro">
+        <div><h4>Special date requirements</h4><p>Override the normal weekday or weekend level for one date, such as Christmas Day or a major event.</p></div>
+      </div>
+      <form method="post" class="special-requirements__form">
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+        <input type="hidden" name="form" value="special_requirement">
+        <label>Date<input type="date" name="special_day" required></label>
+        <label>Reason<input name="special_label" maxlength="80" placeholder="e.g. Christmas Day" required></label>
+        {% for code, name in [('m', 'Morning'), ('d', 'Day'), ('a', 'Afternoon'), ('n', 'Night')] %}
+          <label>{{ name }} ({{ code|upper }})<input type="number" min="0" name="special_req_{{ code }}" value="0" required></label>
+        {% endfor %}
+        <button class="btn btn-primary" type="submit">Add special date</button>
+      </form>
+      <div class="special-requirements__list">
+        {% for special in special_requirements %}
+          <article class="special-requirement-row">
+            <div><strong>{{ special.day.strftime('%d %B %Y') }}</strong><span>{{ special.label }}</span></div>
+            <div class="special-requirement-values">
+              <span>M {{ special.req_m }}</span><span>D {{ special.req_d }}</span><span>A {{ special.req_a }}</span><span>N {{ special.req_n }}</span>
+            </div>
+            <form method="post" data-confirm="Remove the special requirements for {{ special.day.strftime('%d %B %Y') }}?">
+              <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+              <input type="hidden" name="form" value="special_requirement_delete">
+              <input type="hidden" name="special_requirement_id" value="{{ special.id }}">
+              <button class="btn btn-sm" type="submit">Delete</button>
+            </form>
+          </article>
+        {% else %}
+          <p class="empty-state">No special date requirements have been added.</p>
+        {% endfor %}
+      </div>
+    </div>
   </section>
 
   <section id="admin-shifts" class="admin-panel" data-admin-panel="shifts" hidden>
@@ -337,7 +380,11 @@
   const requirementRows = [
     ...document.querySelectorAll('[data-requirement-row]')
   ];
-  const requirementFields = ['req_m', 'req_d', 'req_a', 'req_n'];
+  const requirementFields = [
+    'req_m', 'req_d', 'req_a', 'req_n',
+    'req_sat_m', 'req_sat_d', 'req_sat_a', 'req_sat_n',
+    'req_sun_m', 'req_sun_d', 'req_sun_a', 'req_sun_n'
+  ];
   const copyStatus = document.querySelector(
     '[data-requirements-copy-status]'
   );

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -269,16 +269,36 @@
         {% set total = m + dday + a + (n if night_active[d] else 0) %}
         <td class="totcell{% if d == today %} is-today{% endif %}">
           <div><strong>Total {{ total }}</strong></div>
-          <div class="rag {{ rag[d]['M'] }}">M {{ m }}/{{ requirement.req_m if requirement else 0 }}</div>
-          <div class="rag {{ rag[d]['D'] }}">D {{ dday }}/{{ requirement.req_d if requirement else 0 }}</div>
-          <div class="rag {{ rag[d]['A'] }}">A {{ a }}/{{ requirement.req_a if requirement else 0 }}</div>
-          {% if night_active[d] %}<div class="rag {{ rag[d]['N'] }}">N {{ n }}/{{ requirement.req_n if requirement else 0 }}</div>{% endif %}
+          <div class="rag {{ rag[d]['M'] }}">M {{ m }}/{{ req_by_day[d]['M'] }}</div>
+          <div class="rag {{ rag[d]['D'] }}">D {{ dday }}/{{ req_by_day[d]['D'] }}</div>
+          <div class="rag {{ rag[d]['A'] }}">A {{ a }}/{{ req_by_day[d]['A'] }}</div>
+          {% if night_active[d] %}<div class="rag {{ rag[d]['N'] }}">N {{ n }}/{{ req_by_day[d]['N'] }}</div>{% endif %}
         </td>
       {% endfor %}
     </tr>
   </tfoot>
 </table>
 </div> <!-- /#roster -->
+
+{% if special_requirements %}
+  <section class="roster-special-requirements" aria-labelledby="special-requirements-title">
+    <div>
+      <span class="eyebrow">Date-specific coverage</span>
+      <h3 id="special-requirements-title">Special staffing requirements</h3>
+    </div>
+    <div class="roster-special-requirements__list">
+      {% for special in special_requirements %}
+        <article>
+          <div><strong>{{ special.day.strftime('%A %d %B') }}</strong><span>{{ special.label }}</span></div>
+          <div class="special-requirement-values" aria-label="Required staffing">
+            <span>M {{ special.req_m }}</span><span>D {{ special.req_d }}</span><span>A {{ special.req_a }}</span>
+            {% if night_active[special.day] %}<span>N {{ special.req_n }}</span>{% endif %}
+          </div>
+        </article>
+      {% endfor %}
+    </div>
+  </section>
+{% endif %}
 
 {% if roster_publication %}
   <div class="roster-state-note roster-state-note--published" role="status">

--- a/tests/test_legacy_migration_fixtures.py
+++ b/tests/test_legacy_migration_fixtures.py
@@ -119,7 +119,7 @@ def test_legacy_fixture_upgrades_to_head_without_data_loss(
         inspector = inspect(connection)
         assert connection.execute(
             text("SELECT version_num FROM alembic_version")
-        ).scalar_one() == "20260727_16"
+        ).scalar_one() == "20260727_17"
         for table, count in before.items():
             assert connection.execute(
                 text(f'SELECT COUNT(*) FROM "{table}"')

--- a/tests/test_legacy_migration_fixtures.py
+++ b/tests/test_legacy_migration_fixtures.py
@@ -119,7 +119,7 @@ def test_legacy_fixture_upgrades_to_head_without_data_loss(
         inspector = inspect(connection)
         assert connection.execute(
             text("SELECT version_num FROM alembic_version")
-        ).scalar_one() == "20260727_17"
+        ).scalar_one() == "20260727_18"
         for table, count in before.items():
             assert connection.execute(
                 text(f'SELECT COUNT(*) FROM "{table}"')

--- a/tests/test_postgresql_multidatabase.py
+++ b/tests/test_postgresql_multidatabase.py
@@ -54,9 +54,9 @@ def test_postgresql_control_and_two_airport_databases_are_isolated(
     dispose_operational_engines()
     for url in (CONTROL_URL, AIRPORT_A_URL, AIRPORT_B_URL):
         _reset_postgres(url)
-    assert upgrade_database(CONTROL_URL, "control") == "20260727_16"
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260727_16"
-    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260727_16"
+    assert upgrade_database(CONTROL_URL, "control") == "20260727_17"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260727_17"
+    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260727_17"
     secret_a = "ATCROSTER_UNIT_1_DATABASE_URL"
     secret_b = "ATCROSTER_UNIT_2_DATABASE_URL"
     monkeypatch.setenv(secret_a, AIRPORT_A_URL)

--- a/tests/test_postgresql_multidatabase.py
+++ b/tests/test_postgresql_multidatabase.py
@@ -54,9 +54,9 @@ def test_postgresql_control_and_two_airport_databases_are_isolated(
     dispose_operational_engines()
     for url in (CONTROL_URL, AIRPORT_A_URL, AIRPORT_B_URL):
         _reset_postgres(url)
-    assert upgrade_database(CONTROL_URL, "control") == "20260727_17"
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260727_17"
-    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260727_17"
+    assert upgrade_database(CONTROL_URL, "control") == "20260727_18"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260727_18"
+    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260727_18"
     secret_a = "ATCROSTER_UNIT_1_DATABASE_URL"
     secret_b = "ATCROSTER_UNIT_2_DATABASE_URL"
     monkeypatch.setenv(secret_a, AIRPORT_A_URL)
@@ -127,7 +127,12 @@ def test_postgresql_control_and_two_airport_databases_are_isolated(
     )
     assert "platform_identity" in control_tables
     assert "staff" not in control_tables
+    assert "special_requirement" not in control_tables
     assert "staff" in airport_a_tables and "staff" in airport_b_tables
+    assert (
+        "special_requirement" in airport_a_tables
+        and "special_requirement" in airport_b_tables
+    )
     assert "platform_identity" not in airport_a_tables
     assert "unit" not in airport_a_tables
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1117,6 +1117,92 @@ def test_staffing_requirements_rows_offer_copy_below(client):
     assert b"requirementRows.slice(rowIndex + 1)" in page.data
 
 
+def test_weekend_and_special_date_requirements_are_available(client):
+    login(client)
+    page = client.get("/admin")
+    assert page.status_code == 200
+    assert b"Monday\xe2\x80\x93Friday" in page.data
+    assert b"Saturday" in page.data
+    assert b"Sunday" in page.data
+    assert page.data.count(b'name="req_sat_m"') == 24
+    assert page.data.count(b'name="req_sun_n"') == 24
+    assert b"Special date requirements" in page.data
+    assert b'name="special_day"' in page.data
+
+    requirement_values = {
+        "req_m": "4", "req_d": "3", "req_a": "4", "req_n": "2",
+        "req_sat_m": "2", "req_sat_d": "1",
+        "req_sat_a": "2", "req_sat_n": "0",
+        "req_sun_m": "1", "req_sun_d": "1",
+        "req_sun_a": "1", "req_sun_n": "0",
+    }
+    saved_defaults = client.post(
+        "/admin",
+        data={
+            "_csrf_token": csrf(client),
+            "form": "req",
+            "ym": "2026-12",
+            **requirement_values,
+        },
+        follow_redirects=True,
+    )
+    assert saved_defaults.status_code == 200
+    with app.app.app_context():
+        monthly = app.Requirement.query.filter_by(
+            unit_id=1, year=2026, month=12
+        ).one()
+        assert monthly.req_sat_m == 2
+        assert monthly.req_sun_a == 1
+
+    saved = client.post(
+        "/admin",
+        data={
+            "_csrf_token": csrf(client),
+            "form": "special_requirement",
+            "special_day": "2026-12-25",
+            "special_label": "Christmas Day",
+            "special_req_m": "2",
+            "special_req_d": "1",
+            "special_req_a": "2",
+            "special_req_n": "0",
+        },
+        follow_redirects=True,
+    )
+    assert saved.status_code == 200
+    assert b"Special requirements saved for 25 December 2026" in saved.data
+
+    roster = client.get("/roster/2026-12")
+    assert roster.status_code == 200
+    assert b"Special staffing requirements" in roster.data
+    assert b"Christmas Day" in roster.data
+    assert b"Friday 25 December" in roster.data
+
+    with app.app.app_context():
+        special = app.SpecialRequirement.query.filter_by(
+            unit_id=1, day=date(2026, 12, 25)
+        ).one()
+        assert app.requirements_for_day(
+            None, special.day, special
+        ) == {"M": 2, "D": 1, "A": 2, "N": 0}
+
+
+def test_effective_requirements_use_weekend_defaults_and_date_override():
+    monthly = app.Requirement(
+        req_m=4, req_d=3, req_a=4, req_n=2,
+        req_sat_m=2, req_sat_d=1, req_sat_a=2, req_sat_n=0,
+        req_sun_m=1, req_sun_d=1, req_sun_a=1, req_sun_n=0,
+    )
+    assert app.requirements_for_day(
+        monthly, date(2026, 12, 21)
+    ) == {"M": 4, "D": 3, "A": 4, "N": 2}
+    assert app.requirements_for_day(
+        monthly, date(2026, 12, 26)
+    ) == {"M": 2, "D": 1, "A": 2, "N": 0}
+    assert app.requirements_for_day(
+        monthly, date(2026, 12, 27)
+    ) == {"M": 1, "D": 1, "A": 1, "N": 0}
+
+
 def test_counter_requires_created_shift_and_respects_closed_nights(client):
     monday = date(2026, 7, 27)
     tuesday = date(2026, 7, 28)


### PR DESCRIPTION
## Summary\n- configure separate weekday, Saturday and Sunday M/D/A/N staffing defaults for each month\n- add calendar-selected date overrides with a reason and dedicated roster summary\n- use the effective requirement in roster RAG totals and CSV exports\n- preserve existing weekend levels during migration and document the workflow\n\n## Verification\n- ......................s.........s....................................... [ 63%]
..........................................                               [100%]
112 passed, 2 skipped in 26.30s (112 passed, 2 skipped)\n- legacy migration fixtures (5 passed)\n- 