### PR TITLE
Filter leave reports by watch

### DIFF
--- a/app.py
+++ b/app.py
@@ -7554,17 +7554,27 @@ def calendar_feed(sid, token):
 # (unchanged core; monthly AL-only kept to endpoints)
 
 
-def _leave_summary_for_month(year: int, month: int):
+def _leave_summary_for_month(year: int, month: int, watch_id: int | None = None):
     start, days = month_range(year, month)
     month_end = (start.replace(day=28) + timedelta(days=10)).replace(day=1)
+    unit_id = _current_unit_id()
 
     a_map = defaultdict(dict)
-    for a in Assignment.query.filter(Assignment.day >= start, Assignment.day < month_end):
+    for a in Assignment.query.filter(
+        Assignment.unit_id == unit_id,
+        Assignment.day >= start,
+        Assignment.day < month_end,
+    ):
         a_map[a.staff_id][a.day] = a.code
 
-    staff = (Staff.query
-             .outerjoin(Watch, Staff.watch_id == Watch.id)
-             .order_by(Watch.order_index, Staff.name).all())
+    staff_query = (
+        Staff.query
+        .filter(Staff.unit_id == unit_id)
+        .outerjoin(Watch, Staff.watch_id == Watch.id)
+    )
+    if watch_id is not None:
+        staff_query = staff_query.filter(Staff.watch_id == watch_id)
+    staff = staff_query.order_by(Watch.order_index, Staff.name).all()
 
     codes_sorted = [
         item["code"] for item in get_absence_types("leave", active_only=True)
@@ -7587,6 +7597,27 @@ def _leave_summary_for_month(year: int, month: int):
     return rows, codes_sorted, totals, grand_total, days
 
 
+def _leave_report_watch_selection():
+    unit_id = _current_unit_id()
+    watches = (
+        Watch.query
+        .filter(Watch.unit_id == unit_id)
+        .order_by(Watch.order_index, Watch.name)
+        .all()
+    )
+    raw_watch_id = (request.args.get("watch_id") or "").strip()
+    if not raw_watch_id:
+        return watches, None
+    try:
+        watch_id = int(raw_watch_id)
+    except ValueError:
+        abort(400, "Invalid watch.")
+    selected_watch = next((watch for watch in watches if watch.id == watch_id), None)
+    if selected_watch is None:
+        abort(404)
+    return watches, selected_watch
+
+
 @app.route("/reports/leave/<ym>")
 @login_required
 def report_leave(ym):
@@ -7595,13 +7626,15 @@ def report_leave(ym):
     year, month = parse_ym(ym)
     ensure_month_requirement(year, month)
     generate_month(year, month)
+    watches, selected_watch = _leave_report_watch_selection()
     rows, codes, totals, grand_total, days = _leave_summary_for_month(
-        year, month)
+        year, month, selected_watch.id if selected_watch else None)
     month_title = datetime(year, month, 1).strftime("%B %Y")
     return render_template("report_leave.html",
                            ym=ym, year=year, month=month, month_title=month_title,
                            rows=rows, codes=codes,
-                           totals=totals, grand_total=grand_total)
+                           totals=totals, grand_total=grand_total,
+                           watches=watches, selected_watch=selected_watch)
 
 
 @app.route("/reports/leave.csv")
@@ -7615,8 +7648,9 @@ def report_leave_csv():
     year, month = parse_ym(ym)
     ensure_month_requirement(year, month)
     generate_month(year, month)
+    watches, selected_watch = _leave_report_watch_selection()
     rows, codes, totals, grand_total, days = _leave_summary_for_month(
-        year, month)
+        year, month, selected_watch.id if selected_watch else None)
 
     output = io.StringIO()
     w = csv.writer(output)
@@ -7631,7 +7665,8 @@ def report_leave_csv():
                for c in codes], grand_total])
 
     csv_bytes = output.getvalue().encode("utf-8")
-    filename = f"leave_{year:04d}-{month:02d}.csv"
+    watch_suffix = f"_watch-{selected_watch.id}" if selected_watch else ""
+    filename = f"leave_{year:04d}-{month:02d}{watch_suffix}.csv"
     return Response(csv_bytes,
                     mimetype="text/csv; charset=utf-8",
                     headers={"Content-Disposition": f"attachment; filename={filename}"})
@@ -7697,9 +7732,16 @@ def report_leave_year():
     if not is_admin_user(current_user):
         abort(403)
     today = date.today()
-    people = (Staff.query
-              .outerjoin(Watch, Staff.watch_id == Watch.id)
-              .order_by(Watch.order_index, Staff.name).all())
+    unit_id = _current_unit_id()
+    watches, selected_watch = _leave_report_watch_selection()
+    people_query = (
+        Staff.query
+        .filter(Staff.unit_id == unit_id)
+        .outerjoin(Watch, Staff.watch_id == Watch.id)
+    )
+    if selected_watch:
+        people_query = people_query.filter(Staff.watch_id == selected_watch.id)
+    people = people_query.order_by(Watch.order_index, Staff.name).all()
     rows = []
     for s in people:
         start, end = _current_leave_year_window(s, today)
@@ -7728,7 +7770,13 @@ def report_leave_year():
             "toil_used_days": use_half / 2.0,
             "toil_balance_days": (s.toil_half_days or 0) / 2.0,
         })
-    return render_template("report_leave_year.html", rows=rows, today=today)
+    return render_template(
+        "report_leave_year.html",
+        rows=rows,
+        today=today,
+        watches=watches,
+        selected_watch=selected_watch,
+    )
 
 
 # ===== Sickness Report (unchanged) =====

