### PR TITLE
Add overtime what-if eligibility check

### DIFF
--- a/app.py
+++ b/app.py
@@ -7281,12 +7281,22 @@ def overtime():
     ):
         abort(403)
 
+    unit_id = _current_unit_id()
     shifts = ShiftType.query.filter_by(
-        is_working=True).order_by(ShiftType.code).all()
+        unit_id=unit_id, is_working=True
+    ).order_by(ShiftType.code).all()
+    overtime_staff = (
+        Staff.query
+        .filter_by(unit_id=unit_id, is_operational=True)
+        .order_by(Staff.name)
+        .all()
+    )
     results = []
     excluded = []
+    what_if_result = None
     chosen_date = None
     chosen_shift = None
+    what_if_staff_id = None
     selected_staff_ids: set[str] = set()
     sms_body = ""
     searched = request.method == "POST"
@@ -7296,6 +7306,12 @@ def overtime():
         action = request.form.get("action", "find")
         chosen_date = _parse_date(request.form.get("date"))
         chosen_shift = (request.form.get("shift_code") or "").upper().strip()
+        raw_what_if_staff_id = request.form.get("what_if_staff_id", "")
+        what_if_staff_id = (
+            int(raw_what_if_staff_id)
+            if raw_what_if_staff_id.isdigit()
+            else None
+        )
         selected_staff_ids = {sid for sid in request.form.getlist("staff_ids")}
         sms_body = (request.form.get("message") or "").strip()
 
@@ -7303,7 +7319,51 @@ def overtime():
             chosen_date, chosen_shift
         )
 
-        if action == "send_sms":
+        if action == "what_if":
+            searched = False
+            selected_staff = next(
+                (
+                    person for person in overtime_staff
+                    if person.id == what_if_staff_id
+                ),
+                None,
+            )
+            if error_msg:
+                flash(error_msg, "error")
+            elif selected_staff is None:
+                flash("Select an ATCO to check.", "error")
+            else:
+                eligible_result = next(
+                    (
+                        row for row in results
+                        if row["staff"].id == selected_staff.id
+                    ),
+                    None,
+                )
+                excluded_result = next(
+                    (
+                        row for row in excluded
+                        if row["staff"].id == selected_staff.id
+                    ),
+                    None,
+                )
+                if eligible_result:
+                    what_if_result = {
+                        "eligible": True,
+                        "staff": selected_staff,
+                        "flags": eligible_result["flags"],
+                    }
+                else:
+                    what_if_result = {
+                        "eligible": False,
+                        "staff": selected_staff,
+                        "reasons": (
+                            excluded_result["reasons"]
+                            if excluded_result
+                            else ["Eligibility could not be determined"]
+                        ),
+                    }
+        elif action == "send_sms":
             if not can_send_unit_messages(current_user):
                 abort(403)
             if error_msg:
