### PR TITLE
Highlight shifts applied from requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,12 @@ When a cell is changed to the exact shift requested by a pending or approved
 request, the request is retained, marked `fulfilled`, and linked to the
 assignment.
 
+A shift applied through the approval workflow has a blue outline and small
+blue corner marker on the roster. Hovering the cell identifies it as applied
+from an approved shift request. The marker remains only while the linked
+assignment still contains the requested shift code; a later manual change
+does not misleadingly retain the request highlight.
+
 ### Roster request badges
 
 - Pending requests use a warning-style badge and accessible pending label.

--- a/app.py
+++ b/app.py
@@ -4730,6 +4730,28 @@ def roster_month(ym):
         for r in reqs
         if (r.status or "pending").lower() in {"pending", "approved"}
     }
+    applied_request_map = {
+        (staff_id, request_day): {"code": request_code}
+        for staff_id, request_day, request_code in (
+            db.session.query(
+                ShiftRequest.staff_id,
+                ShiftRequest.day,
+                ShiftRequest.code,
+            )
+            .join(
+                Assignment,
+                ShiftRequest.resulting_assignment_id == Assignment.id,
+            )
+            .filter(
+                ShiftRequest.unit_id == unit_id,
+                ShiftRequest.status == "fulfilled",
+                ShiftRequest.day >= start,
+                ShiftRequest.day < month_end,
+                Assignment.code == ShiftRequest.code,
+            )
+            .all()
+        )
+    }
 
     # --- Unified editability flags ---
     can_edit = can_edit_roster(current_user)
@@ -4809,6 +4831,7 @@ def roster_month(ym):
         month_title=month_title,
         today=today,
         req_pending_map=req_pending_map,
+        applied_request_map=applied_request_map,
         show_ot_finder=True,
         display_watch_by_staff=display_watch_by_staff,
         annotation_groups=get_annotation_groups(),

--- a/static/styles.css
+++ b/static/styles.css
@@ -765,6 +765,32 @@ th.sticky.left{left:0; z-index:3; background:var(--head);}
   min-width:54px; max-width:64px;
   padding:0;
 }
+.roster .cell.request-applied{
+  box-shadow:inset 0 0 0 2px #62a8ff;
+}
+.request-applied-marker{
+  position:absolute;
+  z-index:5;
+  top:3px;
+  right:3px;
+  width:6px;
+  height:6px;
+  border-radius:50%;
+  background:#62a8ff;
+  box-shadow:0 0 0 2px rgba(10,18,32,.75);
+  pointer-events:none;
+}
+.roster-key-divider{
+  width:1px;
+  height:16px;
+  margin:0 3px;
+  background:var(--control-border);
+}
+.roster-key-chip--request{
+  border:2px solid #62a8ff !important;
+  background:transparent !important;
+  color:var(--text) !important;
+}
 
 .roster .cell form{ margin:0; }
 

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -140,8 +140,13 @@
           {% set f = fatigue.get(s.id, {}).get(d) %}
           {% set ann = ann_map.get(s.id, {}).get(d, "") %}
           {% set ann_note = ann_note_map.get(s.id, {}).get(d, "") %}
+          {% set applied_request = applied_request_map.get((s.id, d)) %}
           {% set prefix = ('m' if code == 'EM' else ('a' if code == 'LA' else code[:1]|lower)) %}
-          <td class="cell {{ 'editable' if can_edit and not readonly else 'locked' }}{% if not s.is_operational %} nonop{% endif %}{% if f %} fatigue{% endif %}{% if d == today %} is-today{% endif %}{% if code in training_codes %} training{% endif %}">
+          <td class="cell {{ 'editable' if can_edit and not readonly else 'locked' }}{% if not s.is_operational %} nonop{% endif %}{% if f %} fatigue{% endif %}{% if d == today %} is-today{% endif %}{% if code in training_codes %} training{% endif %}{% if applied_request %} request-applied{% endif %}"
+              {% if applied_request %}title="Applied from an approved shift request" aria-label="{{ s.name }}, {{ d.strftime('%d %B %Y') }}, {{ code }}, applied from an approved shift request"{% endif %}>
+            {% if applied_request %}
+              <span class="request-applied-marker" aria-hidden="true"></span>
+            {% endif %}
             {% if f %}
               <span class="fatigue-hazard" tabindex="0" role="img"
                     aria-label="Fatigue warning: {{ f|join('; ') }}">
@@ -332,6 +337,9 @@
   <span class="roster-key-chip exp-amber" title="90 days or fewer remaining">&lt;90 days</span>
   <span class="roster-key-chip exp-red" title="The recorded date has expired">Expired</span>
   <span class="roster-key-chip exp-orange" title="Under training">UT</span>
+  <span class="roster-key-divider" aria-hidden="true"></span>
+  <span class="roster-key-chip roster-key-chip--request"
+        title="Shift applied through an approved request">Requested shift</span>
 </div>
 
 <script nonce="{{ csp_nonce() }}">

--- a/tests/test_shift_request_security.py
+++ b/tests/test_shift_request_security.py
@@ -365,6 +365,11 @@ def test_approve_only_then_apply_and_notify(secured_client):
         assert row.status == "fulfilled"
         assert db.session.get(Assignment, row.resulting_assignment_id).code == "REQ"
         assert Notification.query.filter_by(recipient_id=row.staff_id, kind="shift_request_fulfilled").count() == 1
+    roster = secured_client.get(f"/roster/{request_day():%Y-%m}")
+    assert roster.status_code == 200
+    assert b"request-applied" in roster.data
+    assert b"Applied from an approved shift request" in roster.data
+    assert b"request-applied-marker" in roster.data
 
 
 def test_simple_manager_approve_and_refuse_actions_notify_user(secured_client):


### PR DESCRIPTION
## Summary\n- add a blue outline and corner marker to roster cells linked to fulfilled shift requests\n- show an accessible explanation on the highlighted cell and add a roster legend key\n- suppress the highlight if the linked assignment is later changed to a different shift\n- document and test the request-applied state\n\n## Verification\n- ......................s.........s....................................... [ 63%]
..........................................                               [100%]
112 passed, 2 skipped in 25.97s (112 passed, 2 skipped)\n- focused request workflow (30 passed)\n- 