### PR TITLE
Allow users to delete read notifications

### DIFF
--- a/app.py
+++ b/app.py
@@ -6793,6 +6793,28 @@ def notifications_read():
         url_for("staff_profile", sid=current_user.id) + "#notifications"
     )
 
+
+@app.post("/notifications/<int:notification_id>/delete")
+@login_required
+def notification_delete(notification_id):
+    _validate_csrf()
+    item = Notification.query.filter_by(
+        id=notification_id,
+        unit_id=_current_unit_id(),
+        recipient_id=current_user.id,
+    ).first_or_404()
+    if not item.read_at:
+        flash("Mark the notification as read before deleting it.", "error")
+        return redirect(
+            url_for("staff_profile", sid=current_user.id) + "#notifications"
+        )
+    db.session.delete(item)
+    db.session.commit()
+    flash("Notification deleted.", "ok")
+    return redirect(
+        url_for("staff_profile", sid=current_user.id) + "#notifications"
+    )
+
 # -------------------- Metrics + CSV (date range; FYTD default) --------------------
 # (… unchanged metrics functions from your file …)
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -1907,8 +1907,10 @@ table.roster { transform-origin: top left; transform: scale(var(--ui-scale)); }
 .profile-timeline > div { display:grid; grid-template-columns:minmax(105px,1fr) 60px 1fr; gap:.7rem; padding:.55rem 0; border-bottom:1px solid rgba(255,255,255,.08); }
 .profile-timeline time,.profile-timeline span { color:var(--muted,#aab7c4); }
 .profile-notifications { display:grid; gap:.65rem; }
-.profile-notifications article { padding:.7rem; border-left:3px solid transparent; }
+.profile-notifications article { padding:.7rem; border-left:3px solid transparent; display:flex; align-items:flex-start; justify-content:space-between; gap:1rem; }
 .profile-notifications article.unread { border-color:#58aef5; background:rgba(88,174,245,.07); }
+.profile-notification-copy { min-width:0; flex:1; }
+.profile-notification-delete { padding:.2rem .5rem; font-size:.72rem; }
 .profile-notifications p { margin:.25rem 0; }
 .profile-notifications small { color:var(--muted,#aab7c4); }
 .profile-stats { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:.8rem; }

--- a/templates/staff_profile.html
+++ b/templates/staff_profile.html
@@ -82,9 +82,17 @@
     <div class="card-bd profile-notifications">
       {% for item in notifications %}
         <article class="{{ 'unread' if not item.read_at else '' }}">
-          <strong>{{ item.kind|replace('_',' ')|title }}</strong>
-          <p>{{ item.message }}</p>
-          <small>{{ item.created_at.strftime('%d %b %Y %H:%M') }}</small>
+          <div class="profile-notification-copy">
+            <strong>{{ item.kind|replace('_',' ')|title }}</strong>
+            <p>{{ item.message }}</p>
+            <small>{{ item.created_at.strftime('%d %b %Y %H:%M') }}</small>
+          </div>
+          {% if item.read_at %}
+          <form method="post" action="{{ url_for('notification_delete', notification_id=item.id) }}" data-confirm="Delete this notification?">
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+            <button class="btn btn-sm profile-notification-delete" type="submit">Delete</button>
+          </form>
+          {% endif %}
         </article>
       {% else %}
         <p>No notifications.</p>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1768,6 +1768,56 @@ def test_sms_audit_is_unit_admin_only(client):
     assert wm_client.get("/admin/sms-audit").status_code == 403
 
 
+def test_users_can_delete_only_their_own_read_notifications(client):
+    login(client)
+    with app.app.app_context():
+        admin = Staff.query.filter_by(username="admin_test").one()
+        other = Staff.query.filter_by(username="staff_test").one()
+        unread = app.Notification(
+            unit_id=1, recipient_id=admin.id,
+            kind="test", message="Unread notification",
+        )
+        read = app.Notification(
+            unit_id=1, recipient_id=admin.id,
+            kind="test", message="Read notification",
+            read_at=app.utcnow(),
+        )
+        someone_else = app.Notification(
+            unit_id=1, recipient_id=other.id,
+            kind="test", message="Private notification",
+            read_at=app.utcnow(),
+        )
+        db.session.add_all([unread, read, someone_else])
+        db.session.commit()
+        unread_id, read_id, other_id = unread.id, read.id, someone_else.id
+
+    blocked = client.post(
+        f"/notifications/{unread_id}/delete",
+        data={"_csrf_token": csrf(client)},
+        follow_redirects=True,
+    )
+    assert b"Mark the notification as read before deleting it." in blocked.data
+    with app.app.app_context():
+        assert db.session.get(app.Notification, unread_id) is not None
+
+    deleted = client.post(
+        f"/notifications/{read_id}/delete",
+        data={"_csrf_token": csrf(client)},
+        follow_redirects=True,
+    )
+    assert b"Notification deleted." in deleted.data
+    with app.app.app_context():
+        assert db.session.get(app.Notification, read_id) is None
+
+    forbidden = client.post(
+        f"/notifications/{other_id}/delete",
+        data={"_csrf_token": csrf(client)},
+    )
+    assert forbidden.status_code == 404
+    with app.app.app_context():
+        assert db.session.get(app.Notification, other_id) is not None
+
+
 def test_primary_navigation_matches_role_permissions():
     editor_client = app.app.test_client()
     editor_client.post(


### PR DESCRIPTION
## What changed

- Added a compact Delete action to read profile notifications.
- Kept unread notifications non-deletable until the user marks them read.
- Enforced recipient, airport and read-state ownership on the server.
- Added confirmation, responsive layout styling and regression coverage.

## Validation

- Full pytest suite passed
- Focused notification ownership test passed
- `git diff --check`
