### PR TITLE
Show report warning on every entry

### DIFF
--- a/app.py
+++ b/app.py
@@ -5283,6 +5283,7 @@ def roster_print_view(ym):
 @login_required
 def logout():
     session.pop("reports_sensitive_data_ack", None)
+    session.pop("reports_sensitive_data_hub_entry", None)
     logout_user()
     flash("Logged out", "ok")
     return redirect(url_for("login"))
@@ -10383,9 +10384,21 @@ def reports_index():
     if request.method == "POST":
         _validate_csrf()
         session["reports_sensitive_data_ack"] = _reports_acknowledgement_key()
+        # Permit exactly the redirect that opens the reports hub. A later
+        # navigation back to /reports is a new entry and must show the privacy
+        # warning again.
+        session["reports_sensitive_data_hub_entry"] = _reports_acknowledgement_key()
         return redirect(url_for("reports_index"))
 
     if not _reports_sensitive_data_acknowledged():
+        return render_template(
+            "reports_index.html",
+            requires_acknowledgement=True,
+        )
+
+    hub_entry_key = session.pop("reports_sensitive_data_hub_entry", None)
+    if hub_entry_key != _reports_acknowledgement_key():
+        session.pop("reports_sensitive_data_ack", None)
         return render_template(
             "reports_index.html",
             requires_acknowledgement=True,

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -240,6 +240,17 @@ def test_reports_require_sensitive_data_acknowledgement(client):
     assert opened.status_code == 200
     assert b"Leave year" in opened.data
 
+    # Returning to the Reports tab is a new entry and must require a fresh
+    # privacy acknowledgement.
+    returned = client.get("/reports")
+    assert returned.status_code == 200
+    assert b"Sensitive information ahead" in returned.data
+    assert b"Leave-Year Summary" not in returned.data
+
+    direct_after_return = client.get("/reports/leave-year")
+    assert direct_after_return.status_code == 302
+    assert direct_after_return.headers["Location"].endswith("/reports")
+
 
 def test_leave_year_report_filters_by_watch(client):
     login(client)


### PR DESCRIPTION
## Summary

- Require the privacy warning each time a user navigates back into the Reports tab.
- Preserve access while moving from the acknowledged hub into an individual report.
- Clear all report-entry acknowledgement state at logout.
- Add a regression test for leaving and re-entering Reports.

## Validation

- `python -m pytest -q`: 130 passed, 2 skipped
- `git diff --check` passed
