### PR TITLE
Open annotation text by clicking code

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -946,21 +946,12 @@ select.code-input{
   border-top:0;
 }
 .annotation-display--has-detail{
-  background:#ffeb3b;
   color:#171717;
 }
 .annotation-display--has-detail .annotation-code{
-  border-color:transparent;
-  background:transparent;
-}
-.annotation-display--has-detail .annotation-edit-button,
-.annotation-display--has-detail .annotation-remove-form button{
-  color:#2d2d2d;
-}
-.annotation-display--has-detail .annotation-edit-button:hover,
-.annotation-display--has-detail .annotation-edit-button:focus-visible{
-  background:rgba(0,0,0,.12);
-  color:#000;
+  border-color:#d6bd1a;
+  background:#ffeb3b;
+  color:#171717;
 }
 .annotation-code{
   display:block;
@@ -969,46 +960,30 @@ select.code-input{
   overflow:hidden;
   text-overflow:ellipsis;
   padding:2px 3px;
-  border:1px solid #d6bd1a;
+  border:1px solid rgba(108,129,168,.55);
   border-radius:4px;
-  background:#ffeb3b;
-  color:#171717;
+  background:rgba(0,0,0,.24);
+  color:var(--text);
   font-size:10px;
   font-weight:800;
   line-height:1.15;
   white-space:nowrap;
 }
+.annotation-code--editable{
+  appearance:none;
+  -webkit-appearance:none;
+  font-family:inherit;
+  cursor:pointer;
+}
+.annotation-code--editable:hover,
+.annotation-code--editable:focus-visible{
+  outline:2px solid rgba(83,170,255,.72);
+  outline-offset:1px;
+}
 .annotation-display--shift-line .annotation-code{
   max-width:100%;
   font-size:clamp(10px, .72rem, 12px);
   line-height:1.1;
-}
-.annotation-edit-button{
-  position:absolute;
-  top:3px;
-  right:2px;
-  width:13px;
-  height:12px;
-  display:grid;
-  place-items:center;
-  border-radius:3px;
-  border:0;
-  padding:0;
-  background:transparent;
-  color:var(--text-muted);
-  font-size:10px;
-  cursor:pointer;
-}
-.annotation-edit-button svg{
-  display:block;
-  width:9px;
-  height:9px;
-  fill:currentColor;
-}
-.annotation-edit-button:hover,
-.annotation-edit-button:focus-visible{
-  background:rgba(83,170,255,.14);
-  color:#fff;
 }
 .annotation-remove-form{
   position:absolute;

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -4,18 +4,19 @@
 {% macro annotation_badge(staff, roster_day, value, detail, editable, shift_line=false) -%}
   {% set dialog_id = 'annotation-detail-' ~ staff.id ~ '-' ~ roster_day.strftime('%Y%m%d') %}
   <div class="annotation-display{% if shift_line %} annotation-display--shift-line{% endif %}{% if detail %} annotation-display--has-detail{% endif %}">
-    <span class="annotation-code" tabindex="0"
-          {% if detail %}title="{{ detail }}"{% endif %}
-          aria-label="{{ value }}{% if detail %}: {{ detail }}{% endif %}">{{ value }}</span>
     {% if editable %}
-      <button type="button" class="annotation-edit-button"
+      <button type="button" class="annotation-code annotation-code--editable"
               data-annotation-dialog-open="{{ dialog_id }}"
-              title="{% if detail %}Edit annotation text{% else %}Add annotation text{% endif %}"
+              title="{% if detail %}{{ detail }} — click to edit{% else %}Click to add annotation text{% endif %}"
               aria-label="{% if detail %}Edit text for {{ value }}{% else %}Add text for {{ value }}{% endif %}">
-        <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
-          <path d="M11.9 1.4a1.5 1.5 0 0 1 2.1 0l.6.6a1.5 1.5 0 0 1 0 2.1L6 12.7 2.4 13.6l.9-3.6 8.6-8.6ZM4.2 10.5l-.4 1.7 1.7-.4 7.4-7.4-1.3-1.3-7.4 7.4Z"/>
-        </svg>
+        {{ value }}
       </button>
+    {% else %}
+      <span class="annotation-code" tabindex="0"
+            {% if detail %}title="{{ detail }}"{% endif %}
+            aria-label="{{ value }}{% if detail %}: {{ detail }}{% endif %}">{{ value }}</span>
+    {% endif %}
+    {% if editable %}
       <form class="annotation-remove-form" method="post"
             action="{{ url_for('assign_cell', staff_id=staff.id, ym=ym, day=roster_day.isoformat()) }}">
         <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">

--- a/tests/test_shift_request_security.py
+++ b/tests/test_shift_request_security.py
@@ -727,13 +727,15 @@ def test_roster_shows_annotation_once_and_hover_detail_can_be_edited(
     page = secured_client.get(f"/roster/{request_day():%Y-%m}")
     assert page.status_code == 200
     assert b'<option value="" selected>' in page.data
-    assert b'class="annotation-code"' in page.data
+    assert b'class="annotation-code annotation-code--editable"' in page.data
     assert b"annotation-display--shift-line" in page.data
     assert b'class="annotation-dialog"' in page.data
     assert b'class="annotation-remove-form"' in page.data
     assert b'aria-label="Remove NEAT annotation"' in page.data
     assert b'class="shift-picker"' in page.data
-    assert b'<svg viewBox="0 0 16 16"' in page.data
+    assert b"annotation-code--editable" in page.data
+    assert b"Click to add annotation text" in page.data
+    assert b'<svg viewBox="0 0 16 16"' not in page.data
     assert b"Save text" in page.data
     assert b"Current: NEAT" not in page.data
 
@@ -762,9 +764,9 @@ def test_roster_shows_annotation_once_and_hover_detail_can_be_edited(
         assert audit.new_value == "Cover requested by tower"
 
     page = secured_client.get(f"/roster/{request_day():%Y-%m}")
-    assert b'title="Cover requested by tower"' in page.data
+    assert b'title="Cover requested by tower \xe2\x80\x94 click to edit"' in page.data
     assert b"annotation-display--has-detail" in page.data
-    assert page.data.count(b">NEAT</span>") == 1
+    assert page.data.count(b"NEAT\n      </button>") == 1
     assert b">Cover requested by tower</textarea>" in page.data
 
 


### PR DESCRIPTION
## Summary

- Make the annotation code itself open the text editor.
- Remove the pencil icon and its reserved control space.
- Keep the remove control separate.
- Restrict yellow highlighting to the annotation badge when text exists instead of flooding the row/cell.
- Preserve hover text and reopen/edit behaviour.

## Validation

- Annotation workflow tests: 4 passed
- Full suite: 130 passed, 2 skipped
- `git diff --check` passed
