### PR TITLE
Add launch assurance and improve roster annotations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,7 @@ SMTP_PASSWORD=replace-with-smtp-password
 SMTP_FROM_ADDRESS=no-reply@example.com
 SMTP_USE_TLS=true
 ATCROSTER_SUPPORT_EMAIL=platform-admin@example.com
+ATCROSTER_PRIVACY_EMAIL=privacy@atcroster.com
+ATCROSTER_LEGAL_ENTITY="Ian John Dickson trading as IDAviation"
+ATCROSTER_LEGAL_ADDRESS="Flat 0/2, 24 Caird Drive, Glasgow, Scotland, G11 5DT"
+ATCROSTER_COMPANY_NUMBER=

--- a/.github/workflows/production-health.yml
+++ b/.github/workflows/production-health.yml
@@ -1,0 +1,37 @@
+name: Production health
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-health
+  cancel-in-progress: true
+
+jobs:
+  health:
+    runs-on: ubuntu-latest
+    timeout-minutes: 4
+    steps:
+      - name: Check public production service
+        env:
+          PRODUCTION_ORIGIN: https://www.atcroster.com
+        run: |
+          set -euo pipefail
+          live="$(curl --fail --show-error --silent --location \
+            --retry 3 --retry-all-errors --retry-delay 5 \
+            --max-time 15 "$PRODUCTION_ORIGIN/health/live")"
+          jq -e '.status == "ok" and .service == "atcroster" and .environment == "production"' \
+            <<<"$live"
+          ready="$(curl --fail --show-error --silent --location \
+            --retry 3 --retry-all-errors --retry-delay 5 \
+            --max-time 15 "$PRODUCTION_ORIGIN/health/ready")"
+          jq -e '.status == "ready"' <<<"$ready"
+          curl --fail --show-error --silent --location \
+            --retry 2 --retry-all-errors --retry-delay 3 \
+            --max-time 15 "$PRODUCTION_ORIGIN/login" |
+            grep -Fq "<title>Login"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,8 +1,0 @@
-[extend]
-useDefault = true
-
-[[allowlists]]
-description = "DPA security-control wording is not a credential"
-regexes = [
-  '''protected secrets, vulnerability/dependency management and change control''',
-]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,8 @@
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "DPA security-control wording is not a credential"
+regexes = [
+  '''protected secrets, vulnerability/dependency management and change control''',
+]

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,1 @@
+f2c306ca657ea00fb11546f0e2de1a16368d1eb4:docs/legal/data_processing_agreement.md:generic-api-key:42

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,1 +1,2 @@
 f2c306ca657ea00fb11546f0e2de1a16368d1eb4:docs/legal/data_processing_agreement.md:generic-api-key:42
+592dceb45f15e5c7bd6ad7bad41afb76247940c0:docs/legal/data_processing_agreement.md:generic-api-key:42

--- a/README.md
+++ b/README.md
@@ -879,6 +879,11 @@ acceptance and evidence plan.
 Deployment, monitoring, backup, restore, incident and upgrade procedures are
 in [docs/production_runbook.md](docs/production_runbook.md).
 
+The visual language, component hierarchy, colour roles and responsive rules are
+defined in the [interface design system](docs/design_system.md). New UI work
+must preserve its restrained operational appearance and the distinct semantic
+colours used by the roster.
+
 Live-service ownership, monitoring/alerting, support, incident communications
 and controlled release procedures are collected in the
 [production operations pack](docs/operations/README.md). A scheduled

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ aggregates only.
 
 ## Roles and privacy
 
+Public legal information is available without signing in at `/privacy`,
+`/cookies`, `/terms`, and `/subprocessors`. The controller/processor agreement,
+DPIA, retention schedule, rights procedure, special-category policy, incident
+procedure, and launch-owner actions are maintained in
+[`docs/legal`](docs/legal/README.md). The airport/ATS unit normally controls its
+workforce and operational records; IDAviation normally processes those records
+to provide ATCRoster and separately controls limited platform-security,
+support, contracting, and billing records.
+
 | Role | Intended access |
 | --- | --- |
 | `SuperAdmin` | Airport account metadata, plans, feature flags, database health, migration state, storage, and aggregate activity. No personnel or roster data. |
@@ -869,6 +878,18 @@ acceptance and evidence plan.
 
 Deployment, monitoring, backup, restore, incident and upgrade procedures are
 in [docs/production_runbook.md](docs/production_runbook.md).
+
+Live-service ownership, monitoring/alerting, support, incident communications
+and controlled release procedures are collected in the
+[production operations pack](docs/operations/README.md). A scheduled
+production health probe checks the public live, ready and login endpoints; a
+dedicated pager/status service is still required for a contractual service.
+
+Pricing assumptions, customer onboarding, training, demo, draft service levels,
+customer readiness and a customer-facing assurance summary are collected in
+the [commercial-launch pack](docs/commercial/README.md). Draft prices and
+service targets are not approved offers until costs, coverage and legal review
+are complete.
 
 The accountable-manager product assessment and remaining operational roadmap
 are recorded in [docs/atc_manager_review.md](docs/atc_manager_review.md).

--- a/app.py
+++ b/app.py
@@ -312,6 +312,50 @@ def favicon():
     )
 
 
+def _legal_context() -> dict[str, str]:
+    """Public contact details used by the legal and privacy notices."""
+    return {
+        "legal_entity": os.environ.get(
+            "ATCROSTER_LEGAL_ENTITY",
+            "Ian John Dickson trading as IDAviation",
+        ).strip(),
+        "privacy_email": os.environ.get(
+            "ATCROSTER_PRIVACY_EMAIL",
+            os.environ.get(
+                "ATCROSTER_SUPPORT_EMAIL", "privacy@atcroster.com"
+            ),
+        ).strip(),
+        "legal_address": os.environ.get(
+            "ATCROSTER_LEGAL_ADDRESS",
+            "Flat 0/2, 24 Caird Drive, Glasgow, Scotland, G11 5DT",
+        ).strip(),
+        "company_number": os.environ.get(
+            "ATCROSTER_COMPANY_NUMBER", ""
+        ).strip(),
+        "policy_date": "27 July 2026",
+    }
+
+
+@app.get("/privacy")
+def privacy_notice():
+    return render_template("privacy.html", **_legal_context())
+
+
+@app.get("/cookies")
+def cookie_notice():
+    return render_template("cookies.html", **_legal_context())
+
+
+@app.get("/terms")
+def terms_of_service():
+    return render_template("terms.html", **_legal_context())
+
+
+@app.get("/subprocessors")
+def subprocessor_notice():
+    return render_template("subprocessors.html", **_legal_context())
+
+
 @app.get("/health/live")
 def health_live():
     return jsonify({
@@ -5064,6 +5108,7 @@ def assign_cell(staff_id, ym, day):
         if not can_apply_annotations(current_user):
             abort(403)
         old = a.annotation or ""
+        old_annotation_note = a.annotation_note or ""
         newv = (annot or "").strip().upper()
         if newv == "__REMOVE__":
             newv = ""
@@ -5113,6 +5158,17 @@ def assign_cell(staff_id, ym, day):
             ))
         elif note_was_posted:
             a.annotation_note = annotation_note
+            if old_annotation_note != annotation_note:
+                db.session.flush()
+                db.session.add(AnnotationAudit(
+                    unit_id=unit_id,
+                    annotation_type_id=ann_def.id if ann_def else None,
+                    assignment_id=a.id,
+                    actor_id=current_user.id,
+                    action="detail_updated",
+                    old_value=old_annotation_note,
+                    new_value=annotation_note,
+                ))
 
     db.session.commit()
     return redirect(url_for("roster_month", ym=ym))

--- a/docs/commercial/README.md
+++ b/docs/commercial/README.md
@@ -1,0 +1,15 @@
+# ATCRoster commercial-launch pack
+
+Status: commercial and legal owner approval required
+
+- `product_one_pager.md` — concise customer proposition
+- `pricing_draft.md` — proposed packaging and assumptions
+- `service_level_schedule.md` — draft customer service commitment
+- `customer_onboarding.md` — discovery through go-live and handover
+- `training_plan.md` — role-based training and competence checks
+- `demo_script.md` — repeatable, safe product demonstration
+- `security_assurance_statement.md` — customer due-diligence summary
+- `customer_readiness_checklist.md` — evidence required for go-live
+
+Do not publish prices or contractual targets until costs, insurance, support
+coverage, backups and legal review are complete.

--- a/docs/commercial/customer_onboarding.md
+++ b/docs/commercial/customer_onboarding.md
@@ -1,0 +1,58 @@
+# Customer onboarding and go-live
+
+## 1. Discovery
+
+- Contracting entity, unit, operating hours, watches and user count
+- Current roster cycle, shift definitions and publication process
+- Roles, qualifications, fatigue rules and staffing requirements
+- Leave/sickness categories and retention requirements
+- SMS/email needs, data migration and integrations
+- Privacy, information-security, safety and acceptance owners
+- Contingency process and target go-live window
+
+Output: signed scope, order/DPA, owners, risks, success criteria and plan.
+
+## 2. Secure provision
+
+Create airport metadata and isolated database; configure secrets, user limit,
+branding and bootstrap invitation. The named administrator accepts the
+invitation, sets unique credentials and MFA. Record provisioning/migration
+evidence without putting credentials in tickets.
+
+## 3. Configuration workshop
+
+Complete the in-app onboarding workflow: airport details, watches, base pattern,
+anchors, night availability, shifts/OFF, count mappings, annotations,
+leave/sickness types, fatigue rules, requirements, messaging senders and roles.
+
+## 4. Data and validation
+
+Import only approved minimum data. Reconcile people, watches, patterns,
+qualifications, leave, assignments and published month totals against
+controller-approved source records. Record exceptions and owner decisions.
+
+## 5. Training and acceptance
+
+Complete administrator, manager/editor and ATCO training. Run
+`docs/manual_acceptance_test.md` with representative customer data across all
+roles. Exercise access isolation, publication/undo, request approval, warning
+explanations, exports, backup restore and contingency.
+
+## 6. Parallel pilot
+
+Operate alongside the approved current method for the agreed period. Review
+defects weekly; do not expand scope mid-pilot without change control. Define who
+may declare ATCRoster authoritative and when.
+
+## 7. Go-live decision
+
+Customer operational/safety, privacy/security and accountable business owners
+sign the readiness checklist. Confirm support, on-call, monitoring, backups,
+rollback, status page and incident contacts. Archive the accepted configuration
+and release identifier.
+
+## 8. Handover
+
+Provide administrator/user manuals, training records, support process, security
+statement, DPA/subprocessor list, data-exit method and first service review date.
+Schedule 2-week and 6-week adoption reviews, then quarterly service reviews.

--- a/docs/commercial/customer_readiness_checklist.md
+++ b/docs/commercial/customer_readiness_checklist.md
@@ -1,0 +1,39 @@
+# Customer production-readiness sign-off
+
+## Contract/privacy
+
+- [ ] Order, terms and DPA signed
+- [ ] Controller/privacy and incident contacts named
+- [ ] Workforce privacy notice issued; lawful bases/health condition documented
+- [ ] Retention schedule and subprocessors approved
+
+## Configuration/data
+
+- [ ] People, roles, watches, patterns and dates reconciled
+- [ ] Shifts, OFF, count mappings and night availability approved
+- [ ] Qualifications, fatigue rules and requirements validated by accountable owner
+- [ ] Leave/sickness types and messaging configuration approved
+- [ ] User limit and leaver/access-review process agreed
+
+## People/process
+
+- [ ] Administrators, managers/editors and users trained
+- [ ] Publication/request/overtime/messaging authorities documented
+- [ ] Support and escalation contacts distributed
+- [ ] Existing contingency roster process remains available and rehearsed
+
+## Technical assurance
+
+- [ ] Customer acceptance suite signed with no open release blocker
+- [ ] Monitoring, paging and status page tested
+- [ ] Backup freshness and isolated restore evidenced
+- [ ] MFA enabled for privileged users
+- [ ] Release, rollback and incident exercises completed
+- [ ] Production URL, supported browsers and data export tested
+
+Go-live approved by:
+
+- Customer accountable/operational manager: __________ Date: ____
+- Customer safety/assurance representative: __________ Date: ____
+- Customer privacy/security representative: __________ Date: ____
+- IDAviation service owner: __________________________ Date: ____

