### PR TITLE
Lock roster annotation alignment

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -764,6 +764,7 @@ th.sticky.left{left:0; z-index:3; background:var(--head);}
   overflow: hidden;
   min-width:54px; max-width:64px;
   padding:0;
+  vertical-align:top;
 }
 .roster .cell.request-applied{
   box-shadow:inset 0 0 0 2px #62a8ff;
@@ -793,6 +794,16 @@ th.sticky.left{left:0; z-index:3; background:var(--head);}
 }
 
 .roster .cell form{ margin:0; }
+.roster .cell .shift-picker{
+  display:block;
+  height:calc(28px * var(--ui-scale));
+  line-height:0;
+}
+.roster .cell .annotation-picker{
+  display:block;
+  height:calc(20px * var(--ui-scale));
+  line-height:0;
+}
 
 .roster-zoom-controls{
   display:inline-flex;
@@ -965,6 +976,12 @@ select.code-input{
   color:var(--text-muted);
   font-size:10px;
   cursor:pointer;
+}
+.annotation-edit-button svg{
+  display:block;
+  width:10px;
+  height:10px;
+  fill:currentColor;
 }
 .annotation-edit-button:hover,
 .annotation-edit-button:focus-visible{

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -12,7 +12,9 @@
               data-annotation-dialog-open="{{ dialog_id }}"
               title="{% if detail %}Edit annotation text{% else %}Add annotation text{% endif %}"
               aria-label="{% if detail %}Edit text for {{ value }}{% else %}Add text for {{ value }}{% endif %}">
-        <i class="fa-solid fa-pencil" aria-hidden="true"></i>
+        <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+          <path d="M11.9 1.4a1.5 1.5 0 0 1 2.1 0l.6.6a1.5 1.5 0 0 1 0 2.1L6 12.7 2.4 13.6l.9-3.6 8.6-8.6ZM4.2 10.5l-.4 1.7 1.7-.4 7.4-7.4-1.3-1.3-7.4 7.4Z"/>
+        </svg>
       </button>
       <form class="annotation-remove-form" method="post"
             action="{{ url_for('assign_cell', staff_id=staff.id, ym=ym, day=roster_day.isoformat()) }}">
@@ -209,7 +211,7 @@
             {% if ann and not code %}
               {{ annotation_badge(s, d, ann, ann_note, can_edit and not readonly, true) }}
             {% else %}
-            <form method="post" action="{{ url_for('assign_cell', staff_id=s.id, ym=ym, day=d.isoformat()) }}">
+            <form class="shift-picker" method="post" action="{{ url_for('assign_cell', staff_id=s.id, ym=ym, day=d.isoformat()) }}">
               <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
               <select
                 name="code"

--- a/tests/test_shift_request_security.py
+++ b/tests/test_shift_request_security.py
@@ -732,6 +732,8 @@ def test_roster_shows_annotation_once_and_hover_detail_can_be_edited(
     assert b'class="annotation-dialog"' in page.data
     assert b'class="annotation-remove-form"' in page.data
     assert b'aria-label="Remove NEAT annotation"' in page.data
+    assert b'class="shift-picker"' in page.data
+    assert b'<svg viewBox="0 0 16 16"' in page.data
     assert b"Save text" in page.data
     assert b"Current: NEAT" not in page.data
 


### PR DESCRIPTION
## Summary
- replace the external pencil glyph with a reliable inline SVG
- give shift and annotation controls explicit fixed-height slots
- remove browser baseline spacing that moved annotated shifts in Safari

## Validation
- `python -m pytest -q` — 125 passed, 2 skipped
- annotation security suite — 32 passed
- `git diff --check`