### PR TITLE
Filter sickness reports by watch

### DIFF
--- a/app.py
+++ b/app.py
@@ -7597,7 +7597,7 @@ def _leave_summary_for_month(year: int, month: int, watch_id: int | None = None)
     return rows, codes_sorted, totals, grand_total, days
 
 
-def _leave_report_watch_selection():
+def _report_watch_selection():
     unit_id = _current_unit_id()
     watches = (
         Watch.query
@@ -7626,7 +7626,7 @@ def report_leave(ym):
     year, month = parse_ym(ym)
     ensure_month_requirement(year, month)
     generate_month(year, month)
-    watches, selected_watch = _leave_report_watch_selection()
+    watches, selected_watch = _report_watch_selection()
     rows, codes, totals, grand_total, days = _leave_summary_for_month(
         year, month, selected_watch.id if selected_watch else None)
     month_title = datetime(year, month, 1).strftime("%B %Y")
@@ -7648,7 +7648,7 @@ def report_leave_csv():
     year, month = parse_ym(ym)
     ensure_month_requirement(year, month)
     generate_month(year, month)
-    watches, selected_watch = _leave_report_watch_selection()
+    watches, selected_watch = _report_watch_selection()
     rows, codes, totals, grand_total, days = _leave_summary_for_month(
         year, month, selected_watch.id if selected_watch else None)
 
@@ -7733,7 +7733,7 @@ def report_leave_year():
         abort(403)
     today = date.today()
     unit_id = _current_unit_id()
-    watches, selected_watch = _leave_report_watch_selection()
+    watches, selected_watch = _report_watch_selection()
     people_query = (
         Staff.query
         .filter(Staff.unit_id == unit_id)
@@ -7802,16 +7802,24 @@ def report_sickness():
         abort(403)
     today = date.today()
     start = today - timedelta(days=365)
-    people = (Staff.query
-              .outerjoin(Watch, Staff.watch_id == Watch.id)
-              .order_by(Watch.order_index, Staff.name).all())
+    unit_id = _current_unit_id()
+    watches, selected_watch = _report_watch_selection()
+    people_query = (
+        Staff.query
+        .filter(Staff.unit_id == unit_id)
+        .outerjoin(Watch, Staff.watch_id == Watch.id)
+    )
+    if selected_watch:
+        people_query = people_query.filter(Staff.watch_id == selected_watch.id)
+    people = people_query.order_by(Watch.order_index, Staff.name).all()
     sickness_types = get_absence_types("sickness", active_only=True)
     codes = [item["code"] for item in sickness_types]
     rows = []
     totals = Counter()
     for s in people:
         q = (Assignment.query
-             .filter(Assignment.staff_id == s.id,
+             .filter(Assignment.unit_id == unit_id,
+                     Assignment.staff_id == s.id,
                      Assignment.day >= start,
                      Assignment.day <= today))
         assignments = [a for a in q.all() if a.code in codes]
@@ -7827,6 +7835,8 @@ def report_sickness():
     return render_template(
         "report_sickness.html", start=start, end=today, rows=rows,
         sickness_types=sickness_types, totals=totals,
+        watches=watches, selected_watch=selected_watch,
+        has_sickness=any(row["total"] > 0 for row in rows),
     )
 
 

--- a/templates/report_sickness.html
+++ b/templates/report_sickness.html
@@ -6,6 +6,17 @@
   <div class="compliance-actions"><a class="btn" href="{{ url_for('reports_index') }}">&larr; Reports</a></div>
 </section>
 
+<form class="report-filter card" method="get">
+  <label for="sickness-watch">Users</label>
+  <select id="sickness-watch" name="watch_id" onchange="this.form.submit()">
+    <option value="">All users</option>
+    {% for watch in watches %}
+      <option value="{{ watch.id }}" {% if selected_watch and selected_watch.id == watch.id %}selected{% endif %}>{{ watch.name }}</option>
+    {% endfor %}
+  </select>
+  <noscript><button class="btn btn-primary" type="submit">Apply</button></noscript>
+</form>
+
 <div class="table-scroll">
   <table class="table">
     <thead><tr><th>ATCO</th><th>Watch</th>{% for item in sickness_types %}<th>{{ item.label }} ({{ item.code }})</th>{% endfor %}<th>Total days</th><th>Periods</th></tr></thead>
@@ -21,6 +32,9 @@
         </tr>
         {% endif %}
       {% endfor %}
+      {% if not has_sickness %}
+        <tr><td colspan="{{ 5 + sickness_types|length }}">No sickness is recorded for this selection.</td></tr>
+      {% endif %}
       <tr class="totals"><td colspan="2"><strong>Totals</strong></td>{% for item in sickness_types %}<td class="ta-right"><strong>{{ totals.get(item.code, 0) }}</strong></td>{% endfor %}<td class="ta-right"><strong>{{ totals.values()|sum }}</strong></td><td></td></tr>
     </tbody>
   </table>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -228,6 +228,45 @@ def test_leave_year_report_filters_by_watch(client):
     assert b"<td>Admin Test</td>" not in watch_b_only.data
 
 
+def test_sickness_report_filters_by_watch(client):
+    login(client)
+    with app.app.app_context():
+        watch_a = Watch.query.filter_by(unit_id=1, name="Watch A").one()
+        watch_b = Watch.query.filter_by(unit_id=1, name="Watch B").one()
+        admin = Staff.query.filter_by(unit_id=1, username="admin_test").one()
+        dwm = Staff.query.filter_by(
+            unit_id=1, username="duty_watch_manager_test"
+        ).one()
+        today = date.today()
+        for person in (admin, dwm):
+            assignment = Assignment.query.filter_by(
+                unit_id=1, staff_id=person.id, day=today
+            ).first()
+            if assignment is None:
+                assignment = Assignment(
+                    unit_id=1, staff_id=person.id, day=today, source="manual"
+                )
+                db.session.add(assignment)
+            assignment.code = "SC"
+        db.session.commit()
+
+    all_users = client.get("/reports/sickness")
+    assert all_users.status_code == 200
+    assert b"All users" in all_users.data
+    assert b"<td>Admin Test</td>" in all_users.data
+    assert b"<td>Duty Watch Manager Test</td>" in all_users.data
+
+    watch_a_only = client.get(f"/reports/sickness?watch_id={watch_a.id}")
+    assert watch_a_only.status_code == 200
+    assert b"<td>Admin Test</td>" in watch_a_only.data
+    assert b"<td>Duty Watch Manager Test</td>" not in watch_a_only.data
+
+    watch_b_only = client.get(f"/reports/sickness?watch_id={watch_b.id}")
+    assert watch_b_only.status_code == 200
+    assert b"<td>Duty Watch Manager Test</td>" in watch_b_only.data
+    assert b"<td>Admin Test</td>" not in watch_b_only.data
+
+
 def test_sickness_days_are_grouped_into_continuous_instances():
     person = SimpleNamespace(name="Test ATCO")
     rows = [


### PR DESCRIPTION
## Summary
- add an All users / watch selector to the sickness report
- filter sickness rows, periods and totals to the selected watch
- keep watch selection scoped to the active airport
- provide a clear empty state when no sickness is recorded

## Validation
- `python -m pytest -q` — 127 passed, 2 skipped
- `git diff --check`