--- a/docs/commercial/demo_script.md
+++ b/docs/commercial/demo_script.md
@@ -1,0 +1,22 @@
+# 25-minute customer demonstration
+
+Use synthetic data only. Never demo the pilot customer's production database.
+
+1. **Problem and boundary (2 min):** unit rostering, controlled workflows and
+   human accountability; explain what the product is not.
+2. **Roster picture (5 min):** watch patterns, staffing totals, requirements,
+   qualification/UE colours, fatigue warning reason and draft status.
+3. **Real workflow (5 min):** ATCO submits a shift request; authorised manager
+   sees the badge, approves with comment and roster shows request provenance.
+4. **Operational change (4 min):** edit a shift, add a concise annotation/free
+   text, explain audit and protected leave/sickness.
+5. **Publication (3 min):** publish a month, show timestamp/status and controlled
+   undo.
+6. **Administration (3 min):** watches, patterns, night availability, shifts,
+   counters, user limit and onboarding.
+7. **Trust (2 min):** airport isolation, roles, MFA, audit, backups/privacy and
+   human review.
+8. **Next step (1 min):** discovery workshop and configured sandbox.
+
+Do not demonstrate unfinished features, claim certification, promise a support
+level not contracted, or describe warnings as proof of legal compliance.

--- a/docs/commercial/pricing_draft.md
+++ b/docs/commercial/pricing_draft.md
@@ -1,0 +1,48 @@
+# Pricing and packaging — decision draft
+
+The safest early model is a fixed monthly fee per airport with an included user
+allowance. It is predictable for customers and aligns with the existing
+airport-level account limit. Avoid per-SMS inclusion: pass messaging through at
+cost or sell a separately capped allowance.
+
+## Proposed validation prices (excluding VAT)
+
+| Package | Suitable for | Included active users | Proposed monthly | Proposed setup |
+|---|---|---:|---:|---:|
+| Unit | Small non-24-hour unit | 25 | £195 | £750 |
+| Unit Plus | Medium/24-hour unit | 75 | £395 | £1,500 |
+| Enterprise | Large/multi-function unit | custom | from £695 | scoped |
+
+Annual prepayment could receive up to a 10% discount after cashflow and churn
+are understood. Pilot pricing should be a time-limited written offer, not a
+permanent hidden tier.
+
+## Included baseline
+
+- isolated airport account and configured user limit;
+- roster, requests, leave/sickness, reports and authorised messaging;
+- standard onboarding materials and UK business-hours support;
+- routine updates, security fixes and customer data export;
+- published security/privacy information.
+
+## Separately priced
+
+- data migration/cleansing;
+- bespoke integrations or reports;
+- on-site training and travel;
+- 24/7 P1 on-call;
+- additional storage/retention;
+- SMS/provider consumption;
+- custom contractual/security assessment; and
+- multi-airport group reporting when implemented and assured.
+
+## Cost validation before approval
+
+For each tier calculate Railway databases/web/worker/Redis, independent backup,
+monitoring, email, support time, Twilio use, payment fees, insurance, tax,
+security testing and legal/accounting overhead. Target a gross margin that
+funds support and assurance; do not price only against Railway's current hobby
+bill.
+
+Owner decisions: VAT status, currency/term, minimum contract, setup/refund
+rules, overage price, annual uplift, pilot conversion and public/private price.

--- a/docs/commercial/product_one_pager.md
+++ b/docs/commercial/product_one_pager.md
@@ -1,0 +1,38 @@
+# ATCRoster
+
+## Clearer unit rostering. Controlled change. One operational picture.
+
+ATCRoster is a secure, airport-separated roster-management platform designed
+around the practical needs of air traffic control units.
+
+### What it helps units do
+
+- Build and maintain watch-based rosters and local shift patterns.
+- Show staffing requirements, qualifications and fatigue-rule warnings in
+  context.
+- Manage leave, sickness, shift requests, overtime and TOIL through controlled
+  workflows.
+- Publish monthly rosters with a clear draft/published state and audit trail.
+- Notify individuals, watches or the whole unit through authorised operational
+  messaging.
+- Give administrators useful reports without exposing other airports.
+
+### Designed for accountable operations
+
+Airport data is isolated, permissions follow operational roles, material
+changes are audited and MFA is supported. Fatigue and staffing warnings explain
+why attention is required while leaving decisions with competent managers.
+
+### What ATCRoster is not
+
+It is not an ATS, surveillance or tactical operational system, clinical record,
+or autonomous safety decision-maker. It supports—not replaces—the unit's
+regulatory obligations, safety-management system, approved contingency process
+and accountable judgement.
+
+### A controlled adoption path
+
+Discovery → configured sandbox → administrator training → representative-data
+acceptance → parallel pilot → formal go-live decision → supported production.
+
+Contact: `[sales@atcroster.com]` · `https://atcroster.com`

--- a/docs/commercial/security_assurance_statement.md
+++ b/docs/commercial/security_assurance_statement.md
@@ -1,0 +1,31 @@
+# ATCRoster security and assurance summary
+
+ATCRoster uses airport-scoped identities/memberships, role-based access and
+separate operational database routing to prevent one airport from selecting or
+reading another airport's roster data. Platform administration is deliberately
+limited to account metadata and health information.
+
+Current implemented controls include secure password hashing, TOTP MFA,
+encrypted MFA/bootstrap secrets, secure session configuration, CSRF protection,
+rate limiting, tenant-aware database access, audit trails, controlled
+publication/request transitions, migration checks and automated unit,
+PostgreSQL, Redis, container, dependency, static-analysis and secret-scanning
+tests.
+
+Production operation requires TLS, managed PostgreSQL/Redis, a secrets manager,
+central monitoring, independent encrypted backups, restore rehearsal, incident
+response, access review and controlled release/rollback. Customer data roles,
+retention and subprocessors are documented in the privacy/DPA pack.
+
+Fatigue, staffing and qualification findings are decision support. ATCRoster
+does not autonomously certify a roster, replace competent management or replace
+the customer's safety-management and contingency arrangements.
+
+Evidence available under appropriate confidentiality includes architecture and
+data-classification summaries, permission matrix/test report, release security
+report, DPIA/DPA, backup/restore record, migration/runbooks and current
+independent testing when commissioned.
+
+Outstanding before broad commercial assurance: independent penetration test,
+off-project production backup/restore evidence, confirmed provider transfer
+records, approved legal contracts and customer-specific operational acceptance.

--- a/docs/commercial/service_level_schedule.md
+++ b/docs/commercial/service_level_schedule.md
@@ -1,0 +1,51 @@
+# Service level schedule — draft
+
+This schedule must be reviewed against actual infrastructure and on-call
+capability before signature.
+
+## Service target
+
+Proposed initial paid-service objective: **99.5% monthly availability**, measured
+at ATCRoster's public application boundary. This is approximately 3 hours 39
+minutes maximum unavailability in a 31-day month. Do not contract to this target
+until external monitoring, resilient backups, paging and tested support exist.
+
+Excluded from measurement:
+
+- announced maintenance within the agreed window;
+- customer systems, internet access or unsupported configuration;
+- customer misuse or unauthorised changes;
+- suspension required for security, law or non-payment;
+- force majeure; and
+- provider failure only to the extent the customer contract lawfully excludes
+  it—provider dependency is not automatically ignored operationally.
+
+## Maintenance
+
+Give at least five business days' notice for planned material interruption
+where practicable. Emergency security maintenance may occur without advance
+notice; communicate promptly.
+
+## Support
+
+Priority definitions and response objectives are in the support policy. Unless
+the order form purchases on-call coverage, support hours are UK business days
+09:00–17:00 Europe/London.
+
+## Recovery objectives
+
+Proposed objectives, subject to demonstrated restore evidence:
+
+- RPO: 24 hours initially; target 4 hours before larger commercial adoption.
+- RTO: 8 hours initially.
+
+These are disaster-recovery objectives, not guarantees that every incident is
+resolved within the period.
+
+## Service credits
+
+Do not offer credits until pricing and liability are approved. A conventional
+draft is 5% of the affected month's recurring fee below 99.5%, 10% below 99.0%
+and 20% below 95.0%, capped at 20%, claimed within 30 days. Credits should be
+the sole financial remedy for availability failure without excluding remedies
+that law does not permit excluding.

--- a/docs/commercial/training_plan.md
+++ b/docs/commercial/training_plan.md
@@ -1,0 +1,34 @@
+# Role-based training plan
+
+## Unit Administrator — 3 hours plus supervised exercise
+
+Identity/access, onboarding, watches/patterns, shifts/counters, fatigue rules,
+leave/sickness types, user setup/invitations, requests, publication, reports,
+SMS controls/audit, privacy, incident reporting and contingency. Pass: configure
+a test unit and complete critical admin scenarios without unsafe assistance.
+
+## Roster Editor / WM / DWM — 90 minutes
+
+Roster navigation/editing, warnings and hover reasons, staffing requirements,
+requests, overtime, annotations, publication authority where granted, messaging
+and audit expectations. Pass: safely execute and reverse representative
+changes, explaining warnings and escalation.
+
+## Operational user — 30–45 minutes
+
+Login/MFA, roster and status, requests, notifications, profile/contact data,
+calendar subscription, operational messages, reporting errors and security.
+Pass: submit/cancel a request, read a response, identify draft/published state
+and explain account-protection duties.
+
+## Platform Super Admin — 90 minutes, restricted
+
+Airport metadata/provisioning, database secret prerequisites, one-time
+invitations, account limits, health/migration state, MFA recovery, tenant
+privacy boundary and deletion/exit controls. No operational impersonation.
+
+## Records
+
+Record learner, role, trainer, date, environment/release, modules, exercise
+result, retraining due date and any restricted permissions. Refresh annually and
+after material workflow/permission changes.

--- a/docs/design_system.md
+++ b/docs/design_system.md
@@ -1,0 +1,62 @@
+# ATCRoster interface design system
+
+ATCRoster uses a restrained operational interface intended for prolonged,
+high-attention use. It should feel like mature institutional software, not a
+marketing dashboard.
+
+## Principles
+
+1. **Information before decoration.** Layout, labels and state carry meaning;
+   gradients, glow, animation and ornamental graphics do not.
+2. **One hierarchy.** Page heading, section heading, field label and supporting
+   text have consistent size and weight across every feature.
+3. **One neutral system.** Graphite surfaces and grey borders form the
+   interface. Muted aviation teal marks selection and primary action.
+4. **Colour has a job.** Roster duty colours, warnings, errors and publication
+   states retain their operational meaning. Do not use those colours merely for
+   decoration.
+5. **Compact, not cramped.** Controls suit dense roster work while maintaining
+   readable labels, minimum touch targets and visible keyboard focus.
+6. **Flat, accountable controls.** Avoid glass effects, heavy shadows, animated
+   backgrounds, excessive rounding and competing button treatments.
+
+## Core tokens
+
+| Use | Value |
+|---|---|
+| Page background | `#0d1117` |
+| Primary surface | `#151a21` |
+| Elevated surface | `#1a2028` |
+| Border | `#2a333e` |
+| Primary text | `#e8edf2` |
+| Muted text | `#9aa5b1` |
+| Accent | `#68b7b2` |
+| Primary action | `#356d69` |
+| Standard radius | `6–10px` |
+
+The font stack is the operating system's native UI family with a native
+monospace stack for times, codes and technical identifiers. This avoids an
+external font dependency and keeps rendering familiar on managed devices.
+
+## Components
+
+- Header: solid surface, simple `AR` identifier, flat navigation and restrained
+  session context.
+- Page introduction: bordered surface with a narrow accent edge, one heading
+  and one concise explanation.
+- Cards: flat surface, one-pixel border and minimal shadow.
+- Buttons: neutral by default; filled teal only for the primary action; muted
+  red only for destructive actions.
+- Tables: flat header, sentence-case labels, subtle alternating rows and no
+  decorative gradient.
+- Forms: dark input surface, visible labels, consistent 38px minimum height and
+  teal focus ring.
+- Mobile administration: two-column tool grid, becoming one column only where
+  content requires it; no hidden horizontal toolbar.
+
+## Change rule
+
+New component styling belongs in the final institutional-design section of
+`static/styles.css` until legacy rules are progressively removed. Any new
+colour, radius, shadow or font treatment needs a functional reason and must be
+checked at desktop and 390px mobile width.

