### PR TITLE
Make message recipients contextual

### DIFF
--- a/templates/messages.html
+++ b/templates/messages.html
@@ -28,22 +28,22 @@
           <option value="operational" {% if selected_scope == 'operational' %}selected{% endif %}>Operational number</option>
         </select>
       </label>
-      <label>Person
-        <select name="recipient_id">
+      <label data-recipient-detail="individual" {% if selected_scope != 'individual' %}hidden{% endif %}>Individual
+        <select name="recipient_id" {% if selected_scope != 'individual' %}disabled{% endif %}>
           <option value="">Choose a person</option>
           {% for person in people %}<option value="{{ person.id }}" {% if selected_recipient == person.id|string %}selected{% endif %}>{{ person.name }}{% if not person.phone_number %} · no mobile{% endif %}</option>{% endfor %}
         </select>
       </label>
-      <label>Operational number
-        <select name="operational_number">
-          <option value="">Choose an operational number</option>
-          {% for item in operational_options %}<option value="{{ item.number }}" {% if selected_operational == item.number %}selected{% endif %}>{{ item.label }} · {{ item.number }}</option>{% endfor %}
-        </select>
-      </label>
-      <label>Watch
-        <select name="watch_id">
+      <label data-recipient-detail="watch" {% if selected_scope != 'watch' %}hidden{% endif %}>Watch
+        <select name="watch_id" {% if selected_scope != 'watch' %}disabled{% endif %}>
           <option value="">Choose a watch</option>
           {% for watch in watches %}<option value="{{ watch.id }}" {% if selected_watch == watch.id|string %}selected{% endif %}>{{ watch.name }}</option>{% endfor %}
+        </select>
+      </label>
+      <label data-recipient-detail="operational" {% if selected_scope != 'operational' %}hidden{% endif %}>Operational number
+        <select name="operational_number" {% if selected_scope != 'operational' %}disabled{% endif %}>
+          <option value="">Choose an operational number</option>
+          {% for item in operational_options %}<option value="{{ item.number }}" {% if selected_operational == item.number %}selected{% endif %}>{{ item.label }} · {{ item.number }}</option>{% endfor %}
         </select>
       </label>
       <label>Message
@@ -64,4 +64,22 @@
 {% if preview %}
 <section class="card mt-3"><div class="card-hd">Messages prepared</div><div class="card-bd">{% for recipient_name, body in preview %}<p><strong>{{ recipient_name }}</strong><br>{{ body }}</p>{% endfor %}</div></section>
 {% endif %}
+<script nonce="{{ csp_nonce() }}">
+(() => {
+  const scope = document.querySelector('#message-scope');
+  const details = [...document.querySelectorAll('[data-recipient-detail]')];
+  if (!scope) return;
+  const updateRecipientDetails = () => {
+    details.forEach(detail => {
+      const visible = detail.dataset.recipientDetail === scope.value;
+      detail.hidden = !visible;
+      detail.querySelectorAll('select, input').forEach(control => {
+        control.disabled = !visible;
+      });
+    });
+  };
+  scope.addEventListener('change', updateRecipientDetails);
+  updateRecipientDetails();
+})();
+</script>
 {% endblock %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1657,6 +1657,10 @@ def test_unit_messages_recipient_order_and_default(client):
     assert b">Whole unit</option>" in content
     assert b">Watch</option>" in content
     assert b">Individual</option>" in content
+    assert b'data-recipient-detail="watch" hidden' in content
+    assert b'data-recipient-detail="individual" hidden' in content
+    assert b'data-recipient-detail="operational" hidden' in content
+    assert b"updateRecipientDetails" in content
 
 
 def test_admin_configures_airport_sms_numbers(client, monkeypatch):


### PR DESCRIPTION
## What changed

- Made Whole unit the no-detail recipient choice.
- Shows the watch selector only for Watch.
- Shows the staff selector only for Individual.
- Shows the configured number selector only for Operational number.
- Disables hidden controls so stale values are never submitted.

## Validation

- 117 passed, 2 skipped
