### PR TITLE
Restore the header radar icon

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -2681,20 +2681,29 @@ a:focus-visible { color:var(--accent-strong); }
   height:34px;
   flex:0 0 34px;
   border:1px solid #4a7775;
-  border-radius:6px;
-  background:#19302f;
-  box-shadow:none;
+  border-radius:50%;
+  background:
+    radial-gradient(circle, #b7dfdc 0 2px, transparent 3px),
+    repeating-radial-gradient(circle, transparent 0 5px, rgba(118, 181, 176, .25) 6px 7px),
+    #19302f;
+  box-shadow:0 0 0 3px rgba(118, 181, 176, .08);
   overflow:hidden;
 }
 
-.brand-mark::before,
-.brand-mark::after { display:none; }
+.brand-mark::before {
+  display:block;
+  background:linear-gradient(90deg, #8fcac6, transparent);
+  animation:radar-sweep 5s linear infinite;
+}
+
+.brand-mark::after {
+  display:block;
+  inset:4px;
+  border-color:rgba(183, 223, 220, .2);
+}
 
 .brand-mark span {
-  color:#b7dfdc;
-  font-size:.68rem;
-  font-weight:750;
-  letter-spacing:.03em;
+  display:none;
 }
 
 .logo {

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,7 +33,7 @@
   <header class="site-header">
     <div class="nav-container">
       <div class="brand">
-        <span class="brand-mark" aria-hidden="true"><span>AR</span></span>
+        <span class="brand-mark" aria-hidden="true"><span></span></span>
         <div class="brand-copy">
           <h1 class="logo">{{ unit_branding.display_name if unit_branding and unit_branding.display_name else 'ATC Roster' }}</h1>
         </div>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -65,7 +65,7 @@ def test_privacy_notice_identifies_operator_and_contact(client):
 def test_public_shell_uses_local_professional_branding(client):
     response = client.get("/login")
     assert response.status_code == 200
-    assert b'<span class="brand-mark" aria-hidden="true"><span>AR</span>' in response.data
+    assert b'<span class="brand-mark" aria-hidden="true"><span></span>' in response.data
     assert b"fonts.googleapis.com" not in response.data
 
 


### PR DESCRIPTION
## Summary
- restore the animated radar mark in the top-left header
- retain the restrained teal design-system palette
- update the rendered-header regression test

## Validation
- `python -m pytest -q` — 125 passed, 2 skipped
- `git diff --check`