--- a/docs/legal/README.md
+++ b/docs/legal/README.md
@@ -1,0 +1,27 @@
+# ATCRoster privacy and contractual pack
+
+Status: owner review required before commercial issue
+
+Prepared: 27 July 2026
+
+Review cycle: annually and after any material product, provider or legal change
+
+This folder contains the baseline UK privacy documents for ATCRoster:
+
+- `data_processing_agreement.md` — Article 28 controller/processor schedule;
+- `retention_schedule.md` — configurable baseline requiring customer approval;
+- `data_subject_rights_procedure.md` — access, correction, deletion and related requests;
+- `incident_and_breach_response.md` — security and personal-data breach procedure;
+- `dpia.md` — initial data protection impact assessment;
+- `special_category_policy.md` — health/medical information safeguards; and
+- `launch_owner_checklist.md` — facts and decisions the product owner must complete.
+
+The airport/ATS unit will normally be controller for workforce and operational
+data. IDAviation will normally be processor for hosted service data and a
+separate controller for its own platform security, support, contracting and
+billing records. Actual roles depend on who determines each processing purpose,
+not merely the contract label.
+
+These drafts support professional legal review; they are not a substitute for
+advice on the customer's employment, aviation, records-management or regulatory
+obligations.

--- a/docs/legal/data_processing_agreement.md
+++ b/docs/legal/data_processing_agreement.md
@@ -39,7 +39,7 @@ shall maintain measures appropriate to risk, including:
   secrets;
 - MFA for privileged access, secure sessions, CSRF protection and rate limits;
 - audit trails for material roster, request, account and SMS activity;
-- protected secrets, vulnerability/dependency management and change control;
+- protected credentials, vulnerability/dependency management and change control;
 - resilient backups, restore testing, monitoring and incident procedures; and
 - staff access removal and periodic access review.
 

--- a/docs/legal/data_processing_agreement.md
+++ b/docs/legal/data_processing_agreement.md
@@ -1,0 +1,126 @@
+# ATCRoster Data Processing Agreement
+
+**Parties:** `[CUSTOMER LEGAL NAME]` (Controller) and Ian John Dickson trading
+as IDAviation, of Flat 0/2, 24 Caird Drive, Glasgow, Scotland, G11 5DT
+(Processor).
+
+**Effective date:** `[DATE]`
+
+**Main agreement:** `[CUSTOMER AGREEMENT / ORDER FORM]`
+
+## 1. Scope and precedence
+
+This DPA applies where Processor processes personal data for Controller in
+providing ATCRoster. It forms part of the Main Agreement. Data protection terms
+take precedence for that processing. Defined UK GDPR terms have their statutory
+meaning.
+
+## 2. Controller instructions
+
+Processor shall process personal data only on Controller's documented
+instructions, including the Main Agreement, configuration and authorised use of
+the service, unless UK law requires otherwise. Processor shall notify Controller
+before legally required processing unless prohibited by law and shall inform
+Controller if an instruction appears to infringe applicable data protection law.
+
+Controller is responsible for its lawful bases, special-category condition,
+workforce transparency, data accuracy, authorised users, retention decisions and
+lawfulness of instructions and communications.
+
+## 3. Confidentiality and security
+
+Processor shall ensure authorised personnel are bound by confidentiality and
+shall maintain measures appropriate to risk, including:
+
+- logical separation of airport tenants and physically separate operational
+  databases where configured;
+- least-privilege role controls and controlled privileged administration;
+- TLS in transit, managed encryption at rest, password hashing and encrypted MFA
+  secrets;
+- MFA for privileged access, secure sessions, CSRF protection and rate limits;
+- audit trails for material roster, request, account and SMS activity;
+- protected secrets, vulnerability/dependency management and change control;
+- resilient backups, restore testing, monitoring and incident procedures; and
+- staff access removal and periodic access review.
+
+Security measures may evolve provided protection is not materially reduced.
+
+## 4. Subprocessors
+
+Controller gives general written authorisation for the subprocessors published
+at `/subprocessors`. Processor shall:
+
+1. bind each subprocessor to materially equivalent data-protection duties;
+2. remain responsible for its subprocessor's performance;
+3. give at least 30 days' notice of an intended new subprocessor where
+   practicable; and
+4. allow Controller to object on reasonable data-protection grounds.
+
+If the parties cannot resolve an objection, Controller may stop the affected
+optional feature or terminate the affected service under the Main Agreement.
+
+## 5. International transfers
+
+Processor shall not make a restricted transfer without a lawful mechanism,
+including the UK International Data Transfer Agreement/Addendum where
+appropriate, and any required transfer-risk assessment and supplementary
+measures. Controller authorises transfers inherent in approved subprocessors,
+subject to these safeguards.
+
+## 6. Data-subject requests
+
+Taking account of the nature of processing, Processor shall provide reasonable
+technical and organisational assistance for Controller to respond to rights
+requests. Processor shall promptly forward requests received directly and shall
+not respond substantively unless instructed or legally required.
+
+## 7. Assistance and incidents
+
+Processor shall assist Controller, taking account of available information, with
+security, breach assessment/notification, DPIAs and regulatory consultation.
+Processor shall notify Controller without undue delay after confirming a
+personal-data breach affecting Controller data and provide known:
+
+- nature, affected data/people and likely consequences;
+- containment and remediation measures;
+- incident contact and continuing material updates.
+
+Notification is not an admission of fault. Controller is responsible for
+regulatory and data-subject notifications.
+
+## 8. Return and deletion
+
+On termination or Controller's written request, Processor shall provide an
+agreed export and delete or return personal data, unless law requires retention.
+Residual backup data will be isolated from ordinary use and expire through the
+documented backup cycle. Controller must request its export before the agreed
+closure deadline.
+
+## 9. Evidence and audit
+
+Processor shall provide information reasonably necessary to demonstrate Article
+28 compliance. No more than annually, unless following a material incident or
+regulatory requirement, Controller may audit through current independent
+reports, questionnaires and then a scoped inspection if those are insufficient.
+Audits require reasonable notice, confidentiality, security safeguards and
+minimal disruption. Controller bears its costs unless material non-compliance is
+found.
+
+## Schedule 1 — processing details
+
+| Item | Description |
+|---|---|
+| Subject matter | Hosted multi-tenant ATC roster, staffing, availability, communications and reporting service |
+| Duration | Main Agreement plus export/closure and backup-expiry period |
+| Nature/purpose | Store, organise, display, calculate, communicate, audit, secure, back up and support Controller's roster operations |
+| Data subjects | ATCOs, managers, administrators, trainees, other authorised unit personnel and support contacts |
+| Ordinary data | Identity, staff number, username, contact details, unit/watch/role, rosters, requests, annotations, leave, TOIL, overtime, communications, audit and technical records |
+| Special-category data | Sickness/absence information and medical validity or related health information entered by Controller |
+| Frequency | Continuous during service use |
+| Controller rights | Configuration, role management, access, correction, export, retention instructions and termination/deletion |
+
+## Signatures
+
+Controller: __________________ Name/title: __________________ Date: ______
+
+Processor: ___________________ Name/title: __________________ Date: ______

--- a/docs/legal/data_subject_rights_procedure.md
+++ b/docs/legal/data_subject_rights_procedure.md
@@ -1,0 +1,44 @@
+# Data-subject rights procedure
+
+## Intake and ownership
+
+1. Record the request date, channel, requester, unit and requested right without
+   copying unnecessary identity documents.
+2. The airport/ATS unit owns requests about workforce, roster, leave, sickness,
+   qualifications and operational messages. IDAviation owns requests about its
+   contracting, support, billing and platform-security controller records.
+3. Forward misdirected requests securely within two working days.
+
+## Identity and scope
+
+- Verify identity proportionately through the existing account/unit and a
+  second trusted channel for sensitive records.
+- Never disclose whether another person's account exists.
+- Clarify broad requests promptly without delaying reasonable searches.
+- Record the statutory deadline and any lawful extension; the controller makes
+  the extension/refusal decision.
+
+## Search locations
+
+Search the relevant airport database, control identity/membership records,
+security and change logs, SMS audit, support system, email delivery records and
+recoverable exports. Search backups only where restoration is proportionate and
+required; otherwise ensure the request is honoured if data later returns to a
+live system.
+
+## Review and response
+
+- Export in a secure, intelligible format.
+- Redact third-party information and security secrets.
+- Explain purposes, categories, recipients, retention, source and transfer
+  safeguards where applicable.
+- Correction must propagate to relevant live records and processors.
+- Erasure/restriction/objection requests require the controller to assess legal,
+  employment, safety and evidential requirements; they are not automatic.
+- Keep a minimal request log showing decision, dates and evidence delivered.
+
+## Escalation
+
+Escalate suspected breach, contested identity, special-category disclosure,
+legal hold, regulatory correspondence or inability to meet the deadline to the
+privacy lead immediately.

--- a/docs/legal/dpia.md
+++ b/docs/legal/dpia.md
@@ -1,0 +1,73 @@
+# Initial Data Protection Impact Assessment — ATCRoster
+
+**Status:** draft for controller and privacy-adviser approval
+
+**Owner:** Ian John Dickson, IDAviation
+
+**Date:** 27 July 2026
+
+**Review trigger:** new data category, automated decision, provider/region,
+large customer, integration, security incident or material workflow change
+
+## 1. Processing
+
+ATCRoster is a hosted multi-airport workforce rostering service. Airport units
+create users, watches, patterns and shifts; manage leave/sickness,
+qualifications, requests, overtime and communications; and review fatigue and
+staffing warnings. Data is entered by authorised users and processed by the
+application, airport-specific databases and approved infrastructure providers.
+
+## 2. Necessity and proportionality
+
+The processing supports safe staffing and workforce administration. Tenant and
+role boundaries, configurable types, limited platform metadata and absence of
+clinical diagnosis fields reduce scope. Fatigue and staffing outputs are
+decision support; accountable humans retain decisions. Customers must document
+lawful bases, special-category conditions, workforce transparency and why less
+intrusive records would not meet their obligations.
+
+## 3. People affected
+
+ATCOs, trainees, watch/duty managers, roster editors, administrators and other
+authorised unit staff. Employment imbalance, safety-sensitive roles and
+health-related records increase potential impact.
+
+## 4. Risk assessment
+
+| Risk | Initial | Controls | Residual |
+|---|---|---|---|
+| Cross-airport disclosure | High | authenticated tenant binding, airport databases, tests, privacy-safe super-admin | Medium |
+| Excess access to sickness/medical data | High | role limits, minimal status data, reports, special-category policy, audit | Medium |
+| Account takeover | High | strong password hashing, MFA, secure recovery, rate limits, secure cookies | Medium |
+| Incorrect roster/fatigue result affects decisions | High | visible warnings/reasons, human review, publication status, audit, tests | Medium |
+| SMS exposes sensitive or wrong-recipient data | High | authorised roles, verified contacts, sender control, audit, content policy | Medium |
+| Data loss/outage | High | database separation, backups, restore rehearsal, monitoring/runbooks | Medium pending independent backup |
+| Excess retention/free text | High | retention schedule, field limits, minimisation guidance, deletion process | Medium pending automation |
+| Provider/international transfer | Medium | DPA, subprocessor register, regions, transfer mechanism/assessment | Medium pending contract evidence |
+| Privileged misuse | High | restricted platform view, MFA, audit, access review, leaver process | Medium |
+| Workers unaware/unable to exercise rights | Medium | public notice, controller workforce notice, rights procedure | Low/medium |
+
+## 5. Outstanding measures before wider launch
+
+- Approve customer-specific retention and implement deletion automation.
+- Establish independently recoverable backups and record a successful restore.
+- Confirm Railway/email/backup regions, DPAs and transfer safeguards.
+- Complete external penetration/security testing and remediate material issues.
+- Make privileged MFA mandatory and complete quarterly access reviews.
+- Validate fatigue/qualification logic through operational assurance.
+- Obtain controller sign-off, including Article 6/9 bases and workforce notice.
+- Record consultation with representative users/worker representatives or
+  explain why it was not appropriate.
+
+## 6. Decision
+
+Pilot processing may continue only within documented scope and controls.
+Commercial expansion should not be approved until the outstanding high-impact
+measures have owners and evidence. Any residual high risk that cannot be reduced
+requires specialist advice and potential prior consultation with the ICO.
+
+Approval — Controller privacy lead: __________ Date: ____
+
+Approval — Controller operational/safety lead: ______ Date: ____
+
+Approval — IDAviation product/security owner: _______ Date: ____