--- a/static/styles.css
+++ b/static/styles.css
@@ -3144,6 +3144,26 @@ table:not(.roster) td {
   background:#1b252c;
 }
 
+.report-filter{
+  display:flex;
+  flex-direction:row;
+  align-items:center;
+  gap:.75rem;
+  margin-bottom:1rem;
+  padding:.75rem 1rem;
+}
+.report-filter label{
+  margin:0;
+  color:var(--text-muted);
+  font-size:.78rem;
+  font-weight:700;
+  letter-spacing:.04em;
+  text-transform:uppercase;
+}
+.report-filter select{
+  width:min(280px, 100%);
+}
+
 .alert,
 .flash {
   border-radius:6px;

--- a/templates/report_leave.html
+++ b/templates/report_leave.html
@@ -5,9 +5,20 @@
   <div><span class="admin-step">Leave reporting</span><h2>Leave · {{ month_title }}</h2><p>Recorded leave totals by controller and leave type.</p></div>
   <div class="compliance-actions">
     <a class="btn" href="{{ url_for('reports_index', ym=ym) }}"><i class="fa-solid fa-chevron-left"></i> Reports</a>
-    <a class="btn" href="{{ url_for('report_leave_csv', ym=ym) }}"><i class="fa-solid fa-file-csv"></i> Download CSV</a>
+    <a class="btn" href="{{ url_for('report_leave_csv', ym=ym, watch_id=selected_watch.id if selected_watch else None) }}"><i class="fa-solid fa-file-csv"></i> Download CSV</a>
   </div>
 </section>
+
+<form class="report-filter card" method="get">
+  <label for="leave-watch">Users</label>
+  <select id="leave-watch" name="watch_id" onchange="this.form.submit()">
+    <option value="">All users</option>
+    {% for watch in watches %}
+      <option value="{{ watch.id }}" {% if selected_watch and selected_watch.id == watch.id %}selected{% endif %}>{{ watch.name }}</option>
+    {% endfor %}
+  </select>
+  <noscript><button class="btn btn-primary" type="submit">Apply</button></noscript>
+</form>
 
 <div class="table-scroll">
   <table class="table">
@@ -29,6 +40,8 @@
           {% endfor %}
           <td class="ta-right"><strong>{{ r.total }}</strong></td>
         </tr>
+      {% else %}
+        <tr><td colspan="{{ 4 + codes|length }}">No users are assigned to this watch.</td></tr>
       {% endfor %}
       <tr class="totals">
         <td colspan="3" class="ta-right"><strong>Totals</strong></td>

--- a/templates/report_leave_year.html
+++ b/templates/report_leave_year.html
@@ -6,6 +6,17 @@
   <div class="compliance-actions"><a class="btn" href="{{ url_for('reports_index') }}">&larr; Reports</a></div>
 </section>
 
+<form class="report-filter card" method="get">
+  <label for="leave-year-watch">Users</label>
+  <select id="leave-year-watch" name="watch_id" onchange="this.form.submit()">
+    <option value="">All users</option>
+    {% for watch in watches %}
+      <option value="{{ watch.id }}" {% if selected_watch and selected_watch.id == watch.id %}selected{% endif %}>{{ watch.name }}</option>
+    {% endfor %}
+  </select>
+  <noscript><button class="btn btn-primary" type="submit">Apply</button></noscript>
+</form>
+
 <div class="table-scroll">
   <table class="table">
     <thead>
@@ -32,6 +43,8 @@
           <td class="ta-right">{{ '%.1f' % r.toil_used_days }}</td>
           <td class="ta-right"><strong>{{ '%.1f' % r.toil_balance_days }}</strong></td>
         </tr>
+      {% else %}
+        <tr><td colspan="12">No users are assigned to this watch.</td></tr>
       {% endfor %}
     </tbody>
   </table>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -205,6 +205,29 @@ def csrf(client):
         return sess["_csrf_token"]
 
 
+def test_leave_year_report_filters_by_watch(client):
+    login(client)
+    with app.app.app_context():
+        watch_a = Watch.query.filter_by(unit_id=1, name="Watch A").one()
+        watch_b = Watch.query.filter_by(unit_id=1, name="Watch B").one()
+
+    all_users = client.get("/reports/leave-year")
+    assert all_users.status_code == 200
+    assert b"All users" in all_users.data
+    assert b"<td>Admin Test</td>" in all_users.data
+    assert b"<td>Duty Watch Manager Test</td>" in all_users.data
+
+    watch_a_only = client.get(f"/reports/leave-year?watch_id={watch_a.id}")
+    assert watch_a_only.status_code == 200
+    assert b"<td>Admin Test</td>" in watch_a_only.data
+    assert b"<td>Duty Watch Manager Test</td>" not in watch_a_only.data
+
+    watch_b_only = client.get(f"/reports/leave-year?watch_id={watch_b.id}")
+    assert watch_b_only.status_code == 200
+    assert b"<td>Duty Watch Manager Test</td>" in watch_b_only.data
+    assert b"<td>Admin Test</td>" not in watch_b_only.data
+
+
 def test_sickness_days_are_grouped_into_continuous_instances():
     person = SimpleNamespace(name="Test ATCO")
     rows = [


### PR DESCRIPTION
## Summary
- add an All users / watch selector to the Leave-Year Summary
- apply the same selector to the monthly leave report and CSV export
- keep watch selection unit-scoped and recalculate report rows and totals
- show a clear empty state for watches without users

## Validation
- `python -m pytest -q` — 126 passed, 2 skipped
- `git diff --check`