### PR TITLE
Require a reports privacy acknowledgement

### DIFF
--- a/app.py
+++ b/app.py
@@ -5282,6 +5282,7 @@ def roster_print_view(ym):
 @app.route("/logout", methods=["GET"], endpoint="logout")
 @login_required
 def logout():
+    session.pop("reports_sensitive_data_ack", None)
     logout_user()
     flash("Logged out", "ok")
     return redirect(url_for("login"))
@@ -6964,11 +6965,28 @@ def _fy_start_for(d: date) -> date:
     return date(d.year if d.month >= 4 else d.year - 1, 4, 1)
 
 
+def _reports_acknowledgement_key() -> str:
+    return f"{current_user.id}:{_current_unit_id()}"
+
+
+def _reports_sensitive_data_acknowledged() -> bool:
+    return session.get("reports_sensitive_data_ack") == _reports_acknowledgement_key()
+
+
+def _require_reports_sensitive_data_acknowledgement():
+    if _reports_sensitive_data_acknowledged():
+        return None
+    return redirect(url_for("reports_index"))
+
+
 @app.route("/metrics")
 @login_required
 def metrics():
     if not (is_admin_user(current_user) or getattr(current_user, "role", "") in ("editor", "admin")):
         abort(403)
+    acknowledgement = _require_reports_sensitive_data_acknowledgement()
+    if acknowledgement:
+        return acknowledgement
     # ... existing body unchanged ...
     today = date.today()
     default_start = _fy_start_for(today)
@@ -7059,6 +7077,9 @@ def metrics_export():
         abort(429)
     if not is_admin_user(current_user):
         abort(403)