--- a/docs/legal/incident_and_breach_response.md
+++ b/docs/legal/incident_and_breach_response.md
@@ -1,0 +1,53 @@
+# Security incident and personal-data breach response
+
+## Reporting
+
+Users and operators must immediately report suspected unauthorised access,
+misdirected SMS/email, exposed credentials, cross-airport access, lost exports,
+malware, destructive change or availability/data-integrity failure to the
+designated incident contact.
+
+## First response
+
+1. Open a restricted incident record; note discovery time and reporter.
+2. Preserve relevant logs and evidence without unnecessarily copying personal
+   data.
+3. Contain: revoke sessions/tokens, disable affected accounts, isolate services,
+   rotate exposed secrets or stop messaging as appropriate.
+4. Confirm airport(s), people, data categories, special-category involvement,
+   period, recipients, integrity/availability effect and recoverability.
+5. Notify the affected controller without undue delay once a personal-data
+   breach affecting its data is confirmed; do not wait for a complete forensic
+   report.
+
+## Assessment and notification
+
+The controller documents likelihood and severity of harm. It decides whether
+notification to the ICO is required and, where required, submits within 72 hours
+of awareness, supplementing incomplete information later. High-risk affected
+people must be informed without undue delay unless a lawful exception applies.
+Record every personal-data breach, including the rationale where notification is
+not made.
+
+## Recovery
+
+- Remove persistence/root cause, patch, restore from a verified clean source and
+  validate tenant isolation, authentication and data integrity.
+- Use an approved rollback and communicate service status without disclosing
+  exploitable detail or personal information.
+- Monitor for recurrence and suspicious account activity.
+
+## Closure
+
+Within ten working days of stabilisation, record timeline, cause, affected
+records, decisions, notifications, corrective actions, owner and due dates.
+Track actions to completion and feed regression tests/change controls. Preserve
+the incident record according to the approved schedule.
+
+## Contacts to complete
+
+- IDAviation incident lead: `[NAME / 24H METHOD]`
+- Privacy lead: Ian John Dickson — privacy@atcroster.com
+- Railway support/escalation: `[DETAILS]`
+- Twilio support/escalation: `[DETAILS]`
+- Customer incident contacts: maintained in each order form

--- a/docs/legal/launch_owner_checklist.md
+++ b/docs/legal/launch_owner_checklist.md
@@ -1,0 +1,45 @@
+# Legal/privacy launch owner checklist
+
+## Identity and contacts
+
+- [x] Record legal identity as Ian John Dickson trading as IDAviation, with
+  service address Flat 0/2, 24 Caird Drive, Glasgow, Scotland, G11 5DT. No
+  company number supplied.
+- [x] Create the domain privacy address `privacy@atcroster.com`.
+- [ ] Set `ATCROSTER_LEGAL_ENTITY`, `ATCROSTER_LEGAL_ADDRESS`,
+  `ATCROSTER_COMPANY_NUMBER` and `ATCROSTER_PRIVACY_EMAIL` in production.
+- [ ] Name incident, privacy and customer-support owners.
+
+## Registration and contracts
+
+- [ ] Complete the ICO fee self-assessment and register/pay or document the
+  exemption.
+- [ ] Have a UK data/privacy solicitor review the customer terms, DPA,
+  limitations, insurance, aviation/safety wording and employment-data roles.
+- [ ] Sign the customer agreement/DPA before loading live customer data.
+- [ ] Obtain and retain Railway, Twilio, email and backup provider terms/DPAs.
+- [ ] Confirm hosting/processing regions and complete required transfer
+  assessments/UK transfer instruments.
+
+Current owner note (27 July 2026): Railway region and independent backup
+provider have not yet been confirmed. The Railway account is intended to be
+upgraded; this does not by itself complete independent backup, restore testing,
+region verification or contractual transfer review.
+
+## Customer decisions
+
+- [ ] Customer documents Article 6 bases and Article 9 condition for
+  sickness/medical information.
+- [ ] Customer issues an accurate workforce privacy notice naming ATCRoster.
+- [ ] Customer approves retention periods, roles, leaver and rights processes.
+- [ ] Customer accepts the DPIA and operational/safety limitations.
+- [ ] Customer supplies privacy and incident contacts.
+
+## Product evidence
+
+- [ ] Public pages checked at `/privacy`, `/cookies`, `/terms`,
+  `/subprocessors`.
+- [ ] No non-essential storage/tracking is deployed without prior consent.
+- [ ] Backup restore, breach exercise, rights-request export and tenant
+  isolation tests have current evidence.
+- [ ] Subprocessor and policy change-notification process is operating.

--- a/docs/legal/retention_schedule.md
+++ b/docs/legal/retention_schedule.md
@@ -1,0 +1,34 @@
+# ATCRoster baseline retention schedule
+
+This is a proposed service baseline, not an automatic legal answer. Each
+airport/ATS controller must approve periods against employment, aviation,
+medical, safety-management, insurance, limitation and public-record duties.
+Health information must not be retained merely because storage is available.
+
+| Record | Proposed active retention | Disposal/action | Owner |
+|---|---:|---|---|
+| Active identity, role and contact | Account life | Delete/anonymise after closure and export window | Controller |
+| Disabled account security stub | 12 months | Delete identity; retain minimal audit reference if necessary | Joint operational process |
+| Rosters and assignments | 7 years after roster month | Delete/anonymise unless safety/legal hold applies | Controller to approve |
+| Shift requests and decisions | 3 years after decision | Delete comments/audit unless dispute requires longer | Controller |
+| Leave records | Current leave year + 3 years | Delete/anonymise | Controller |
+| Sickness/health-related absence | 3 years after record/return, subject to legal need | Secure deletion; periodic necessity review | Controller |
+| Medical/qualification validity | Active engagement + 3 years | Delete/anonymise unless regulatory duty requires longer | Controller |
+| SMS audit content | 12 months | Delete content; aggregated delivery totals may be anonymised | Controller |
+| In-app notifications | Read + 90 days; unread + 12 months | Delete | Controller |
+| Change/security audit records | 24 months | Delete or irreversibly anonymise | Processor/controller by record |
+| Recovery/invitation tokens | Expiry or use + 30 days metadata | Delete token; retain outcome/security event only | Processor |
+| Application logs | 30–90 days | Rolling deletion; never intentionally log health/comments/secrets | Processor |
+| Support cases | Closure + 3 years | Delete/anonymise attachments and personal content | IDAviation controller |
+| Customer contract/billing | Contract + 7 years | Secure deletion subject to tax/legal duties | IDAviation controller |
+| Production backups | 30 daily + 12 monthly proposed | Cryptographic/secure deletion by lifecycle | Processor |
+
+## Controls
+
+- Apply legal holds narrowly, document the reason and review at least quarterly.
+- Review special-category data at least annually and on staff departure.
+- Remove data from live systems promptly; allow documented backup expiry.
+- Record deletion jobs and investigate failures without copying deleted content
+  into logs.
+- Customer-specific schedules must be configuration/documented instructions,
+  not informal support requests.

--- a/docs/legal/special_category_policy.md
+++ b/docs/legal/special_category_policy.md
@@ -1,0 +1,23 @@
+# Special-category and sensitive workforce information policy
+
+ATCRoster may hold sickness/absence and medical-validity information. The
+airport/ATS unit must document both an Article 6 lawful basis and an Article 9
+condition before use. Consent should not be assumed appropriate in an employment
+relationship.
+
+## Rules
+
+- Record only information necessary for staffing, competence, legal or
+  occupational purposes. Do not enter diagnoses in free-text roster notes,
+  requests, SMS or ordinary notifications.
+- Prefer absence/validity status and dates over underlying clinical detail.
+- Restrict access to roles with a documented operational or employment need.
+- Separate detailed health records into an appropriate HR/occupational-health
+  system; ATCRoster is not a clinical record system.
+- Ensure reports expose the minimum necessary information and do not enable
+  punitive or unrelated profiling.
+- Review accuracy, access and retention at least annually and on role change or
+  departure.
+- Export and support procedures must treat these records as restricted.
+- Each controller must determine whether an appropriate policy document is
+  legally required and maintain its record of processing activities.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,0 +1,15 @@
+# ATCRoster production operations
+
+These documents turn the technical production runbook into an operated service.
+They do not mean the controls are active merely because they are documented.
+The owner checklist must contain links to live evidence before launch.
+
+- `monitoring_and_alerting.md` — service-level indicators and alert routing
+- `support_policy.md` — customer support channels, priorities and targets
+- `incident_communications.md` — internal/customer communications templates
+- `release_and_change_management.md` — staging, approval, deployment and rollback
+- `service_ownership_checklist.md` — named owners and live-service evidence
+
+Technical recovery remains in `../production_runbook.md` and
+`../backup_restore_runbook.md`. Personal-data incident handling remains in
+`../legal/incident_and_breach_response.md`.

--- a/docs/operations/incident_communications.md
+++ b/docs/operations/incident_communications.md
@@ -1,0 +1,35 @@
+# Incident communications templates
+
+Use plain facts, UTC and local time, known impact and the next update time.
+Never speculate, blame a provider or expose security/personal details.
+
+## Investigating
+
+> We are investigating an ATCRoster service issue first observed at `[TIME]`.
+> `[KNOWN SCOPE]` may be affected. If you cannot verify roster integrity, use
+> your unit's approved contingency process. We will update by `[TIME]`.
+
+## Identified/mitigating
+
+> We identified `[SAFE DESCRIPTION]` affecting `[SCOPE]`. We are applying a
+> controlled mitigation. Do not repeat failed write actions unless instructed;
+> retain any displayed request ID. Next update by `[TIME]`.
+
+## Monitoring
+
+> Service has been restored as of `[TIME]` and we are monitoring. `[ANY
+> CUSTOMER VALIDATION]`. We will provide a further update by `[TIME]`.
+
+## Resolved
+
+> The incident affecting `[SCOPE]` was resolved at `[TIME]`. Service is
+> operating normally. `[DATA/ROSTER INTEGRITY STATEMENT, ONLY IF VERIFIED]`.
+> Material corrective actions will be tracked through our incident review.
+
+## Security/privacy holding message
+
+> We are investigating a potential security/privacy event affecting
+> `[MINIMUM SCOPE]`. Access has been contained and evidence preserved. Please
+> direct enquiries to `[CONTACT]` and do not circulate personal information.
+> We will provide required information to the affected controller as facts are
+> confirmed.

