### PR TITLE
Add explicit report filter actions

### DIFF
--- a/templates/report_leave.html
+++ b/templates/report_leave.html
@@ -10,14 +10,14 @@
 </section>
 
 <form class="report-filter card" method="get">
-  <label for="leave-watch">Users</label>
-  <select id="leave-watch" name="watch_id" onchange="this.form.submit()">
+  <label for="leave-watch">Filter by watch</label>
+  <select id="leave-watch" name="watch_id">
     <option value="">All users</option>
     {% for watch in watches %}
       <option value="{{ watch.id }}" {% if selected_watch and selected_watch.id == watch.id %}selected{% endif %}>{{ watch.name }}</option>
     {% endfor %}
   </select>
-  <noscript><button class="btn btn-primary" type="submit">Apply</button></noscript>
+  <button class="btn btn-primary" type="submit">Apply filter</button>
 </form>
 
 <div class="table-scroll">

--- a/templates/report_leave_year.html
+++ b/templates/report_leave_year.html
@@ -7,14 +7,14 @@
 </section>
 
 <form class="report-filter card" method="get">
-  <label for="leave-year-watch">Users</label>
-  <select id="leave-year-watch" name="watch_id" onchange="this.form.submit()">
+  <label for="leave-year-watch">Filter by watch</label>
+  <select id="leave-year-watch" name="watch_id">
     <option value="">All users</option>
     {% for watch in watches %}
       <option value="{{ watch.id }}" {% if selected_watch and selected_watch.id == watch.id %}selected{% endif %}>{{ watch.name }}</option>
     {% endfor %}
   </select>
-  <noscript><button class="btn btn-primary" type="submit">Apply</button></noscript>
+  <button class="btn btn-primary" type="submit">Apply filter</button>
 </form>
 
 <div class="table-scroll">

--- a/templates/report_sickness.html
+++ b/templates/report_sickness.html
@@ -7,14 +7,14 @@
 </section>
 
 <form class="report-filter card" method="get">
-  <label for="sickness-watch">Users</label>
-  <select id="sickness-watch" name="watch_id" onchange="this.form.submit()">
+  <label for="sickness-watch">Filter by watch</label>
+  <select id="sickness-watch" name="watch_id">
     <option value="">All users</option>
     {% for watch in watches %}
       <option value="{{ watch.id }}" {% if selected_watch and selected_watch.id == watch.id %}selected{% endif %}>{{ watch.name }}</option>
     {% endfor %}
   </select>
-  <noscript><button class="btn btn-primary" type="submit">Apply</button></noscript>
+  <button class="btn btn-primary" type="submit">Apply filter</button>
 </form>
 
 <div class="table-scroll">

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -251,6 +251,7 @@ def test_leave_year_report_filters_by_watch(client):
     all_users = client.get("/reports/leave-year")
     assert all_users.status_code == 200
     assert b"All users" in all_users.data
+    assert b"Apply filter" in all_users.data
     assert b"<td>Admin Test</td>" in all_users.data
     assert b"<td>Duty Watch Manager Test</td>" in all_users.data
 
@@ -291,6 +292,7 @@ def test_sickness_report_filters_by_watch(client):
     all_users = client.get("/reports/sickness")
     assert all_users.status_code == 200
     assert b"All users" in all_users.data
+    assert b"Apply filter" in all_users.data
     assert b"<td>Admin Test</td>" in all_users.data
     assert b"<td>Duty Watch Manager Test</td>" in all_users.data
 


### PR DESCRIPTION
## Summary
- replace automatic watch-filter submission with an explicit Apply filter button
- apply the interaction consistently to leave-year, monthly leave and sickness reports
- retain the selected watch after submission

## Validation
- `python -m pytest -q` — 128 passed, 2 skipped
- focused leave and sickness filter tests — 2 passed
- `git diff --check`