### PR TITLE
Repair airport staffing migration

### DIFF
--- a/app.py
+++ b/app.py
@@ -437,7 +437,8 @@ def _not_found(_error):
 
 OPERATIONAL_TABLE_NAMES = frozenset({
     "roster_setting", "annotation_type", "watch", "staff", "shift_type",
-    "requirement", "leave", "sickness", "assignment", "shift_request",
+    "requirement", "special_requirement", "leave", "sickness", "assignment",
+    "shift_request",
     "request_audit", "notification", "annotation_audit", "ai_rule_set",
     "change_log", "staff_watch_history", "qualification_type",
     "person_qualification", "person_qualification_history",
@@ -7186,7 +7187,7 @@ def unit_messages():
         membership_status="active"
     ).order_by(Staff.name).all()
     watches = Watch.query.order_by(Watch.order_index, Watch.name).all()
-    selected_scope = request.form.get("scope", "individual")
+    selected_scope = request.form.get("scope", "all")
     selected_recipient = request.form.get("recipient_id", "")
     selected_watch = request.form.get("watch_id", "")
     sender_options = _sms_sender_options()

--- a/migrations/versions/20260727_19_repair_special_requirement.py
+++ b/migrations/versions/20260727_19_repair_special_requirement.py
@@ -1,0 +1,70 @@
+"""Repair missing operational special-requirement tables."""
+
+import os
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision = "20260727_19"
+down_revision = "20260727_18"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
+    bind = op.get_bind()
+    if "special_requirement" in inspect(bind).get_table_names():
+        return
+    tables = set(inspect(bind).get_table_names())
+    unit_column = (
+        sa.Column(
+            "unit_id", sa.Integer(), sa.ForeignKey("unit.id"),
+            nullable=False,
+        )
+        if "unit" in tables
+        else sa.Column("unit_id", sa.Integer(), nullable=False)
+    )
+    op.create_table(
+        "special_requirement",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        unit_column,
+        sa.Column("day", sa.Date(), nullable=False),
+        sa.Column(
+            "label", sa.String(length=80), nullable=False,
+            server_default="",
+        ),
+        sa.Column(
+            "req_m", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "req_d", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "req_a", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "req_n", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.UniqueConstraint(
+            "unit_id", "day",
+            name="uniq_unit_special_requirement_day",
+        ),
+    )
+    op.create_index(
+        "ix_special_requirement_unit_id",
+        "special_requirement", ["unit_id"],
+    )
+    op.create_index(
+        "ix_special_requirement_day",
+        "special_requirement", ["day"],
+    )
+
+
+def downgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
+    if "special_requirement" in inspect(op.get_bind()).get_table_names():
+        op.drop_table("special_requirement")

--- a/templates/messages.html
+++ b/templates/messages.html
@@ -22,9 +22,9 @@
       </label>
       <label>Recipients
         <select name="scope" id="message-scope">
-          <option value="individual" {% if selected_scope == 'individual' %}selected{% endif %}>One person</option>
-          <option value="watch" {% if selected_scope == 'watch' %}selected{% endif %}>A watch</option>
-          <option value="all" {% if selected_scope == 'all' %}selected{% endif %}>Everyone at this airport</option>
+          <option value="all" {% if selected_scope == 'all' %}selected{% endif %}>Whole unit</option>
+          <option value="watch" {% if selected_scope == 'watch' %}selected{% endif %}>Watch</option>
+          <option value="individual" {% if selected_scope == 'individual' %}selected{% endif %}>Individual</option>
           <option value="operational" {% if selected_scope == 'operational' %}selected{% endif %}>Operational number</option>
         </select>
       </label>

--- a/tests/test_legacy_migration_fixtures.py
+++ b/tests/test_legacy_migration_fixtures.py
@@ -119,7 +119,7 @@ def test_legacy_fixture_upgrades_to_head_without_data_loss(
         inspector = inspect(connection)
         assert connection.execute(
             text("SELECT version_num FROM alembic_version")
-        ).scalar_one() == "20260727_18"
+        ).scalar_one() == "20260727_19"
         for table, count in before.items():
             assert connection.execute(
                 text(f'SELECT COUNT(*) FROM "{table}"')

--- a/tests/test_postgresql_multidatabase.py
+++ b/tests/test_postgresql_multidatabase.py
@@ -54,9 +54,9 @@ def test_postgresql_control_and_two_airport_databases_are_isolated(
     dispose_operational_engines()
     for url in (CONTROL_URL, AIRPORT_A_URL, AIRPORT_B_URL):
         _reset_postgres(url)
-    assert upgrade_database(CONTROL_URL, "control") == "20260727_18"
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260727_18"
-    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260727_18"
+    assert upgrade_database(CONTROL_URL, "control") == "20260727_19"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260727_19"
+    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260727_19"
     secret_a = "ATCROSTER_UNIT_1_DATABASE_URL"
     secret_b = "ATCROSTER_UNIT_2_DATABASE_URL"
     monkeypatch.setenv(secret_a, AIRPORT_A_URL)
@@ -135,6 +135,7 @@ def test_postgresql_control_and_two_airport_databases_are_isolated(
     )
     assert "platform_identity" not in airport_a_tables
     assert "unit" not in airport_a_tables
+    assert "special_requirement" in app.OPERATIONAL_TABLE_NAMES
 
     # Two independent workers use separate PostgreSQL sessions. The second
     # cannot claim or migrate the airport while the first owns its lease.

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1645,6 +1645,20 @@ def test_unit_messages_permission_boundary(client):
     assert wm_client.get("/messages").status_code == 200
 
 
+def test_unit_messages_recipient_order_and_default(client):
+    login(client)
+    page = client.get("/messages")
+    assert page.status_code == 200
+    content = page.data
+    whole_unit = content.index(b'value="all" selected')
+    watch = content.index(b'value="watch"')
+    individual = content.index(b'value="individual"')
+    assert whole_unit < watch < individual
+    assert b">Whole unit</option>" in content
+    assert b">Watch</option>" in content
+    assert b">Individual</option>" in content
+
+
 def test_admin_configures_airport_sms_numbers(client, monkeypatch):
     login(client)
     monkeypatch.setenv("TWILIO_ACCOUNT_SID", "ACtest")


### PR DESCRIPTION
## What changed

- Added an idempotent operational migration that repairs missing `special_requirement` tables.
- Kept the table out of the control database.
- Updated migration fixtures and PostgreSQL multi-database expectations.
- Reordered Messaging recipients to Whole unit, Watch, Individual, then Operational number, with Whole unit as the default.

## Root cause

An airport database had already been stamped at revision 18 without the special staffing table. Editing the older role-aware migration could not repair an already-stamped database, so the roster failed immediately after login.

## Validation

- 117 passed, 2 skipped
- Pilot pre-deploy migration upgraded control and both operational databases to revision 19.
- Pilot web and worker deployments succeeded.
- Readiness endpoint returned ready.