--- a/docs/operations/monitoring_and_alerting.md
+++ b/docs/operations/monitoring_and_alerting.md
@@ -1,0 +1,78 @@
+# Monitoring and alerting standard
+
+## Availability signals
+
+Monitor from outside Railway and from a different provider/region:
+
+The repository's `production-health.yml` provides a baseline independent
+scheduled probe through GitHub Actions. It is not a substitute for a dedicated
+monitor with paging and a public status page; scheduled Actions can be delayed.
+
+| Signal | Check | Interval | Alert |
+|---|---|---:|---|
+| Public DNS/TLS | `https://atcroster.com` resolves; valid certificate | 5 min | 2 failures |
+| Liveness | `GET /health/live`, HTTP 200, `status=ok` | 1 min | 3 failures |
+| Readiness | `GET /health/ready`, HTTP 200, `status=ready` | 1 min | 2 failures |
+| Login page | `GET /login`, expected content and latency | 5 min | 2 failures |
+| Deployment | Railway deployment reaches healthy state | event | any failure |
+| Worker | heartbeat/provisioning queue age | 5 min | no heartbeat 10 min or oldest ready job 10 min |
+| Database | connections, storage, CPU, latency | 5 min | sustained threshold 10 min |
+| Redis | reachability, memory and eviction | 5 min | unavailable or unexpected eviction |
+| Backup | latest successful independent backup | daily | age exceeds 26 hours |
+| Restore evidence | isolated restore rehearsal | quarterly | overdue |
+| Email/SMS | provider delivery failures and spend | daily/event | abnormal failure rate or budget threshold |
+
+Health checks must not expose database URLs, exception text, airport names,
+people, rosters or counts. Synthetic monitoring must never use a real user's
+credentials.
+
+## Application/error monitoring
+
+Capture request ID, route template, response status, release identifier,
+duration and safe exception type. Alert on:
+
+- any cross-tenant assertion or security-boundary failure;
+- repeated HTTP 500s or a material rise over baseline;
+- login/recovery rate-limit anomalies;
+- failed database migration or provisioning job exhaustion;
+- unexpected privileged-role, MFA-reset or secret-rotation events; and
+- message delivery failures above the agreed unit threshold.
+
+Do not send passwords, MFA data, tokens, message content, sickness/medical
+information, request comments or roster notes to monitoring providers.
+
+## Severity and routing
+
+| Severity | Example | Acknowledge target | Update target |
+|---|---|---:|---:|
+| SEV-1 | suspected cross-unit disclosure, total outage, roster integrity uncertain | 15 min, 24/7 after commercial launch | every 30 min |
+| SEV-2 | major function unavailable, one airport materially impaired | 1 hour in support hours | every 2 hours |
+| SEV-3 | limited defect with workaround | 1 business day | on material change |
+| SEV-4 | question, cosmetic issue, enhancement | 2 business days | as scheduled |
+
+Targets are operational objectives until incorporated into a signed service
+level agreement. SEV-1 must page the service owner and security/privacy contact.
+If roster integrity is uncertain, tell the unit to use its approved contingency
+process; do not describe ATCRoster as an operational fallback.
+
+## Dashboard
+
+One dashboard should show:
+
+- 30-day availability and latency;
+- live/readiness state and current release;
+- error rate by safe route category;
+- database/Redis capacity;
+- worker queue age;
+- backup age and last restore result;
+- email/SMS delivery failures and spend; and
+- open incidents and overdue operational actions.
+
+## Go-live evidence
+
+- External monitor URL/dashboard: `[LINK]`
+- Paging destination and test date: `[DETAILS]`
+- Railway deployment alert: `[LINK/DATE]`
+- Error-monitoring project and scrub test: `[LINK/DATE]`
+- Backup freshness alert and forced-failure test: `[LINK/DATE]`
+- Status page: `[URL]`

--- a/docs/operations/release_and_change_management.md
+++ b/docs/operations/release_and_change_management.md
@@ -1,0 +1,48 @@
+# Release and change management
+
+## Normal change
+
+1. Define user outcome, risk, affected permissions/data and rollback boundary.
+2. Work on a protected branch; require review and passing quality/security
+   checks.
+3. Update tests, user documentation, migrations, privacy/assurance records and
+   release notes where affected.
+4. Deploy the exact commit to staging; migrate a representative restored copy.
+5. Run automated tests plus risk-based acceptance for every affected role/unit.
+6. Confirm backup, schema-compatible rollback image, decision owner and
+   monitoring coverage.
+7. Approve production deployment during a communicated window.
+8. Verify live/readiness, login, one safe read per role, tenant isolation
+   smoke-check and affected workflow.
+9. Monitor intensively for at least 30 minutes and record evidence.
+
+## Change classes
+
+- **Standard:** documented low-risk repeatable operation with tested runbook.
+- **Normal:** reviewed release using the complete flow above.
+- **Emergency:** required to contain material outage/security/integrity risk.
+  The incident owner authorises minimum change; review and missing evidence are
+  completed next business day.
+
+Direct production database edits are prohibited except an authorised emergency
+runbook with pre-change backup, peer check, transaction boundary, evidence and
+reconciliation.
+
+## Release authority
+
+- Product owner confirms scope and customer communication.
+- Technical release owner confirms tests, migration and rollback.
+- Operational/safety reviewer approves changes to roster generation, fatigue,
+  qualifications, staffing counts, publication and access control.
+- Privacy/security reviewer approves changes to sensitive data, providers,
+  permissions, logs, messaging and authentication.
+
+One person may hold multiple roles during pilot, but commercial release of a
+high-risk change requires an independent second reviewer.
+
+## Rollback decision
+
+Rollback or disable the affected feature when there is cross-unit exposure,
+unreconciled roster writes, authentication bypass, sustained elevated errors,
+failed migration, or no safe understanding of impact. Schema rollback is restore
+from approved backup—not ad-hoc downgrade SQL.

--- a/docs/operations/service_ownership_checklist.md
+++ b/docs/operations/service_ownership_checklist.md
@@ -1,0 +1,19 @@
+# Live service ownership checklist
+
+- [ ] Primary and deputy service owner named
+- [ ] Security/privacy lead named
+- [ ] Release authority and operational/safety reviewer named
+- [ ] Support and on-call channels tested
+- [ ] External live, ready, TLS and login monitoring active
+- [ ] Error monitoring active with personal-data scrubbing verified
+- [ ] Railway, database, Redis and worker alerts active
+- [ ] Independent backup age alarm active
+- [ ] Successful off-project restore evidence current
+- [ ] Status page published and incident template rehearsed
+- [ ] Email/SMS failure and spend alerts active
+- [ ] Staging remains isolated and representative
+- [ ] Release/rollback rehearsal completed
+- [ ] P1 exercise completed with customer/contact simulation
+- [ ] Provider escalation and billing contacts current
+- [ ] Monthly capacity, access and incident review scheduled
+- [ ] Quarterly restore, rights-request and incident exercises scheduled

--- a/docs/operations/support_policy.md
+++ b/docs/operations/support_policy.md
@@ -1,0 +1,44 @@
+# Customer support policy — draft
+
+## Channels
+
+- Support email: `[support@atcroster.com]`
+- Service status: `[status.atcroster.com]`
+- Security/privacy: `[security/privacy contact]`
+- SEV-1 telephone/on-call route: supplied only to contracted customer contacts
+
+Do not accept passwords, MFA codes, database credentials or full medical
+details in tickets. Customers should provide airport, time, page/action, safe
+error/request ID, impact and screenshot with personal information redacted.
+
+## Support hours
+
+Standard support: UK business days, 09:00–17:00 Europe/London, excluding
+published holidays. A commercial 24/7 SEV-1 commitment must not be sold until
+two-person on-call coverage and tested paging exist.
+
+## Priorities
+
+| Priority | Definition | Initial response objective |
+|---|---|---:|
+| P1 critical | Service unavailable, cross-unit/security concern, or roster integrity uncertain with no workaround | 15 minutes if covered by contracted on-call; otherwise immediate best effort |
+| P2 high | Major function unavailable for a unit, serious degradation, or time-sensitive workflow blocked | 1 support hour |
+| P3 normal | Limited defect with workaround or non-urgent operational question | 1 business day |
+| P4 request | Cosmetic issue, documentation or enhancement | 2 business days |
+
+Response is acknowledgement and triage, not guaranteed resolution. Resolution
+depends on cause, provider and safe change/validation requirements.
+
+## Customer responsibilities
+
+Customers maintain authorised contacts, accurate user/contact data, timely
+leaver processing, supported browsers, local contingency arrangements and
+prompt incident reporting. They must verify safety-significant roster outputs
+and must not use SMS as the sole urgent/safety-critical communication method.
+
+## Escalation and closure
+
+P1/P2 tickets receive an incident owner. Customers may escalate through their
+named service contact. A ticket closes when service is restored, a safe
+workaround is accepted, information is supplied, or it is converted to planned
+product work. Material incidents receive a summary after review.

--- a/static/styles.css
+++ b/static/styles.css
@@ -2588,3 +2588,531 @@ button:hover,
   color:var(--muted);
   font-size:.9rem;
 }