+    acknowledgement = _require_reports_sensitive_data_acknowledgement()
+    if acknowledgement:
+        return acknowledgement
     today = date.today()
     default_start = _fy_start_for(today)
     start_day = date.fromisoformat(
@@ -7623,6 +7644,9 @@ def _report_watch_selection():
 def report_leave(ym):
     if not is_admin_user(current_user):
         abort(403)
+    acknowledgement = _require_reports_sensitive_data_acknowledgement()
+    if acknowledgement:
+        return acknowledgement
     year, month = parse_ym(ym)
     ensure_month_requirement(year, month)
     generate_month(year, month)
@@ -7642,6 +7666,9 @@ def report_leave(ym):
 def report_leave_csv():
     if not is_admin_user(current_user):
         abort(403)
+    acknowledgement = _require_reports_sensitive_data_acknowledgement()
+    if acknowledgement:
+        return acknowledgement
     ym = request.args.get("ym")
     if not ym:
         abort(400)
@@ -7731,6 +7758,9 @@ def _toil_accrued_used_in_range_half_days(staff_id: int, start_day: date, end_da
 def report_leave_year():
     if not is_admin_user(current_user):
         abort(403)
+    acknowledgement = _require_reports_sensitive_data_acknowledgement()
+    if acknowledgement:
+        return acknowledgement
     today = date.today()
     unit_id = _current_unit_id()
     watches, selected_watch = _report_watch_selection()
@@ -7800,6 +7830,9 @@ def _group_consecutive_days(days_set):
 def report_sickness():
     if not is_admin_user(current_user):
         abort(403)
+    acknowledgement = _require_reports_sensitive_data_acknowledgement()
+    if acknowledgement:
+        return acknowledgement
     today = date.today()
     start = today - timedelta(days=365)
     unit_id = _current_unit_id()
@@ -10314,6 +10347,24 @@ def admin_toil_new():
 @app.route("/reports", methods=["GET", "POST"])
 @login_required
 def reports_index():
+    can_view_reports = (
+        is_admin_user(current_user)
+        or getattr(current_user, "role", "") in ("editor", "admin")
+    )
+    if not can_view_reports:
+        abort(403)
+
+    if request.method == "POST":
+        _validate_csrf()
+        session["reports_sensitive_data_ack"] = _reports_acknowledgement_key()
+        return redirect(url_for("reports_index"))
+
+    if not _reports_sensitive_data_acknowledged():
+        return render_template(
+            "reports_index.html",
+            requires_acknowledgement=True,
+        )
+
     # Admin: show the hub
     if is_admin_user(current_user):
         today = date.today()
@@ -10334,13 +10385,13 @@ def reports_index():
             months=months,
             links=links,
             page_title="Annotation Totals",
+            requires_acknowledgement=False,
         )
 
     # Editor: annotation totals only
     if getattr(current_user, "role", "") in ("editor", "admin"):
         return redirect(url_for("metrics"))
 
-    # Everyone else: no access
     abort(403)
 
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -3164,6 +3164,41 @@ table:not(.roster) td {
   width:min(280px, 100%);
 }
 
+.sensitive-data-gate{
+  display:grid;
+  grid-template-columns:auto minmax(0, 1fr);
+  align-items:start;
+  gap:1rem;
+  max-width:720px;
+  margin:clamp(2rem, 8vh, 6rem) auto;
+  padding:1.35rem;
+  border-color:#8b7127;
+  background:#211d13;
+}
+.sensitive-data-gate__icon{
+  display:grid;
+  place-items:center;
+  width:38px;
+  height:38px;
+  border:1px solid #b99532;
+  border-radius:50%;
+  background:#332a13;
+  color:#f4d66d;
+  font-size:1.15rem;
+  font-weight:800;
+}
+.sensitive-data-gate h2{
+  margin:.15rem 0 .55rem;
+  color:#f5f2e8;
+}
+.sensitive-data-gate p{
+  max-width:62ch;
+  color:#d8d2bf;
+}
+.sensitive-data-gate form{
+  margin-top:1rem;
+}
+
 .alert,
 .flash {
   border-radius:6px;

--- a/templates/reports_index.html
+++ b/templates/reports_index.html
@@ -3,6 +3,23 @@
 
 {% block content %}
 <div class="page-shell">
+{% if requires_acknowledgement %}
+<section class="sensitive-data-gate card" role="alertdialog" aria-labelledby="sensitive-data-title" aria-describedby="sensitive-data-description">
+  <div class="sensitive-data-gate__icon" aria-hidden="true">!</div>
+  <div>
+    <span class="admin-step">Privacy check</span>
+    <h2 id="sensitive-data-title">Sensitive information ahead</h2>
+    <p id="sensitive-data-description">
+      Reports may contain personal information about leave, sickness and staff records.
+      Check your surroundings and make sure your screen cannot be viewed by anyone who is not authorised.
+    </p>
+    <form method="post">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+      <button class="btn btn-primary" type="submit">OK, open reports</button>
+    </form>
+  </div>
+</section>
+{% else %}
 <section class="compliance-hero">
   <div><span class="admin-step">Operational insight</span><h2>Reports</h2><p>Review leave, sickness and airport-specific roster annotation totals.</p></div>
 </section>
@@ -34,5 +51,6 @@
     These reports reflect the latest roster data. Export options are available inside each report.
   </p>
 </section>
+{% endif %}
 </div>
 {% endblock %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -205,8 +205,45 @@ def csrf(client):
         return sess["_csrf_token"]
 
 
+def acknowledge_reports(client):
+    warning = client.get("/reports")
+    assert warning.status_code == 200
+    assert b"Sensitive information ahead" in warning.data
+    token = csrf(client)
+    response = client.post(
+        "/reports",
+        data={"_csrf_token": token},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/reports")
+
+
+def test_reports_require_sensitive_data_acknowledgement(client):
+    login(client)
+    warning = client.get("/reports")
+    assert warning.status_code == 200
+    assert b"Sensitive information ahead" in warning.data
+    assert b"Check your surroundings" in warning.data
+    assert b"OK, open reports" in warning.data
+    assert b"Leave-Year Summary" not in warning.data
+
+    direct_report = client.get("/reports/leave-year")
+    assert direct_report.status_code == 302
+    assert direct_report.headers["Location"].endswith("/reports")
+
+    acknowledge_reports(client)
+    hub = client.get("/reports")
+    assert hub.status_code == 200
+    assert b"Leave-Year Summary" in hub.data
+    opened = client.get("/reports/leave-year")
+    assert opened.status_code == 200
+    assert b"Leave year" in opened.data
+
+
 def test_leave_year_report_filters_by_watch(client):
     login(client)
+    acknowledge_reports(client)
     with app.app.app_context():
         watch_a = Watch.query.filter_by(unit_id=1, name="Watch A").one()
         watch_b = Watch.query.filter_by(unit_id=1, name="Watch B").one()
@@ -230,6 +267,7 @@ def test_leave_year_report_filters_by_watch(client):
 
 def test_sickness_report_filters_by_watch(client):
     login(client)
+    acknowledge_reports(client)
     with app.app.app_context():
         watch_a = Watch.query.filter_by(unit_id=1, name="Watch A").one()
         watch_b = Watch.query.filter_by(unit_id=1, name="Watch B").one()
@@ -573,6 +611,8 @@ def test_role_permission_matrix_and_cross_airport_isolation():
                 },
             )
             assert verified.status_code == 302
+        if role in ("admin", "editor"):
+            acknowledge_reports(role_client)
         clients[role] = role_client
         for capability, path in common.items():
             actual = role_client.get(path).status_code
@@ -792,6 +832,7 @@ def test_roster_routes_render(client):
 
 def test_admin_pages_accessible(client):
     login(client)
+    acknowledge_reports(client)
     endpoints = [
         "/admin",
         "/leave",
@@ -818,6 +859,7 @@ def test_operations_workspace_is_hidden_from_primary_navigation(client):
 
 def test_annotation_totals_follow_unit_definitions_not_fixed_columns(client):
     login(client)
+    acknowledge_reports(client)
     with app.app.app_context():
         person = Staff.query.filter_by(username="staff_test").one()
         db.session.add_all([


### PR DESCRIPTION
## Summary
- show a clear sensitive-data warning before opening Reports
- require explicit acknowledgement with a CSRF-protected action
- prevent direct report and export URLs from bypassing the warning
- scope acknowledgement to the signed-in user and airport, and clear it on logout

## Validation
- `python -m pytest -q` — 128 passed, 2 skipped
- `git diff --check`