### PR TITLE
Keep roster annotations in their assigned slot

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -904,15 +904,17 @@ select.code-input{
   font-size:10px;
 }
 .annotation-display{
-  min-height:16px;
+  min-height:calc(20px * var(--ui-scale));
+  height:calc(20px * var(--ui-scale));
   display:flex;
   align-items:center;
   justify-content:center;
   gap:2px;
-  margin-top:1px;
+  margin:0;
 }
 .annotation-display--shift-line{
-  min-height:28px;
+  min-height:calc(28px * var(--ui-scale));
+  height:calc(28px * var(--ui-scale));
   margin-top:0;
 }
 .annotation-code{
@@ -951,6 +953,29 @@ select.code-input{
 .annotation-edit-button:focus-visible{
   background:rgba(83,170,255,.14);
   color:#fff;
+}
+.annotation-remove-form{
+  display:flex;
+  margin:0;
+}
+.annotation-remove-form button{
+  width:14px;
+  height:16px;
+  display:grid;
+  place-items:center;
+  padding:0;
+  border:0;
+  border-radius:3px;
+  background:transparent;
+  color:var(--text-muted);
+  font-size:12px;
+  line-height:1;
+  cursor:pointer;
+}
+.annotation-remove-form button:hover,
+.annotation-remove-form button:focus-visible{
+  color:#fff;
+  background:var(--danger);
 }
 .annotation-dialog{
   width:min(520px, calc(100vw - 2rem));

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -14,6 +14,13 @@
               aria-label="{% if detail %}Edit text for {{ value }}{% else %}Add text for {{ value }}{% endif %}">
         <i class="fa-solid fa-pencil" aria-hidden="true"></i>
       </button>
+      <form class="annotation-remove-form" method="post"
+            action="{{ url_for('assign_cell', staff_id=staff.id, ym=ym, day=roster_day.isoformat()) }}">
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+        <button type="submit" name="annotation" value="__remove__"
+                title="Remove {{ value }} annotation"
+                aria-label="Remove {{ value }} annotation">×</button>
+      </form>
       <dialog class="annotation-dialog" id="{{ dialog_id }}"
               aria-labelledby="{{ dialog_id }}-title">
         <form method="post" action="{{ url_for('assign_cell', staff_id=staff.id, ym=ym, day=roster_day.isoformat()) }}">
@@ -248,6 +255,7 @@
             {% endif %}
 
             <!-- ANNOTATION -->
+            {% if not ann %}
             <form class="annotation-picker" method="post" action="{{ url_for('assign_cell', staff_id=s.id, ym=ym, day=d.isoformat()) }}">
               <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
               <select
@@ -259,9 +267,6 @@
                 aria-label="{{ s.name }} annotation on {{ d.strftime('%d %B %Y') }}"
               >
                 <option value="" selected>—</option>
-                {% if ann %}
-                  <option value="__remove__">Remove {{ ann }}</option>
-                {% endif %}
                 {% for group, opts in annotation_groups.items() %}
                   {% if opts %}
                   <optgroup label="{{ group }}">
@@ -280,6 +285,7 @@
                      aria-label="{{ s.name }} annotation note on {{ d.strftime('%d %B %Y') }}">
               <button type="submit" class="btn btn-sm annotation-apply" hidden>Apply annotation</button>
             </form>
+            {% endif %}
             {% if ann and code %}
               {{ annotation_badge(s, d, ann, ann_note, can_edit and not readonly) }}
             {% endif %}

--- a/tests/test_shift_request_security.py
+++ b/tests/test_shift_request_security.py
@@ -730,6 +730,8 @@ def test_roster_shows_annotation_once_and_hover_detail_can_be_edited(
     assert b'class="annotation-code"' in page.data
     assert b"annotation-display--shift-line" in page.data
     assert b'class="annotation-dialog"' in page.data
+    assert b'class="annotation-remove-form"' in page.data
+    assert b'aria-label="Remove NEAT annotation"' in page.data
     assert b"Save text" in page.data
     assert b"Current: NEAT" not in page.data
 


### PR DESCRIPTION
## Summary
- replace the annotation dash with the active annotation instead of adding another row
- preserve annotation text editing and provide an inline removal control
- match annotation replacement heights to the scaled roster controls so shift codes remain aligned

## Validation
- `python -m pytest -q` — 125 passed, 2 skipped
- `git diff --check`