+
+/* ==========================================================
+   ATCRoster institutional design system
+   Deliberately restrained: flat surfaces, precise hierarchy,
+   one accent, and no decorative glass/gradient treatment.
+   Keep this final so legacy component styles cannot reintroduce
+   inconsistent colours, radii, shadows or typography.
+   ========================================================== */
+:root {
+  --bg:#0d1117;
+  --bg-alt:#0a0e13;
+  --card:#151a21;
+  --card-elevated:#1a2028;
+  --head:#181e26;
+  --head2:#202833;
+  --line:#2a333e;
+  --line-strong:#3b4856;
+  --text:#e8edf2;
+  --text-muted:#9aa5b1;
+  --accent:#68b7b2;
+  --accent-strong:#82cbc6;
+  --accent-soft:rgba(104,183,178,.12);
+  --control-surface:#1a2028;
+  --control-surface-hover:#222a34;
+  --control-border:#35414d;
+  --control-border-hover:#52616f;
+  --panel-surface:#151a21;
+  --shadow-soft:0 1px 2px rgba(0,0,0,.28);
+  --shadow-pop:0 8px 24px rgba(0,0,0,.2);
+  --radius-lg:10px;
+  --radius-md:8px;
+  --radius-sm:6px;
+  --font-sans:-apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  --font-mono:"SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  --bs-primary:#68b7b2;
+  --bs-primary-rgb:104,183,178;
+}
+
+html { background:var(--bg); }
+
+body {
+  color:var(--text);
+  background:var(--bg);
+  font-size:15px;
+  line-height:1.5;
+  letter-spacing:0;
+}
+
+body::before { display:none; }
+
+.app-main {
+  padding:2rem 0 3rem;
+}
+
+.page-content {
+  max-width:1680px;
+  padding-inline:clamp(1rem, 2.4vw, 2.5rem);
+  gap:1.25rem;
+}
+
+h1,h2,h3 {
+  color:var(--text);
+  letter-spacing:-.018em;
+}
+
+h1 { font-size:clamp(1.65rem, 1.45rem + .65vw, 2.15rem); font-weight:650; }
+h2 { font-size:clamp(1.35rem, 1.2rem + .4vw, 1.7rem); font-weight:650; }
+h3 { font-size:1.08rem; font-weight:650; }
+p { color:var(--text-muted); line-height:1.55; }
+a { color:var(--accent); }
+a:hover,
+a:focus-visible { color:var(--accent-strong); }
+
+.site-header {
+  padding:.75rem clamp(1rem, 2.4vw, 2.5rem) .6rem;
+  background:#11161d;
+  border-bottom:1px solid var(--line);
+  box-shadow:none;
+  backdrop-filter:none;
+}
+
+.nav-container {
+  max-width:1680px;
+  gap:.65rem 1.25rem;
+}
+
+.brand { gap:.65rem; }
+
+.brand-mark {
+  width:34px;
+  height:34px;
+  flex:0 0 34px;
+  border:1px solid #4a7775;
+  border-radius:6px;
+  background:#19302f;
+  box-shadow:none;
+  overflow:hidden;
+}
+
+.brand-mark::before,
+.brand-mark::after { display:none; }
+
+.brand-mark span {
+  color:#b7dfdc;
+  font-size:.68rem;
+  font-weight:750;
+  letter-spacing:.03em;
+}
+
+.logo {
+  color:#f0f3f5;
+  background:none;
+  text-shadow:none;
+  font-size:1.05rem;
+  font-weight:650;
+  letter-spacing:-.01em;
+  text-transform:none;
+}
+
+.command-context { gap:.4rem; }
+
+.session-context,
+.time-context {
+  min-height:36px;
+  padding:.35rem .6rem;
+  border-color:var(--line);
+  border-radius:6px;
+  background:#151a21;
+  box-shadow:none;
+}
+
+.session-context__status {
+  width:6px;
+  height:6px;
+  flex-basis:6px;
+  background:#69b391;
+  box-shadow:none;
+}
+
+.session-context__label,
+.time-context__label {
+  color:#8995a1;
+  font-size:.58rem;
+  font-weight:650;
+  letter-spacing:.04em;
+  text-transform:none;
+}
+
+.session-context__name,
+.time-context strong {
+  color:#d9e0e6;
+  font-size:.72rem;
+}
+
+.main-nav {
+  gap:.1rem;
+  padding-top:.5rem;
+  border-top:1px solid #202832;
+}
+
+.nav-link {
+  min-height:34px;
+  padding:.38rem .62rem;
+  border:0;
+  border-radius:5px;
+  background:transparent;
+  box-shadow:none;
+  color:#aab4be;
+  font-size:.76rem;
+  font-weight:550;
+  transition:background .12s ease, color .12s ease;
+}
+
+.nav-link::after { display:none; }
+
+.nav-link:hover,
+.nav-link:focus-visible {
+  color:#eef2f4;
+  background:#1c232c;
+  border:0;
+  box-shadow:none;
+  transform:none;
+}
+
+.nav-link.active {
+  color:#e9f6f5;
+  background:#223534;
+  border:0;
+  box-shadow:inset 0 -2px 0 var(--accent);
+}
+
+.nav-link i,
+.nav-link.active i {
+  color:currentColor;
+  font-size:.74rem;
+  opacity:.8;
+}
+
+.site-footer {
+  padding:1rem 0;
+  border-color:var(--line);
+  background:#0f141a;
+  backdrop-filter:none;
+}
+
+.site-footer__copyright,
+.site-footer__links a {
+  color:#7f8a95;
+  font-size:.78rem;
+}
+
+section,
+.content-surface,
+.card,
+.admin-panel,
+.admin-section,
+.collapsible-card,
+.admin-actions,
+.admin-staff-card,
+.admin-shift-row,
+.admin-selection-prompt,
+.admin-create-drawer,
+.admin-optional-fields,
+.form-check,
+.operations-form,
+.operations-list > div,
+.operations-list > article,
+.compliance-summary article,
+.profile-stats div,
+.assurance-grid article,
+.setup-walkthrough article,
+.release-steps li,
+.release-checks article,
+.watch-history-list article,
+.publication-history article,
+.release-evidence,
+.release-evidence__grid section,
+.onboarding-checklist a,
+.counter-mapping-grid label,
+.overtime-page > .card,
+.overtime-page > form.card {
+  color:var(--text);
+  border-color:var(--line);
+  border-radius:var(--radius-md);
+  background:var(--card);
+  box-shadow:var(--shadow-soft);
+  backdrop-filter:none;
+}
+
+.card {
+  padding:1.25rem;
+  margin-bottom:1rem;
+}
+
+.card-hd,
+.card-header {
+  color:#e8edf2;
+  font-size:1rem;
+  font-weight:650;
+  letter-spacing:-.01em;
+}
+
+.card-bd,
+.card-body { color:var(--text); }
+
+.compliance-hero,
+.admin-function-heading,
+.profile-hero {
+  min-height:0;
+  padding:1.25rem 1.35rem;
+  margin:0 0 .5rem;
+  align-items:center;
+  border:1px solid var(--line);
+  border-left:3px solid #4d817e;
+  border-radius:var(--radius-md);
+  background:#151a21;
+  box-shadow:var(--shadow-soft);
+}
+
+.compliance-hero h1,
+.compliance-hero h2,
+.admin-function-heading h1,
+.admin-function-heading h2,
+.profile-hero h2 {
+  margin:.15rem 0 .3rem;
+  font-size:1.45rem;
+  letter-spacing:-.018em;
+}
+
+.compliance-hero p,
+.admin-function-heading p,
+.profile-hero p {
+  font-size:.9rem;
+  line-height:1.45;
+}
+
+.admin-eyebrow,
+.admin-step {
+  margin-bottom:.2rem;
+  color:#7f8b96;
+  font-size:.68rem;
+  font-weight:650;
+  letter-spacing:.035em;
+  text-transform:none;
+}
+
+.btn,
+a.btn,
+button,
+.btn-primary,
+.btn-secondary,
+.btn-success,
+.btn-warning,
+.btn-danger,
+.btn-info,
+.admin-section-tab,
+.report-menu-item {
+  min-height:36px;
+  padding:.45rem .8rem;
+  border:1px solid var(--control-border);
+  border-radius:6px;
+  background:var(--control-surface);
+  color:#dce3e8;
+  box-shadow:none;
+  text-shadow:none;
+  font-size:.84rem;
+  font-weight:600;
+  letter-spacing:0;
+  transform:none;
+  transition:background .12s ease, border-color .12s ease, color .12s ease;
+}
+
+.btn:hover,
+a.btn:hover,
+button:hover,
+.btn-secondary:hover,
+.btn-success:hover,
+.btn-warning:hover,
+.btn-info:hover,
+.admin-section-tab:hover,
+.report-menu-item:hover {
+  border-color:var(--control-border-hover);
+  background:var(--control-surface-hover);
+  color:#fff;
+  box-shadow:none;
+  transform:none;
+}
+
+.btn-primary,
+a.btn-primary {
+  border-color:#568f8b;
+  background:#356d69;
+  color:#fff;
+}
+
+.btn-primary:hover,
+a.btn-primary:hover {
+  border-color:#6aa9a5;
+  background:#407b77;
+}
+
+.btn-danger,
+.admin-danger-action .btn {
+  border-color:#694042;
+  background:#291b1d;
+  color:#e8b1b4;
+}
+
+.btn-danger:hover,
+.admin-danger-action .btn:hover {
+  border-color:#8a5256;
+  background:#352124;
+  color:#f1c4c6;
+}
+
+label {
+  color:#c5cdd4;
+  font-size:.84rem;
+  font-weight:550;
+  letter-spacing:0;
+  text-transform:none;
+}
+
+input,
+select,
+textarea,
+.form-control,
+.form-select {
+  min-height:38px;
+  border:1px solid #36414c;
+  border-radius:6px;
+  background:#10151b;
+  color:#e4e9ed;
+  box-shadow:none;
+  font:500 .9rem/1.4 var(--font-sans);
+}
+
+input:focus,
+select:focus,
+textarea:focus,
+.form-control:focus,
+.form-select:focus {
+  border-color:#609995;
+  background:#10151b;
+  color:#fff;
+  outline:2px solid rgba(104,183,178,.15);
+  box-shadow:none;
+}
+
+input::placeholder,
+textarea::placeholder { color:#687582; }
+
+.password-toggle {
+  min-height:38px;
+  border-radius:0 6px 6px 0;
+}
+
+.admin-section-nav {
+  top:86px;
+  gap:.3rem;
+  padding:.45rem;
+  border-color:var(--line);
+  border-radius:8px;
+  background:#11171e;
+  box-shadow:0 4px 12px rgba(0,0,0,.16);
+  backdrop-filter:none;
+}
+
+.admin-section-tab.active {
+  border-color:#466f6d;
+  background:#223534;
+  color:#e8f3f2;
+}
+
+table:not(.roster),
+.table-responsive {
+  border-color:var(--line);
+  border-radius:7px;
+  background:#12171d;
+  box-shadow:none;
+}
+
+table:not(.roster) thead th {
+  background:#1b222b;
+  color:#b9c3cc;
+  font-size:.72rem;
+  font-weight:650;
+  letter-spacing:.025em;
+  text-transform:none;
+}
+
+table:not(.roster) tbody tr:nth-child(even) { background:#141a21; }
+table:not(.roster) tbody tr:hover { background:#1a222b; }
+
+table:not(.roster) th,
+table:not(.roster) td {
+  border-color:#27303a;
+  padding:.62rem .75rem;
+}
+
+.month-nav {
+  padding:.7rem .85rem;
+  border-color:var(--line);
+  border-radius:7px;
+  background:#151a21;
+  box-shadow:none;
+}
+
+.month-nav strong {
+  color:#e5eaee;
+  font-size:.95rem;
+  letter-spacing:0;
+}
+
+.report-menu-item {
+  min-height:82px;
+  align-items:flex-start;
+  text-align:left;
+  background:#171d24;
+}
+
+.report-menu-item:hover {
+  border-color:#49615f;
+  background:#1b252c;
+}
+
+.alert,
+.flash {
+  border-radius:6px;
+  box-shadow:none;
+}
+
+.annotation-edit-button {
+  min-height:16px;
+  padding:0;
+  border:0;
+  background:transparent;
+}
+
+.annotation-dialog__close {
+  min-height:34px;
+  padding:0;
+}
+
+@media (max-width:900px) {
+  .site-header { padding:.65rem 1rem; }
+  .brand-mark { width:32px; height:32px; flex-basis:32px; }
+  .main-nav { gap:.25rem; }
+  .main-nav.is-open { grid-template-columns:1fr 1fr; }
+  .nav-link { min-height:40px; }
+  .admin-section-nav {
+    position:static;
+    grid-template-columns:repeat(2, minmax(0, 1fr));
+    overflow:visible;
+  }
+  .admin-section-nav .admin-section-tab {
+    width:100%;
+    min-width:0;
+  }
+}
+
+@media (max-width:520px) {
+  .brand-mark { display:grid; }
+  .logo { font-size:1rem; }
+  .main-nav.is-open { grid-template-columns:1fr; }
+  .page-content { padding-inline:.8rem; }
+  .app-main { padding-top:1.25rem; }
+}

--- a/static/styles.css
+++ b/static/styles.css
@@ -911,6 +911,10 @@ select.code-input{
   gap:2px;
   margin-top:1px;
 }
+.annotation-display--shift-line{
+  min-height:28px;
+  margin-top:0;
+}
 .annotation-code{
   display:inline-block;
   max-width:calc(100% - 17px);
@@ -925,36 +929,92 @@ select.code-input{
   font-weight:800;
   line-height:1.2;
 }
-.annotation-detail-editor{position:relative;}
-.annotation-detail-editor summary{
-  width:14px;
-  height:14px;
+.annotation-display--shift-line .annotation-code{
+  max-width:calc(100% - 20px);
+  font-size:clamp(9px, .72rem, 12px);
+  line-height:1.1;
+}
+.annotation-edit-button{
+  width:16px;
+  height:16px;
   display:grid;
   place-items:center;
   border-radius:3px;
+  border:0;
+  padding:0;
+  background:transparent;
   color:var(--text-muted);
   font-size:10px;
   cursor:pointer;
-  list-style:none;
 }
-.annotation-detail-editor summary::-webkit-details-marker{display:none;}
-.annotation-detail-editor[open] form{
-  position:absolute;
-  z-index:30;
-  right:0;
-  bottom:18px;
-  width:190px;
-  padding:6px;
+.annotation-edit-button:hover,
+.annotation-edit-button:focus-visible{
+  background:rgba(83,170,255,.14);
+  color:#fff;
+}
+.annotation-dialog{
+  width:min(520px, calc(100vw - 2rem));
+  max-width:520px;
+  padding:0;
   border:1px solid var(--border);
-  border-radius:6px;
+  border-radius:12px;
   background:var(--card);
-  box-shadow:0 8px 24px rgba(0,0,0,.4);
+  color:var(--text);
+  box-shadow:0 18px 60px rgba(0,0,0,.65);
 }
-.annotation-detail-editor textarea{
+.annotation-dialog::backdrop{background:rgba(0,0,0,.72);}
+.annotation-dialog form{padding:1.1rem;}
+.annotation-dialog__header{
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:1rem;
+  margin-bottom:1rem;
+}
+.annotation-dialog__header h3{
+  margin:.2rem 0 0;
+  font-size:1.1rem;
+}
+.annotation-dialog__close{
+  min-width:34px;
+  min-height:34px;
+  padding:0;
+  border-radius:7px;
+  font-size:1.35rem;
+  line-height:1;
+}
+.annotation-dialog label{
+  display:block;
+  margin-bottom:.45rem;
+  font-size:.9rem;
+  font-weight:600;
+}
+.annotation-dialog textarea{
   width:100%;
-  margin-bottom:4px;
+  min-height:150px;
+  padding:.75rem;
+  border:1px solid var(--control-border);
+  border-radius:8px;
+  background:rgba(0,0,0,.28);
+  color:var(--text);
   resize:vertical;
-  font-size:11px;
+  font:500 1rem/1.45 Inter, sans-serif;
+}
+.annotation-dialog textarea:focus{
+  border-color:var(--control-border-hover);
+  outline:2px solid rgba(83,170,255,.22);
+}
+.annotation-dialog__count{
+  margin-top:.35rem;
+  color:var(--text-muted);
+  font-size:.78rem;
+  text-align:right;
+}
+.annotation-dialog__actions{
+  display:flex;
+  justify-content:flex-end;
+  gap:.5rem;
+  margin-top:1rem;
 }
 
 tfoot td{background:var(--card); font-weight:bold; color:var(--text);}
@@ -2485,4 +2545,46 @@ button:hover,
   border-color:var(--control-border);
   background:var(--panel-surface);
   box-shadow:none;
+}
+
+.site-footer__links {
+  display:flex;
+  flex-wrap:wrap;
+  gap:.5rem 1rem;
+}
+
+.site-footer__links a {
+  color:var(--muted);
+  font-size:.85rem;
+  text-decoration:none;
+}
+
+.site-footer__links a:hover,
+.site-footer__links a:focus-visible {
+  color:var(--text);
+  text-decoration:underline;
+}
+
+.legal-page {
+  max-width:900px;
+  margin-inline:auto;
+}
+
+.legal-page h2 {
+  margin-top:2rem;
+  font-size:1.2rem;
+}
+
+.legal-page h3 {
+  margin-top:1.25rem;
+  font-size:1rem;
+}
+
+.legal-page li + li {
+  margin-top:.35rem;
+}
+
+.legal-meta {
+  color:var(--muted);
+  font-size:.9rem;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -144,6 +144,12 @@
       <div>
         <span class="site-footer__copyright">&copy; {{ now().year }} IDAviation</span>
       </div>
+      <nav class="site-footer__links" aria-label="Legal information">
+        <a href="{{ url_for('privacy_notice') }}">Privacy</a>
+        <a href="{{ url_for('cookie_notice') }}">Cookies</a>
+        <a href="{{ url_for('terms_of_service') }}">Terms</a>
+        <a href="{{ url_for('subprocessor_notice') }}">Subprocessors</a>
+      </nav>
     </div>
   </footer>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,12 +6,9 @@
   <meta name="color-scheme" content="dark">
   <link rel="icon" href="{{ url_for('favicon') }}" type="image/svg+xml">
   <link rel="manifest" href="{{ url_for('static', filename='manifest.webmanifest') }}">
-  <meta name="theme-color" content="#16283a">
+  <meta name="theme-color" content="#11161d">
   <title>{% block title %}{% endblock %} – ATC Roster</title>
 
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-TbP2oT4maGdTKStZJ9+doRTO1D94avYVbwybXDq3s1ymUOI1IKXey9HvK+nZd9kpGdn6FQkR0fF6Bw7+Xw8FfA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
   <link rel="stylesheet" href="{{ asset_url('styles.css') }}">
@@ -36,7 +33,7 @@
   <header class="site-header">
     <div class="nav-container">
       <div class="brand">
-        <span class="brand-mark" aria-hidden="true"><span></span></span>
+        <span class="brand-mark" aria-hidden="true"><span>AR</span></span>
         <div class="brand-copy">
           <h1 class="logo">{{ unit_branding.display_name if unit_branding and unit_branding.display_name else 'ATC Roster' }}</h1>
         </div>

--- a/templates/cookies.html
+++ b/templates/cookies.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block title %}Cookie notice{% endblock %}
+{% block content %}
+<article class="legal-page card"><div class="card-bd">
+  <p class="admin-step">Legal information</p>
+  <h1>Cookie and local-storage notice</h1>
+  <p class="legal-meta">Effective {{ policy_date }}</p>
+  <p>ATCRoster does not currently use advertising or analytics cookies. It uses storage that is necessary to authenticate users, protect forms and preserve requested interface settings.</p>
+
+  <h2>Technologies used</h2>
+  <div class="table-responsive"><table class="table">
+    <thead><tr><th>Name or category</th><th>Purpose</th><th>Duration</th></tr></thead>
+    <tbody>
+      <tr><td><code>__Host-atcroster</code> or <code>atcroster_session</code></td><td>Authentication, security, MFA state, messages and CSRF protection.</td><td>Session/maximum configured session lifetime.</td></tr>
+      <tr><td>Roster zoom and interface preferences</td><td>Remember settings expressly chosen on this device.</td><td>Until cleared in browser settings.</td></tr>
+      <tr><td>Service-worker cache</td><td>Cache application assets for reliable and efficient loading.</td><td>Until replaced by a new version or cleared.</td></tr>
+    </tbody>
+  </table></div>
+  <p>These technologies are limited to providing and securing the service you request, so ATCRoster does not present a consent banner for them. If optional analytics, advertising or other non-essential technology is introduced, it must remain disabled until an appropriate consent mechanism is deployed and this notice is updated.</p>
+  <h2>Your controls</h2>
+  <p>You can clear cookies and site data in your browser. Blocking necessary storage will prevent login or make parts of the roster interface unavailable.</p>
+  <h2>Contact</h2>
+  {% if privacy_email %}<p>Questions may be sent to <a href="mailto:{{ privacy_email }}">{{ privacy_email }}</a>.</p>{% else %}<p>Contact your Unit Administrator for escalation to {{ legal_entity }}.</p>{% endif %}
+</div></article>
+{% endblock %}

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+{% block title %}Privacy notice{% endblock %}
+{% block content %}
+<article class="legal-page card">
+  <div class="card-bd">
+    <p class="admin-step">Legal information</p>
+    <h1>ATCRoster privacy notice</h1>
+    <p class="legal-meta">Effective {{ policy_date }}</p>
+
+    <h2>Who is responsible for your information?</h2>
+    <p>Your airport or air traffic services unit decides why operational and employment information is entered into ATCRoster and is normally the data controller. {{ legal_entity }} supplies and operates ATCRoster on the unit's instructions and is normally its data processor.</p>
+    <p>{{ legal_entity }} is separately a controller for limited platform administration, account security, service support, billing and legal-compliance information.</p>
+
+    <h2>Information processed</h2>
+    <ul>
+      <li>identity and work details, including name, username, staff number, role, watch and airport;</li>
+      <li>contact details, including email address and telephone number;</li>
+      <li>rosters, shift requests, annotations, overtime, TOIL, leave and availability;</li>
+      <li>qualification, endorsement, medical-validity and training status;</li>
+      <li>sickness and absence records, which may constitute health information;</li>
+      <li>account, MFA, invitation, recovery, login, audit and security records;</li>
+      <li>SMS delivery records, including sender, recipient, time and message content; and</li>
+      <li>technical records such as IP address, browser information and service logs where required for security and reliability.</li>
+    </ul>
+
+    <h2>Purposes and lawful bases</h2>
+    <p>Your unit determines its lawful bases and any additional condition required for health information. Typical purposes include managing staffing, operational competence, fatigue risk, leave, absence, communications and legal or employment obligations. Ask your unit for its workforce privacy notice for the exact bases it relies upon.</p>
+    <p>{{ legal_entity }} processes unit information to provide, secure, support and maintain the contracted service. For its own limited controller activities it relies, as applicable, on performance of a contract, legitimate interests in operating and securing the service, and compliance with legal obligations.</p>
+
+    <h2>Who receives information?</h2>
+    <p>Information is available only to authorised users according to their unit and role. Service providers may process limited information to host the platform, deliver email or SMS, operate infrastructure, create backups and provide support. The current provider list is published on the <a href="{{ url_for('subprocessor_notice') }}">subprocessors page</a>.</p>
+    <p>Information may also be disclosed where required by law, to protect legal rights, or to investigate a security incident.</p>
+
+    <h2>International transfers</h2>
+    <p>Some service providers may process information outside the United Kingdom. {{ legal_entity }} will use an applicable UK transfer safeguard and transfer-risk assessment where required. Airport customers should review the subprocessor list before enabling optional communications services.</p>
+
+    <h2>Retention and deletion</h2>
+    <p>Your unit sets retention periods for operational, employment and health records. {{ legal_entity }} retains information only for the contracted service, security, support and legal purposes, then returns, deletes or anonymises it in accordance with the contract and documented instructions. Backup copies expire through the applicable backup-retention cycle.</p>
+
+    <h2>Security</h2>
+    <p>Safeguards include tenant separation, role-based permissions, password hashing, MFA support, encrypted secrets, protected session cookies, audit logging, transport encryption and controlled database access. No online service can guarantee absolute security.</p>
+
+    <h2>Your rights</h2>
+    <p>Depending on the circumstances, you may have rights of access, correction, erasure, restriction, objection and data portability, and the right to complain to the Information Commissioner's Office. Contact your unit first about operational or employment records because it controls that information. The unit can refer technical requests to {{ legal_entity }}.</p>
+
+    <h2>Contact</h2>
+    {% if privacy_email %}<p>Email {{ legal_entity }} at <a href="mailto:{{ privacy_email }}">{{ privacy_email }}</a>.</p>{% else %}<p>Contact your Unit Administrator and ask for the request to be escalated to {{ legal_entity }}. A public privacy email must be configured before commercial launch.</p>{% endif %}
+    {% if legal_address %}<p>{{ legal_address }}</p>{% endif %}
+    {% if company_number %}<p>Company number: {{ company_number }}</p>{% endif %}
+    <p>You can complain to the <a href="https://ico.org.uk/make-a-complaint/" rel="external">Information Commissioner's Office</a>.</p>
+
+    <h2>Changes</h2>
+    <p>Material changes will be posted here and, where appropriate, communicated to airport customers before they take effect.</p>
+  </div>
+</article>
+{% endblock %}

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -1,6 +1,47 @@
 {% extends "base.html" %}
 {% block title %}Roster {{ month_title }}{% endblock %}
 
+{% macro annotation_badge(staff, roster_day, value, detail, editable, shift_line=false) -%}
+  {% set dialog_id = 'annotation-detail-' ~ staff.id ~ '-' ~ roster_day.strftime('%Y%m%d') %}
+  <div class="annotation-display{% if shift_line %} annotation-display--shift-line{% endif %}">
+    <span class="annotation-code" tabindex="0"
+          {% if detail %}title="{{ detail }}"{% endif %}
+          aria-label="{{ value }}{% if detail %}: {{ detail }}{% endif %}">{{ value }}</span>
+    {% if editable %}
+      <button type="button" class="annotation-edit-button"
+              data-annotation-dialog-open="{{ dialog_id }}"
+              title="{% if detail %}Edit annotation text{% else %}Add annotation text{% endif %}"
+              aria-label="{% if detail %}Edit text for {{ value }}{% else %}Add text for {{ value }}{% endif %}">
+        <i class="fa-solid fa-pencil" aria-hidden="true"></i>
+      </button>
+      <dialog class="annotation-dialog" id="{{ dialog_id }}"
+              aria-labelledby="{{ dialog_id }}-title">
+        <form method="post" action="{{ url_for('assign_cell', staff_id=staff.id, ym=ym, day=roster_day.isoformat()) }}">
+          <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+          <input type="hidden" name="annotation" value="{{ value }}">
+          <input type="hidden" name="annotation_detail_update" value="1">
+          <div class="annotation-dialog__header">
+            <div>
+              <span class="admin-step">Annotation text</span>
+              <h3 id="{{ dialog_id }}-title">{{ staff.name }} · {{ roster_day.strftime('%d %B %Y') }}</h3>
+            </div>
+            <button type="button" class="annotation-dialog__close"
+                    data-annotation-dialog-close aria-label="Close annotation editor">×</button>
+          </div>
+          <label for="{{ dialog_id }}-text">Text shown when the {{ value }} annotation is hovered over</label>
+          <textarea id="{{ dialog_id }}-text" name="annotation_note" maxlength="140"
+                    rows="6" placeholder="Add clear, concise context for this annotation">{{ detail }}</textarea>
+          <div class="annotation-dialog__count"><span data-annotation-character-count>{{ detail|length }}</span>/140 characters</div>
+          <div class="annotation-dialog__actions">
+            <button type="button" class="btn btn-sm" data-annotation-dialog-close>Cancel</button>
+            <button type="submit" class="btn btn-primary btn-sm">Save text</button>
+          </div>
+        </form>
+      </dialog>
+    {% endif %}
+  </div>
+{%- endmacro %}
+
 {% block content %}
 <style>
   :root { --today-col: rgba(255,255,0,.85); }
@@ -157,7 +198,10 @@
                 </span>
               </span>
             {% endif %}
-            <!-- SHIFT CODE -->
+            <!-- SHIFT CODE (an annotation occupies this line when no shift exists) -->
+            {% if ann and not code %}
+              {{ annotation_badge(s, d, ann, ann_note, can_edit and not readonly, true) }}
+            {% else %}
             <form method="post" action="{{ url_for('assign_cell', staff_id=s.id, ym=ym, day=d.isoformat()) }}">
               <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
               <select
@@ -194,6 +238,7 @@
                 </optgroup>
               </select>
             </form>
+            {% endif %}
 
             {% set req_info = req_pending_map.get((s.id, d)) %}
             {% if req_info %}
@@ -235,27 +280,8 @@
                      aria-label="{{ s.name }} annotation note on {{ d.strftime('%d %B %Y') }}">
               <button type="submit" class="btn btn-sm annotation-apply" hidden>Apply annotation</button>
             </form>
-            {% if ann %}
-              <div class="annotation-display">
-                <span class="annotation-code" tabindex="0"
-                      {% if ann_note %}title="{{ ann_note }}"{% endif %}
-                      aria-label="{{ ann }}{% if ann_note %}: {{ ann_note }}{% endif %}">{{ ann }}</span>
-                {% if can_edit and not readonly %}
-                  <details class="annotation-detail-editor">
-                    <summary title="{% if ann_note %}Edit annotation detail{% else %}Add annotation detail{% endif %}"
-                             aria-label="{% if ann_note %}Edit detail for {{ ann }}{% else %}Add detail for {{ ann }}{% endif %}">✎</summary>
-                    <form method="post" action="{{ url_for('assign_cell', staff_id=s.id, ym=ym, day=d.isoformat()) }}">
-                      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
-                      <input type="hidden" name="annotation" value="{{ ann }}">
-                      <input type="hidden" name="annotation_detail_update" value="1">
-                      <textarea name="annotation_note" maxlength="140" rows="2"
-                                placeholder="Optional detail shown on hover"
-                                aria-label="Detail for {{ ann }}">{{ ann_note }}</textarea>
-                      <button type="submit" class="btn btn-sm">Save</button>
-                    </form>
-                  </details>
-                {% endif %}
-              </div>
+            {% if ann and code %}
+              {{ annotation_badge(s, d, ann, ann_note, can_edit and not readonly) }}
             {% endif %}
           </td>
         {% endfor %}
@@ -356,6 +382,29 @@
       note.required = needsNote;
       if (needsNote) note.focus();
       else form.requestSubmit();
+    });
+  });
+  document.querySelectorAll('[data-annotation-dialog-open]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const dialog = document.getElementById(button.dataset.annotationDialogOpen);
+      if (!dialog) return;
+      dialog.showModal();
+      const textarea = dialog.querySelector('textarea');
+      textarea?.focus();
+      textarea?.setSelectionRange(textarea.value.length, textarea.value.length);
+    });
+  });
+  document.querySelectorAll('.annotation-dialog').forEach((dialog) => {
+    dialog.querySelectorAll('[data-annotation-dialog-close]').forEach((button) => {
+      button.addEventListener('click', () => dialog.close());
+    });
+    dialog.addEventListener('click', (event) => {
+      if (event.target === dialog) dialog.close();
+    });
+    const textarea = dialog.querySelector('textarea');
+    const counter = dialog.querySelector('[data-annotation-character-count]');
+    textarea?.addEventListener('input', () => {
+      if (counter) counter.textContent = textarea.value.length;
     });
   });
 </script>

