### PR TITLE
Highlight roster annotation details

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -917,6 +917,23 @@ select.code-input{
   height:calc(28px * var(--ui-scale));
   margin-top:0;
 }
+.annotation-display--has-detail{
+  background:#ffeb3b;
+  color:#171717;
+}
+.annotation-display--has-detail .annotation-code{
+  border-color:transparent;
+  background:transparent;
+}
+.annotation-display--has-detail .annotation-edit-button,
+.annotation-display--has-detail .annotation-remove-form button{
+  color:#2d2d2d;
+}
+.annotation-display--has-detail .annotation-edit-button:hover,
+.annotation-display--has-detail .annotation-edit-button:focus-visible{
+  background:rgba(0,0,0,.12);
+  color:#000;
+}
 .annotation-code{
   display:inline-block;
   max-width:calc(100% - 17px);

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -3,7 +3,7 @@
 
 {% macro annotation_badge(staff, roster_day, value, detail, editable, shift_line=false) -%}
   {% set dialog_id = 'annotation-detail-' ~ staff.id ~ '-' ~ roster_day.strftime('%Y%m%d') %}
-  <div class="annotation-display{% if shift_line %} annotation-display--shift-line{% endif %}">
+  <div class="annotation-display{% if shift_line %} annotation-display--shift-line{% endif %}{% if detail %} annotation-display--has-detail{% endif %}">
     <span class="annotation-code" tabindex="0"
           {% if detail %}title="{{ detail }}"{% endif %}
           aria-label="{{ value }}{% if detail %}: {{ detail }}{% endif %}">{{ value }}</span>

--- a/tests/test_shift_request_security.py
+++ b/tests/test_shift_request_security.py
@@ -761,6 +761,7 @@ def test_roster_shows_annotation_once_and_hover_detail_can_be_edited(
 
     page = secured_client.get(f"/roster/{request_day():%Y-%m}")
     assert b'title="Cover requested by tower"' in page.data
+    assert b"annotation-display--has-detail" in page.data
     assert page.data.count(b">NEAT</span>") == 1
     assert b">Cover requested by tower</textarea>" in page.data
 


### PR DESCRIPTION
## Summary
- highlight the annotation strip in yellow when saved free text exists
- keep the shift-code portion of the cell unchanged
- preserve readable edit and remove controls on the highlighted strip

## Validation
- `python -m pytest -q` — 125 passed, 2 skipped
- annotation security suite — 32 passed
- `git diff --check`