### PR TITLE
Improve roster annotation legibility

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -934,16 +934,15 @@ select.code-input{
   display:flex;
   align-items:center;
   justify-content:center;
-  gap:2px;
   margin:3px 0 0;
-  padding-top:3px;
+  padding:3px 17px 0 2px;
   border-top:1px solid rgba(108,129,168,.38);
 }
 .annotation-display--shift-line{
   min-height:30px;
   height:30px;
   margin-top:0;
-  padding-top:0;
+  padding:0 17px 0 2px;
   border-top:0;
 }
 .annotation-display--has-detail{
@@ -964,27 +963,32 @@ select.code-input{
   color:#000;
 }
 .annotation-code{
-  display:inline-block;
-  max-width:calc(100% - 17px);
+  display:block;
+  width:auto;
+  max-width:100%;
   overflow:hidden;
   text-overflow:ellipsis;
-  padding:1px 4px;
+  padding:2px 3px;
   border:1px solid #d6bd1a;
   border-radius:4px;
   background:#ffeb3b;
   color:#171717;
-  font-size:9px;
+  font-size:10px;
   font-weight:800;
-  line-height:1.2;
+  line-height:1.15;
+  white-space:nowrap;
 }
 .annotation-display--shift-line .annotation-code{
-  max-width:calc(100% - 20px);
-  font-size:clamp(9px, .72rem, 12px);
+  max-width:100%;
+  font-size:clamp(10px, .72rem, 12px);
   line-height:1.1;
 }
 .annotation-edit-button{
-  width:16px;
-  height:16px;
+  position:absolute;
+  top:3px;
+  right:2px;
+  width:13px;
+  height:12px;
   display:grid;
   place-items:center;
   border-radius:3px;
@@ -997,8 +1001,8 @@ select.code-input{
 }
 .annotation-edit-button svg{
   display:block;
-  width:10px;
-  height:10px;
+  width:9px;
+  height:9px;
   fill:currentColor;
 }
 .annotation-edit-button:hover,
@@ -1007,12 +1011,15 @@ select.code-input{
   color:#fff;
 }
 .annotation-remove-form{
-  display:flex;
+  position:absolute;
+  right:2px;
+  bottom:1px;
+  display:block;
   margin:0;
 }
 .annotation-remove-form button{
-  width:14px;
-  height:16px;
+  width:13px;
+  height:12px;
   display:grid;
   place-items:center;
   padding:0;


### PR DESCRIPTION
## Summary

- Give annotation codes the full available text width.
- Increase the minimum annotation font size.
- Stack edit and remove controls in a narrow strip at the right edge.
- Preserve the recently corrected shift/annotation row spacing.

## Validation

- Annotation-focused tests: 4 passed
- Full suite: 130 passed, 2 skipped
- `git diff --check` passed