--- a/templates/subprocessors.html
+++ b/templates/subprocessors.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block title %}Subprocessors{% endblock %}
+{% block content %}
+<article class="legal-page card"><div class="card-bd">
+  <p class="admin-step">Legal information</p>
+  <h1>ATCRoster subprocessors</h1>
+  <p class="legal-meta">Effective {{ policy_date }}</p>
+  <p>This list identifies providers currently expected to process customer information for the hosted ATCRoster service. The signed customer agreement and deployment configuration remain authoritative.</p>
+  <div class="table-responsive"><table class="table">
+    <thead><tr><th>Provider</th><th>Purpose</th><th>Information</th><th>Location/transfer</th></tr></thead>
+    <tbody>
+      <tr><td>Railway Corporation</td><td>Application, PostgreSQL and Redis infrastructure</td><td>Account, roster, operational, audit and technical service data</td><td>Configured deployment region; confirm the production region and contractual transfer terms</td></tr>
+      <tr><td>Twilio Inc.</td><td>Optional operational SMS delivery</td><td>Telephone numbers, message content, delivery metadata</td><td>Global provider; applicable UK transfer safeguards required</td></tr>
+      <tr><td>Configured email provider</td><td>Invitations, recovery and service email</td><td>Email address, delivery metadata and message content</td><td>Provider and region must be recorded before launch</td></tr>
+      <tr><td>Configured backup provider</td><td>Encrypted resilient backups and recovery</td><td>Encrypted copies of hosted customer data</td><td>Provider and region must be recorded before launch</td></tr>
+    </tbody>
+  </table></div>
+  <p>Airport customers should receive advance notice of a new subprocessor and a reasonable opportunity to object on genuine data-protection grounds, as specified in the data-processing agreement.</p>
+  {% if privacy_email %}<p>Questions or objections: <a href="mailto:{{ privacy_email }}">{{ privacy_email }}</a>.</p>{% endif %}
+</div></article>
+{% endblock %}