@@ -7349,6 +7409,9 @@ def overtime():
 
     return render_template("overtime.html",
                            shifts=shifts, results=results,
+                           overtime_staff=overtime_staff,
+                           what_if_result=what_if_result,
+                           what_if_staff_id=what_if_staff_id,
                            chosen_date=chosen_date, chosen_shift=chosen_shift,
                            sms_body=sms_body, sms_ready=sms_ready,
                            selected_staff_ids=selected_staff_ids,

--- a/static/styles.css
+++ b/static/styles.css
@@ -3231,6 +3231,31 @@ table:not(.roster) td {
   border-bottom:1px solid var(--line);
   color:var(--text);
 }
+.what-if-result{
+  display:grid;
+  gap:.55rem;
+  margin-top:1rem;
+  padding:1rem 1.1rem;
+  border:1px solid var(--line);
+  border-radius:var(--radius-md);
+  background:rgba(255,255,255,.035);
+}
+.what-if-result > div{
+  display:flex;
+  flex-wrap:wrap;
+  gap:.35rem;
+  align-items:baseline;
+}
+.what-if-result p,
+.what-if-result ul{margin:0;}
+.what-if-result--eligible{
+  border-color:rgba(84,214,150,.65);
+  background:rgba(60,190,125,.11);
+}
+.what-if-result--ineligible{
+  border-color:rgba(245,183,66,.68);
+  background:rgba(245,183,66,.1);
+}
 
 .alert,
 .flash {

--- a/templates/overtime.html
+++ b/templates/overtime.html
@@ -24,6 +24,60 @@
   </div>
 </section>
 
+<section class="card">
+  <div class="card-bd">
+    <div class="section-heading">
+      <div>
+        <h2>What if?</h2>
+        <p class="muted">Check a particular ATCO against the overtime rules. This does not alter the roster or send a message.</p>
+      </div>
+    </div>
+    <form method="post" class="toolbar">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+      <input type="hidden" name="action" value="what_if">
+      <label>ATCO
+        <select name="what_if_staff_id" required>
+          <option value="">Select an ATCO</option>
+          {% for person in overtime_staff %}
+            <option value="{{ person.id }}" {% if what_if_staff_id == person.id %}selected{% endif %}>{{ person.name }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label>Date <input type="date" name="date" value="{{ chosen_date }}" required></label>
+      <label>Proposed shift
+        <select name="shift_code" required>
+          {% for sh in shifts %}
+            <option value="{{ sh.code }}" {% if chosen_shift == sh.code %}selected{% endif %}>{{ sh.code }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <button class="btn"><i class="fa-solid fa-scale-balanced"></i> Check eligibility</button>
+    </form>
+
+    {% if what_if_result %}
+      <div class="what-if-result what-if-result--{{ 'eligible' if what_if_result.eligible else 'ineligible' }}" role="status">
+        <div>
+          <strong>{{ what_if_result.staff.name }} is {{ 'eligible' if what_if_result.eligible else 'not eligible' }}</strong>
+          <span>for {{ chosen_shift }} on {{ chosen_date }}.</span>
+        </div>
+        {% if what_if_result.eligible %}
+          {% if what_if_result.flags %}
+            <p><strong>Advisory information:</strong> {{ what_if_result.flags|join('; ') }}</p>
+          {% else %}
+            <p>No exclusion rules were triggered.</p>
+          {% endif %}
+        {% else %}
+          <p><strong>Why:</strong></p>
+          <ul>
+            {% for reason in what_if_result.reasons %}<li>{{ reason }}</li>{% endfor %}
+          </ul>
+          <p class="muted">This is an explanation only; it does not override fatigue, qualification or roster controls.</p>
+        {% endif %}
+      </div>
+    {% endif %}
+  </div>
+</section>
+
 {% if searched %}
 <form method="post" class="card">
   <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -777,6 +777,7 @@ def test_overtime_finder_offers_operational_staff_on_off_or_leave_days(
             person.set_password("password123")
             db.session.add(person)
             db.session.flush()
+        person.exclude_from_ot = False
         assignment = Assignment.query.filter_by(
             unit_id=1, staff_id=person.id, day=chosen_day
         ).first()
@@ -808,6 +809,41 @@ def test_overtime_finder_offers_operational_staff_on_off_or_leave_days(
     assert b"<td>Ian Overtime Test</td>" in response.data
     if rostered_code == "AL":
         assert b"On AL that day" in response.data
+
+    what_if = client.post(
+        "/overtime",
+        data={
+            "_csrf_token": token,
+            "action": "what_if",
+            "what_if_staff_id": str(person_id),
+            "date": chosen_day.isoformat(),
+            "shift_code": "M",
+        },
+        follow_redirects=True,
+    )
+    assert what_if.status_code == 200
+    assert b"Ian Overtime Test is eligible" in what_if.data
+    assert b"No exclusion rules were triggered" in what_if.data or b"Advisory information" in what_if.data
+
+    with app.app.app_context():
+        person = db.session.get(Staff, person_id)
+        person.exclude_from_ot = True
+        db.session.commit()
+
+    ineligible = client.post(
+        "/overtime",
+        data={
+            "_csrf_token": token,
+            "action": "what_if",
+            "what_if_staff_id": str(person_id),
+            "date": chosen_day.isoformat(),
+            "shift_code": "M",
+        },
+        follow_redirects=True,
+    )
+    assert ineligible.status_code == 200
+    assert b"Ian Overtime Test is not eligible" in ineligible.data
+    assert b"Opted out of overtime" in ineligible.data
 
 
 def test_production_operations_workflows(client):


### PR DESCRIPTION
## Summary

- Add an individual Overtime “What if?” checker for any operational ATCO, date and working shift.
- Use the exact same eligibility engine as the main overtime finder.
- Show a clear eligible/ineligible decision, advisory flags and every blocking reason.
- Keep checks read-only: no roster change and no SMS is sent.
- Scope shift and staff choices to the active airport.

## Validation

- Eligible OFF and AL scenarios covered.
- Ineligible scenario confirms the exclusion reason is displayed.
- `python -m pytest -q`: 130 passed, 2 skipped
- `git diff --check` passed
