### PR TITLE
Add navigation alerts and self-approval guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,13 @@ from an approved shift request. The marker remains only while the linked
 assignment still contains the requested shift code; a later manual change
 does not misleadingly retain the request highlight.
 
+The main navigation shows an unread-notification count on **Profile** for
+every user. Unit Admins also see the number of pending or approved requests
+still requiring a decision on **Requests**. An administrator cannot approve
+their own request while another active Unit Admin is available; the sole
+active administrator may approve their own request so a single-admin airport
+cannot become operationally blocked.
+
 ### Roster request badges
 
 - Pending requests use a warning-style badge and accessible pending label.

--- a/app.py
+++ b/app.py
@@ -4558,15 +4558,30 @@ def inject_perms():
     if not re.fullmatch(r"#[0-9A-Fa-f]{6}", accent_colour):
         accent_colour = ""
     pending_request_count = 0
+    unread_notification_count = 0
+    active_admin_count = 0
     if current_unit and au and is_admin_user(au):
-        pending_request_count = ShiftRequest.query.filter_by(
+        active_admin_count = Staff.query.filter(
+            Staff.unit_id == current_unit.id,
+            Staff.membership_status == "active",
+            db.or_(Staff.role == "admin", Staff.is_admin.is_(True)),
+        ).count()
+        pending_request_count = ShiftRequest.query.filter(
+            ShiftRequest.unit_id == current_unit.id,
+            ShiftRequest.status.in_(("pending", "approved")),
+        ).count()
+    if current_unit and au:
+        unread_notification_count = Notification.query.filter_by(
             unit_id=current_unit.id,
-            status="pending",
+            recipient_id=au.id,
+            read_at=None,
         ).count()
     return {
         "is_admin":  bool(au) and is_admin_user(au),
         "is_editor": bool(au) and is_editor_user(au),
         "pending_request_count": pending_request_count,
+        "unread_notification_count": unread_notification_count,
+        "active_admin_count": active_admin_count,
         "current_unit": current_unit,
         "unit_branding": {
             "primary_colour": primary_colour,
@@ -7723,6 +7738,23 @@ def admin_request_respond(rid):
         abort(409, "The request has an invalid current status.")
     if not r.staff or r.staff.unit_id != unit_id:
         abort(409, "The requester does not belong to this airport.")
+    approval_actions = {"approve", "approve_only", "approve_apply"}
+    is_approval = (
+        action in approval_actions
+        or (action == "status" and requested_status in {"approved", "fulfilled"})
+    )
+    if is_approval and r.staff_id == current_user.id:
+        active_admin_count = Staff.query.filter(
+            Staff.unit_id == unit_id,
+            Staff.membership_status == "active",
+            db.or_(Staff.role == "admin", Staff.is_admin.is_(True)),
+        ).count()
+        if active_admin_count > 1:
+            abort(
+                403,
+                "Administrators cannot approve their own shift requests "
+                "while another active administrator is available.",
+            )
 
     old = {"status": r.status, "response": r.admin_response}
     if action in {"approve", "approve_apply"}:

--- a/static/styles.css
+++ b/static/styles.css
@@ -2153,6 +2153,11 @@ table.roster { transform-origin: top left; transform: scale(var(--ui-scale)); }
 }
 .request-decision-form { display:grid; gap:.5rem; min-width:320px; }
 .request-decision-actions { display:flex; flex-wrap:wrap; gap:.45rem; }
+.self-approval-note{
+  flex-basis:100%;
+  color:#f5b742;
+  font-size:.78rem;
+}
 .request-delete-btn {
   padding:.16rem .42rem;
   font-size:.7rem;
@@ -2168,6 +2173,20 @@ table.roster { transform-origin: top left; transform: scale(var(--ui-scale)); }
   border-radius:999px;
   color:#17120a;
   background:#f5b742;
+  font-size:.68rem;
+  font-weight:800;
+  line-height:1;
+}
+.nav-link--personal-attention{color:#75b8ff;}
+.nav-notification-count{
+  display:inline-grid;
+  place-items:center;
+  min-width:1.25rem;
+  height:1.25rem;
+  padding:0 .3rem;
+  border-radius:999px;
+  color:#07131f;
+  background:#75b8ff;
   font-size:.68rem;
   font-weight:800;
   line-height:1;

--- a/templates/base.html
+++ b/templates/base.html
@@ -90,7 +90,15 @@
                 <span class="nav-attention-count" aria-hidden="true">{{ pending_request_count }}</span>
               {% endif %}
             </a>
-            <a href="{{ url_for('staff_profile', sid=current_user.id) }}" class="nav-link {% if request.endpoint == 'staff_profile' %}active{% endif %}"><i class="fa-solid fa-id-badge" aria-hidden="true"></i> Profile</a>
+            <a href="{{ url_for('staff_profile', sid=current_user.id) }}"
+               class="nav-link {% if request.endpoint == 'staff_profile' %}active{% endif %}{% if unread_notification_count %} nav-link--personal-attention{% endif %}"
+               {% if unread_notification_count %}aria-label="Profile, {{ unread_notification_count }} unread notification{{ '' if unread_notification_count == 1 else 's' }}"{% endif %}>
+              <i class="fa-solid fa-id-badge" aria-hidden="true"></i>
+              Profile
+              {% if unread_notification_count %}
+                <span class="nav-notification-count" aria-hidden="true">{{ unread_notification_count }}</span>
+              {% endif %}
+            </a>
             {% if is_admin or current_user.is_wm or current_user.is_dwm %}
               <a href="{{ url_for('unit_messages') }}" class="nav-link {% if request.endpoint == 'unit_messages' %}active{% endif %}"><i class="fa-solid fa-message" aria-hidden="true"></i> Messages</a>
             {% endif %}

--- a/templates/requests.html
+++ b/templates/requests.html
@@ -195,11 +195,15 @@
                                name="admin_response" maxlength="500"
                                placeholder="Optional comment to {{ req.staff.name }}">
                         <div class="request-decision-actions">
-                          <button class="btn btn-primary btn-sm" name="action" value="approve"
-                                  type="submit"
-                                  data-confirm="Approve this request and add {{ req.code }} to the roster for {{ day.strftime('%d %B %Y') }}?">
-                            Approve and add to roster
-                          </button>
+                          {% if req.staff_id == current_user.id and active_admin_count > 1 %}
+                            <span class="self-approval-note">Another administrator must approve your request.</span>
+                          {% else %}
+                            <button class="btn btn-primary btn-sm" name="action" value="approve"
+                                    type="submit"
+                                    data-confirm="Approve this request and add {{ req.code }} to the roster for {{ day.strftime('%d %B %Y') }}?">
+                              Approve and add to roster
+                            </button>
+                          {% endif %}
                           <button class="btn btn-danger btn-sm" name="action" value="refuse"
                                   type="submit"
                                   data-confirm="Refuse this shift request?">

--- a/tests/test_shift_request_security.py
+++ b/tests/test_shift_request_security.py
@@ -103,6 +103,43 @@ def test_comment_persistence_update_and_single_record(secured_client):
         assert RequestAudit.query.filter_by(request_id=rows[0].id).count() == 2
 
 
+def test_profile_navigation_shows_and_clears_unread_notification_count(
+    secured_client,
+):
+    with app.app.app_context():
+        user = Staff.query.filter_by(username="user-a").one()
+        db.session.add_all([
+            Notification(
+                unit_id=1, recipient_id=user.id,
+                kind="request_update", message="First unread update",
+            ),
+            Notification(
+                unit_id=1, recipient_id=user.id,
+                kind="request_update", message="Second unread update",
+            ),
+            Notification(
+                unit_id=1, recipient_id=user.id,
+                kind="request_update", message="Already read",
+                read_at=app.utcnow(),
+            ),
+        ])
+        db.session.commit()
+
+    token = login(secured_client, "user-a")
+    page = secured_client.get("/requests")
+    assert b"Profile, 2 unread notifications" in page.data
+    assert b"nav-notification-count" in page.data
+
+    marked = secured_client.post(
+        "/notifications/read",
+        data={"_csrf_token": token},
+    )
+    assert marked.status_code == 302
+    page = secured_client.get("/requests")
+    assert b"unread notification" not in page.data
+    assert b"nav-notification-count" not in page.data
+
+
 def test_csrf_and_non_requestable_shift_rejected(secured_client):
     login(secured_client)
     missing = secured_client.post("/requests", data={
@@ -395,6 +432,7 @@ def test_simple_manager_approve_and_refuse_actions_notify_user(secured_client):
     )
     assert b"shift requests awaiting your decision" in attention_page.data
     assert b"nav-attention-count" in attention_page.data
+    assert b"Requests, 2 awaiting decision" in attention_page.data
     approved = secured_client.post(
         f"/admin/requests/{approved_id}/respond",
         data={
@@ -437,6 +475,61 @@ def test_simple_manager_approve_and_refuse_actions_notify_user(secured_client):
         assert "Approved for requested cover." in approved_notice.message
         assert "was refused" in refused_notice.message
         assert "Unable to release" in refused_notice.message
+
+
+def test_admin_self_approval_requires_another_admin_unless_sole_admin(
+    secured_client,
+):
+    with app.app.app_context():
+        watch = db.session.get(Watch, 1)
+        requester = Staff.query.filter_by(username="admin-a").one()
+        second_admin = Staff(
+            unit_id=1, username="admin-second", name="Second Admin",
+            staff_no="A3", role="admin", membership_status="active",
+            watch=watch,
+        )
+        second_admin.set_password("password123")
+        request_row = ShiftRequest(
+            unit_id=1, staff_id=requester.id,
+            day=request_day(), code="REQ",
+        )
+        db.session.add_all([second_admin, request_row])
+        db.session.commit()
+        request_id = request_row.id
+        second_admin_id = second_admin.id
+
+    token = login(secured_client, "admin-a")
+    page = secured_client.get(f"/requests?ym={request_day():%Y-%m}")
+    assert b"Another administrator must approve your request." in page.data
+    blocked = secured_client.post(
+        f"/admin/requests/{request_id}/respond",
+        data={
+            "_csrf_token": token,
+            "action": "approve",
+            "admin_response": "Attempted self approval",
+            "ym": f"{request_day():%Y-%m}",
+        },
+    )
+    assert blocked.status_code == 403
+    with app.app.app_context():
+        assert db.session.get(ShiftRequest, request_id).status == "pending"
+        db.session.get(Staff, second_admin_id).membership_status = "inactive"
+        db.session.commit()
+
+    allowed = secured_client.post(
+        f"/admin/requests/{request_id}/respond",
+        data={
+            "_csrf_token": token,
+            "action": "approve",
+            "admin_response": "Sole administrator approval",
+            "ym": f"{request_day():%Y-%m}",
+        },
+    )
+    assert allowed.status_code == 302
+    with app.app.app_context():
+        row = db.session.get(ShiftRequest, request_id)
+        assert row.status == "fulfilled"
+        assert row.resulting_assignment_id is not None
 
 
 def test_requester_can_dismiss_only_fulfilled_or_rejected_requests(


### PR DESCRIPTION
## Summary\n- show unread personal notification counts on the Profile navigation button\n- show pending and approved decision counts on Requests for Unit Admins\n- prevent administrators approving their own requests when another active administrator is available\n- retain a sole-admin exception and explain the restriction in the decision UI\n- document and test notification, request-count and role-boundary behaviour\n\n## Verification\n- ......................s.........s....................................... [ 62%]
............................................                             [100%]
114 passed, 2 skipped in 28.80s (114 passed, 2 skipped)\n- focused request security suite (32 passed)\n- 