--- a/templates/terms.html
+++ b/templates/terms.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% block title %}Terms of use{% endblock %}
+{% block content %}
+<article class="legal-page card"><div class="card-bd">
+  <p class="admin-step">Legal information</p>
+  <h1>ATCRoster user terms</h1>
+  <p class="legal-meta">Effective {{ policy_date }}</p>
+  <p>These user terms apply alongside the agreement between {{ legal_entity }} and your airport or air traffic services unit. If they conflict, the customer agreement controls.</p>
+
+  <h2>Authorised use</h2>
+  <p>Use ATCRoster only for your authorised unit duties. Keep your credentials and MFA recovery codes secure, do not share accounts, and immediately report suspected compromise. You must not access another person's account or another unit's information, test security without written permission, introduce malicious content, or interfere with the service.</p>
+
+  <h2>Operational responsibility</h2>
+  <p>ATCRoster is a roster-management and decision-support service. Fatigue, qualification, staffing and other warnings require competent human review. The service does not replace applicable law, regulatory requirements, local safety-management systems, operational instructions or accountable management decisions. Users must verify safety-significant information before relying upon it.</p>
+
+  <h2>Accuracy and changes</h2>
+  <p>Users must enter accurate information and correct known errors promptly. Draft rosters may change. Publication status does not by itself certify regulatory compliance or operational fitness.</p>
+
+  <h2>Communications</h2>
+  <p>Operational email and SMS must be relevant, proportionate and sent only by authorised roles. Do not include unnecessary medical or sensitive information in message content. Delivery is not guaranteed; urgent or safety-critical communication requires the unit's approved primary method and confirmation process.</p>
+
+  <h2>Availability and support</h2>
+  <p>The service may be interrupted for maintenance, security, provider outages or circumstances outside reasonable control. Support, availability commitments, data export, suspension and termination are governed by the customer agreement.</p>
+
+  <h2>Intellectual property</h2>
+  <p>{{ legal_entity }} and its licensors retain rights in ATCRoster and its software. Customers and users retain rights in information they lawfully provide. No right is granted to copy, resell, reverse engineer or create a competing service from protected elements except where law cannot exclude that right.</p>
+
+  <h2>Privacy</h2>
+  <p>See the <a href="{{ url_for('privacy_notice') }}">privacy notice</a> and your unit's workforce privacy information.</p>
+
+  <h2>Contact</h2>
+  {% if privacy_email %}<p>Contact <a href="mailto:{{ privacy_email }}">{{ privacy_email }}</a>.</p>{% else %}<p>Contact your Unit Administrator, who can escalate the matter to {{ legal_entity }}.</p>{% endif %}
+</div></article>
+{% endblock %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -39,6 +39,29 @@ from app import (
 ADMIN_CREDENTIALS = {"username": "admin_test", "password": "password123"}
 
 
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        ("/privacy", b"ATCRoster privacy notice"),
+        ("/cookies", b"Cookie and local-storage notice"),
+        ("/terms", b"ATCRoster user terms"),
+        ("/subprocessors", b"ATCRoster subprocessors"),
+    ],
+)
+def test_public_legal_pages(client, path, expected):
+    response = client.get(path)
+    assert response.status_code == 200
+    assert expected in response.data
+
+
+def test_privacy_notice_identifies_operator_and_contact(client):
+    response = client.get("/privacy")
+    assert response.status_code == 200
+    assert b"Ian John Dickson trading as IDAviation" in response.data
+    assert b"Flat 0/2, 24 Caird Drive" in response.data
+    assert b"privacy@atcroster.com" in response.data
+
+
 @pytest.fixture(scope="module", autouse=True)
 def setup_database():
     with app.app.app_context():

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -62,6 +62,13 @@ def test_privacy_notice_identifies_operator_and_contact(client):
     assert b"privacy@atcroster.com" in response.data
 
 
+def test_public_shell_uses_local_professional_branding(client):
+    response = client.get("/login")
+    assert response.status_code == 200
+    assert b'<span class="brand-mark" aria-hidden="true"><span>AR</span>' in response.data
+    assert b"fonts.googleapis.com" not in response.data
+
+
 @pytest.fixture(scope="module", autouse=True)
 def setup_database():
     with app.app.app_context():

--- a/tests/test_shift_request_security.py
+++ b/tests/test_shift_request_security.py
@@ -705,6 +705,15 @@ def test_roster_shows_annotation_once_and_hover_detail_can_be_edited(
         refresh_annotation_cache()
 
     token = login(secured_client, "admin-a")
+    with app.app.app_context():
+        db.session.add(Assignment(
+            unit_id=1,
+            staff_id=target_id,
+            day=request_day(),
+            code="",
+            source="manual",
+        ))
+        db.session.commit()
     endpoint = (
         f"/assign/{target_id}/{request_day():%Y-%m}/"
         f"{request_day():%Y-%m-%d}"
@@ -719,6 +728,9 @@ def test_roster_shows_annotation_once_and_hover_detail_can_be_edited(
     assert page.status_code == 200
     assert b'<option value="" selected>' in page.data
     assert b'class="annotation-code"' in page.data
+    assert b"annotation-display--shift-line" in page.data
+    assert b'class="annotation-dialog"' in page.data
+    assert b"Save text" in page.data
     assert b"Current: NEAT" not in page.data
 
     updated = secured_client.post(
@@ -737,10 +749,18 @@ def test_roster_shows_annotation_once_and_hover_detail_can_be_edited(
         ).one()
         assert assignment.annotation_note == "Cover requested by tower"
         assert assignment.note != "Cover requested by tower"
+        audit = AnnotationAudit.query.filter_by(
+            unit_id=1,
+            assignment_id=assignment.id,
+            action="detail_updated",
+        ).one()
+        assert audit.old_value == ""
+        assert audit.new_value == "Cover requested by tower"
 
     page = secured_client.get(f"/roster/{request_day():%Y-%m}")
     assert b'title="Cover requested by tower"' in page.data
     assert page.data.count(b">NEAT</span>") == 1
+    assert b">Cover requested by tower</textarea>" in page.data
 
 
 def test_bulk_annotation_feature_is_removed(secured_client):


### PR DESCRIPTION
## What changed

- adds public privacy, cookie, terms and subprocessor pages with the supplied IDAviation legal identity and contact details
- adds the UK privacy foundation: DPA, DPIA, retention, rights, special-category data and incident procedures
- adds production operations guidance for monitoring, support, incidents, releases and service ownership
- adds a commercial launch pack covering pricing assumptions, onboarding, training, service levels, demos and assurance
- adds a scheduled production health probe for the live, ready and login endpoints
- improves roster annotations so an annotation replaces an empty shift dash, provides a readable pencil editor, shows saved text on hover and audits text edits

## Why

ATCRoster needs documented privacy, operational and commercial controls before moving beyond pilot use. The roster annotation UI also placed annotations beneath empty shifts and exposed an editor that was clipped and difficult to use.

## Validation

- `python -m pytest -q` — 123 passed, 2 skipped
- focused annotation tests — 4 passed
- focused public legal-page tests — 5 passed
- production live, ready and login endpoints returned healthy responses
- all GitHub workflow YAML parsed successfully
- `git diff --check` passed

## Remaining owner actions

- confirm the production SMTP/email provider
- upgrade and verify Railway region/contract terms
- configure independent backup storage and complete restore evidence
- complete ICO assessment and obtain professional legal review before commercial signature
- approve public pricing and contractual service targets