### PR TITLE
Add administrator SMS delivery audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,11 @@ step.
   sender numbers, named operational destination numbers, and defaults in
   **Admin → SMS settings**. The Messages page preselects those defaults and
   lets the sender choose another airport-approved number.
+- Every successful unit, operational, shift-reminder, and overtime SMS is
+  retained in the airport-isolated **Admin → SMS audit**. The audit records
+  who initiated it, the actual sender and recipient numbers, delivery time,
+  message type, provider reference and exact message content. Only Unit
+  Administrators can view it; failed sends are not shown as delivered.
 - Reports include fatigue, sickness, leave year, overtime, swaps, extensions,
   and CSV exports.
 

--- a/app.py
+++ b/app.py
@@ -438,7 +438,7 @@ def _not_found(_error):
 OPERATIONAL_TABLE_NAMES = frozenset({
     "roster_setting", "annotation_type", "watch", "staff", "shift_type",
     "requirement", "special_requirement", "leave", "sickness", "assignment",
-    "shift_request",
+    "shift_request", "sms_audit",
     "request_audit", "notification", "annotation_audit", "ai_rule_set",
     "change_log", "staff_watch_history", "qualification_type",
     "person_qualification", "person_qualification_history",
@@ -977,6 +977,30 @@ def _send_sms_via_twilio(
         return False, str(exc)
 
 
+def _record_sms_audit(
+    *,
+    sender_number: str,
+    recipient_number: str,
+    recipient_label: str,
+    body: str,
+    message_type: str,
+    provider_message_id: str,
+) -> None:
+    """Persist one successful provider delivery in the airport database."""
+    db.session.add(SmsAudit(
+        unit_id=_current_unit_id(),
+        sent_by_staff_id=current_user.id,
+        sent_by_name=current_user.name,
+        sender_number=_normalise_sms_number(sender_number),
+        recipient_number=_normalise_sms_number(recipient_number),
+        recipient_label=(recipient_label or recipient_number)[:120],
+        message_type=(message_type or "unit")[:30],
+        message_content=body,
+        provider_message_id=(provider_message_id or "")[:64],
+    ))
+    db.session.commit()
+
+
 def _send_overtime_sms_notifications(
     staff_list: list["Staff"], message: str
 ) -> tuple[int, list[tuple[Optional["Staff"], str]]]:
@@ -998,6 +1022,14 @@ def _send_overtime_sms_notifications(
             staff.phone_number, message, creds, from_number
         )
         if ok:
+            _record_sms_audit(
+                sender_number=from_number,
+                recipient_number=staff.phone_number,
+                recipient_label=staff.name,
+                body=message,
+                message_type="overtime",
+                provider_message_id=detail,
+            )
             sent += 1
         else:
             failures.append((staff, detail))
@@ -1420,6 +1452,25 @@ class SpecialRequirement(db.Model):
     )
 
 
+class SmsAudit(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    unit_id = db.Column(
+        db.Integer, db.ForeignKey("unit.id"), nullable=False,
+        default=1, index=True,
+    )
+    sent_at = db.Column(
+        db.DateTime, nullable=False, default=utcnow, index=True
+    )
+    sent_by_staff_id = db.Column(db.Integer, nullable=False, index=True)
+    sent_by_name = db.Column(db.String(80), nullable=False)
+    sender_number = db.Column(db.String(20), nullable=False)
+    recipient_number = db.Column(db.String(20), nullable=False)
+    recipient_label = db.Column(db.String(120), nullable=False)
+    message_type = db.Column(db.String(30), nullable=False, default="unit")
+    message_content = db.Column(db.Text, nullable=False)
+    provider_message_id = db.Column(db.String(64), nullable=False, default="")
+
+
 class Leave(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     unit_id = db.Column(db.Integer, db.ForeignKey("unit.id"), nullable=False, default=1, index=True)
@@ -1587,7 +1638,7 @@ from tenancy import authenticated_unit_id
 
 TENANT_OPERATIONAL_MODELS = (
     RosterSetting, AnnotationType, Watch, Staff, ShiftType, Requirement,
-    SpecialRequirement, Leave, Sickness,
+    SpecialRequirement, SmsAudit, Leave, Sickness,
     Assignment, ShiftRequest, RequestAudit, Notification, AnnotationAudit,
     ChangeLog, StaffWatchHistory, QualificationType,
     PersonQualification, PersonQualificationHistory,
@@ -7264,6 +7315,14 @@ def unit_messages():
                 )
                 preview.append((person.name, body))
                 if ok:
+                    _record_sms_audit(
+                        sender_number=selected_sender,
+                        recipient_number=person.phone_number,
+                        recipient_label=person.name,
+                        body=body,
+                        message_type="shift_reminder",
+                        provider_message_id=detail,
+                    )
                     sent += 1
                 else:
                     failures.append((person, detail))
@@ -7284,6 +7343,15 @@ def unit_messages():
                 direct_recipient,
             )
             preview = [(label, message)]
+            if ok:
+                _record_sms_audit(
+                    sender_number=selected_sender,
+                    recipient_number=direct_recipient,
+                    recipient_label=label,
+                    body=message,
+                    message_type="operational",
+                    provider_message_id=detail,
+                )
             _flash_sms_result(
                 1 if ok else 0,
                 [] if ok else [(None, detail)],
@@ -7298,6 +7366,14 @@ def unit_messages():
                     from_number=selected_sender,
                 )
                 if ok:
+                    _record_sms_audit(
+                        sender_number=selected_sender,
+                        recipient_number=person.phone_number,
+                        recipient_label=person.name,
+                        body=message,
+                        message_type="unit",
+                        provider_message_id=detail,
+                    )
                     sent += 1
                 else:
                     failures.append((person, detail))
@@ -7315,6 +7391,16 @@ def unit_messages():
         selected_operational=selected_operational,
         preview=preview,
     )
+
+
+@app.route("/admin/sms-audit")
+@login_required
+@admin_required
+def admin_sms_audit():
+    rows = SmsAudit.query.order_by(
+        SmsAudit.sent_at.desc(), SmsAudit.id.desc()
+    ).limit(1000).all()
+    return render_template("admin_sms_audit.html", rows=rows)
 
 # -------------------- Calendar subscription --------------------
 

--- a/migrations/fresh_schema.py
+++ b/migrations/fresh_schema.py
@@ -224,6 +224,22 @@ def create_fresh_schema():
     )
     op.create_index('ix_special_requirement_unit_id', 'special_requirement', ['unit_id'], unique=False)
     op.create_index('ix_special_requirement_day', 'special_requirement', ['day'], unique=False)
+    op.create_table('sms_audit',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('unit_id', sa.Integer(), nullable=False),
+        sa.Column('sent_at', sa.DateTime(), nullable=False),
+        sa.Column('sent_by_staff_id', sa.Integer(), nullable=False),
+        sa.Column('sent_by_name', sa.String(80), nullable=False),
+        sa.Column('sender_number', sa.String(20), nullable=False),
+        sa.Column('recipient_number', sa.String(20), nullable=False),
+        sa.Column('recipient_label', sa.String(120), nullable=False),
+        sa.Column('message_type', sa.String(30), nullable=False),
+        sa.Column('message_content', sa.Text(), nullable=False),
+        sa.Column('provider_message_id', sa.String(64), nullable=False),
+    )
+    op.create_index('ix_sms_audit_unit_id', 'sms_audit', ['unit_id'], unique=False)
+    op.create_index('ix_sms_audit_sent_at', 'sms_audit', ['sent_at'], unique=False)
+    op.create_index('ix_sms_audit_sent_by_staff_id', 'sms_audit', ['sent_by_staff_id'], unique=False)
     op.create_table('roster_publication',
         sa.Column('id', sa.Integer(), primary_key=True),
         sa.Column('unit_id', sa.Integer(), sa.ForeignKey('unit.id'), nullable=False),

--- a/migrations/versions/20260727_20_sms_audit.py
+++ b/migrations/versions/20260727_20_sms_audit.py
@@ -1,0 +1,49 @@
+"""Add airport-scoped SMS delivery audit."""
+
+import os
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision = "20260727_20"
+down_revision = "20260727_19"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
+    if "sms_audit" in inspect(op.get_bind()).get_table_names():
+        return
+    op.create_table(
+        "sms_audit",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("unit_id", sa.Integer(), nullable=False),
+        sa.Column("sent_at", sa.DateTime(), nullable=False),
+        sa.Column("sent_by_staff_id", sa.Integer(), nullable=False),
+        sa.Column("sent_by_name", sa.String(length=80), nullable=False),
+        sa.Column("sender_number", sa.String(length=20), nullable=False),
+        sa.Column("recipient_number", sa.String(length=20), nullable=False),
+        sa.Column("recipient_label", sa.String(length=120), nullable=False),
+        sa.Column("message_type", sa.String(length=30), nullable=False),
+        sa.Column("message_content", sa.Text(), nullable=False),
+        sa.Column(
+            "provider_message_id", sa.String(length=64),
+            nullable=False, server_default="",
+        ),
+    )
+    op.create_index("ix_sms_audit_unit_id", "sms_audit", ["unit_id"])
+    op.create_index("ix_sms_audit_sent_at", "sms_audit", ["sent_at"])
+    op.create_index(
+        "ix_sms_audit_sent_by_staff_id",
+        "sms_audit", ["sent_by_staff_id"],
+    )
+
+
+def downgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
+    if "sms_audit" in inspect(op.get_bind()).get_table_names():
+        op.drop_table("sms_audit")

--- a/templates/_admin_nav.html
+++ b/templates/_admin_nav.html
@@ -50,4 +50,8 @@
     <i class="fa-solid fa-comment-sms"></i><span>SMS settings</span>
   </a>
   {% endif %}
+  <a class="admin-section-tab admin-section-link {% if request.endpoint == 'admin_sms_audit' %}active{% endif %}"
+     href="{{ url_for('admin_sms_audit') }}">
+    <i class="fa-solid fa-receipt"></i><span>SMS audit</span>
+  </a>
 </nav>

--- a/templates/admin_sms_audit.html
+++ b/templates/admin_sms_audit.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+{% block title %}SMS Audit{% endblock %}
+{% block content %}
+<section class="compliance-hero">
+  <div>
+    <span class="admin-step">Operational communications</span>
+    <h2>SMS audit</h2>
+    <p>Delivered messages sent from this airport. This record is visible only to Unit Administrators.</p>
+  </div>
+</section>
+
+{% include "_admin_nav.html" %}
+
+<section class="card">
+  <div class="card-hd">Successful SMS deliveries</div>
+  <div class="card-bd">
+    <div class="table-scroll">
+      <table class="mini admin-table">
+        <thead>
+          <tr>
+            <th>Sent</th>
+            <th>Sent by</th>
+            <th>From</th>
+            <th>To</th>
+            <th>Type</th>
+            <th>Message</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in rows %}
+          <tr>
+            <td>{{ row.sent_at.strftime('%d/%m/%Y %H:%M') }}</td>
+            <td>{{ row.sent_by_name }}</td>
+            <td><span class="mono">{{ row.sender_number }}</span></td>
+            <td>{{ row.recipient_label }}<br><small class="mono">{{ row.recipient_number }}</small></td>
+            <td>{{ row.message_type.replace('_', ' ')|title }}</td>
+            <td class="sms-audit-message">{{ row.message_content }}</td>
+          </tr>
+          {% else %}
+          <tr><td colspan="6">No successful SMS deliveries have been recorded yet.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <p class="text-muted mt-3">The most recent 1,000 deliveries are shown. Failed sends are not recorded as delivered messages.</p>
+  </div>
+</section>
+{% endblock %}

--- a/tests/test_legacy_migration_fixtures.py
+++ b/tests/test_legacy_migration_fixtures.py
@@ -119,7 +119,7 @@ def test_legacy_fixture_upgrades_to_head_without_data_loss(
         inspector = inspect(connection)
         assert connection.execute(
             text("SELECT version_num FROM alembic_version")
-        ).scalar_one() == "20260727_19"
+        ).scalar_one() == "20260727_20"
         for table, count in before.items():
             assert connection.execute(
                 text(f'SELECT COUNT(*) FROM "{table}"')

--- a/tests/test_postgresql_multidatabase.py
+++ b/tests/test_postgresql_multidatabase.py
@@ -54,9 +54,9 @@ def test_postgresql_control_and_two_airport_databases_are_isolated(
     dispose_operational_engines()
     for url in (CONTROL_URL, AIRPORT_A_URL, AIRPORT_B_URL):
         _reset_postgres(url)
-    assert upgrade_database(CONTROL_URL, "control") == "20260727_19"
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260727_19"
-    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260727_19"
+    assert upgrade_database(CONTROL_URL, "control") == "20260727_20"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260727_20"
+    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260727_20"
     secret_a = "ATCROSTER_UNIT_1_DATABASE_URL"
     secret_b = "ATCROSTER_UNIT_2_DATABASE_URL"
     monkeypatch.setenv(secret_a, AIRPORT_A_URL)
@@ -128,14 +128,17 @@ def test_postgresql_control_and_two_airport_databases_are_isolated(
     assert "platform_identity" in control_tables
     assert "staff" not in control_tables
     assert "special_requirement" not in control_tables
+    assert "sms_audit" not in control_tables
     assert "staff" in airport_a_tables and "staff" in airport_b_tables
     assert (
         "special_requirement" in airport_a_tables
         and "special_requirement" in airport_b_tables
     )
+    assert "sms_audit" in airport_a_tables and "sms_audit" in airport_b_tables
     assert "platform_identity" not in airport_a_tables
     assert "unit" not in airport_a_tables
     assert "special_requirement" in app.OPERATIONAL_TABLE_NAMES
+    assert "sms_audit" in app.OPERATIONAL_TABLE_NAMES
 
     # Two independent workers use separate PostgreSQL sessions. The second
     # cannot claim or migrate the airport while the first owns its lease.

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1741,6 +1741,31 @@ def test_messages_rejects_unapproved_sender_and_sends_to_operational_number(
         ("+441415550100", "Operational test", "+447700900112")
     ]
     assert b"SMS sent to 1 recipient." in response.data
+    with app.app.app_context():
+        audit = app.SmsAudit.query.order_by(app.SmsAudit.id.desc()).first()
+        assert audit.sent_by_name == "Admin Test"
+        assert audit.sender_number == "+447700900112"
+        assert audit.recipient_number == "+441415550100"
+        assert audit.recipient_label == "Duty desk"
+        assert audit.message_type == "operational"
+        assert audit.message_content == "Operational test"
+        assert audit.provider_message_id == "SMtest"
+
+
+def test_sms_audit_is_unit_admin_only(client):
+    login(client)
+    page = client.get("/admin/sms-audit")
+    assert page.status_code == 200
+    assert b"Operational test" in page.data
+    assert b"Admin Test" in page.data
+
+    wm_client = app.app.test_client()
+    wm_client.post(
+        "/login",
+        data={"username": "watch_manager_test", "password": "password123"},
+    )
+    assert wm_client.get("/messages").status_code == 200
+    assert wm_client.get("/admin/sms-audit").status_code == 403
 
 
 def test_primary_navigation_matches_role_permissions():


### PR DESCRIPTION
## What changed

- Added an airport-isolated SMS delivery audit.
- Records initiating user, actual sender, recipient label and number, timestamp, message type, exact content and Twilio message reference.
- Covers unit, watch, individual, operational, shift-reminder and overtime SMS sends.
- Added an Admin-only audit page showing the latest 1,000 deliveries.
- Added a role-aware operational migration and fresh-install schema support.
- Updated the user manual.

## Security and behavior

- Only Unit Administrators can view the audit.
- WM/DWM users retain sending permission but cannot access audit data.
- Only successful Twilio responses are recorded as delivered.
- Audit rows remain isolated to the authenticated airport database.

## Validation

- 118 passed, 2 skipped
- Migration fixture and messaging permission tests passed
- `git diff --check`
