### PR TITLE
Add non-reportable INFO annotation

### DIFF
--- a/app.py
+++ b/app.py
@@ -1115,6 +1115,17 @@ DEFAULT_NON_WORKING_CODES = [
 
 DEFAULT_ANNOTATION_TYPES = [
     {
+        "code": "INFO",
+        "label": "Information",
+        "category": "Information",
+        "allow_suffix": False,
+        "suffixes": "",
+        "toil_half_days": 0,
+        "tags": "info,report_exclude",
+        "is_active": True,
+        "sort_order": 0,
+    },
+    {
         "code": "EXTS",
         "label": "Short EXT",
         "category": "Extensions",
@@ -2058,6 +2069,29 @@ def bootstrap_reference_data() -> None:
             )
             db.session.add(ann)
         db.session.commit()
+
+    for unit in Unit.query.filter(Unit.status != "platform_control").all():
+        if not AnnotationType.query.filter_by(
+            unit_id=unit.id, code="INFO"
+        ).first():
+            db.session.add(AnnotationType(
+                unit_id=unit.id,
+                code="INFO",
+                label="Information",
+                category="Information",
+                colour="#6c757d",
+                description=(
+                    "Additional roster information. Excluded from reports."
+                ),
+                allow_suffix=False,
+                suffixes="",
+                toil_half_days=0,
+                tags="info,report_exclude",
+                note_required=False,
+                admin_only=False,
+                is_active=True,
+                sort_order=0,
+            ))
 
     for key, values in DEFAULT_ROSTER_SETTINGS.items():
         if not RosterSetting.query.filter_by(unit_id=1, key=key).first():
@@ -6965,6 +6999,11 @@ def _compute_metrics_range(start_day: date, end_day: date):
         int(_current_unit_id() or 1)
     )["items"]
     label_map = {item["code"]: item["label"] for item in annotation_snapshot}
+    report_excluded_codes = {
+        item["code"]
+        for item in annotation_snapshot
+        if "report_exclude" in set(item.get("tags") or ())
+    }
 
     annotation_columns = [
         {
@@ -6973,7 +7012,7 @@ def _compute_metrics_range(start_day: date, end_day: date):
             "active": bool(item["is_active"]),
         }
         for item in annotation_snapshot
-        if item["is_active"]
+        if item["is_active"] and item["code"] not in report_excluded_codes
     ]
     annotation_order = [
         column["code"] for column in annotation_columns
@@ -6998,6 +7037,8 @@ def _compute_metrics_range(start_day: date, end_day: date):
         if not parsed:
             continue
         code = parsed["type"]
+        if code in report_excluded_codes:
+            continue
         # Preserve historical totals when a definition was retired after use.
         if code not in annotation_known:
             annotation_known.add(code)

--- a/platform_provisioning.py
+++ b/platform_provisioning.py
@@ -22,6 +22,7 @@ from sqlalchemy import create_engine, inspect
 
 from scripts.migrate_all_databases import (
     _canonical_database_url,
+    _ensure_info_annotation,
     upgrade_database,
 )
 
@@ -259,7 +260,8 @@ class ProvisioningWorker:
             self._fail(application, job, "database_route_conflict", False)
             return
         try:
-            version = upgrade_database(operational_url, "operational", unit_id=unit.id)
+            version = upgrade_database(operational_url, "operational")
+            _ensure_info_annotation(operational_url, unit.id)
             application.db.session.expire(job)
             if not self._owns_lease(job):
                 return

--- a/platform_provisioning.py
+++ b/platform_provisioning.py
@@ -259,7 +259,9 @@ class ProvisioningWorker:
             self._fail(application, job, "database_route_conflict", False)
             return
         try:
-            version = upgrade_database(operational_url, "operational")
+            version = upgrade_database(
+                operational_url, "operational", unit_id=unit.id
+            )
             application.db.session.expire(job)
             if not self._owns_lease(job):
                 return

--- a/platform_provisioning.py
+++ b/platform_provisioning.py
@@ -259,9 +259,7 @@ class ProvisioningWorker:
             self._fail(application, job, "database_route_conflict", False)
             return
         try:
-            version = upgrade_database(
-                operational_url, "operational", unit_id=unit.id
-            )
+            version = upgrade_database(operational_url, "operational", unit_id=unit.id)
             application.db.session.expire(job)
             if not self._owns_lease(job):
                 return

--- a/scripts/migrate_all_databases.py
+++ b/scripts/migrate_all_databases.py
@@ -145,9 +145,7 @@ def main() -> None:
             raise SystemExit(
                 f"Unit {unit_id} operational database must differ from control."
             )
-        version = upgrade_database(
-            operational_url, "operational", unit_id=unit_id
-        )
+        version = upgrade_database(operational_url, "operational", unit_id=unit_id)
         print(f"Operational database for unit {unit_id} upgraded to {version}.")
 
 

--- a/scripts/migrate_all_databases.py
+++ b/scripts/migrate_all_databases.py
@@ -10,13 +10,55 @@ from pathlib import Path
 from alembic import command
 from alembic.config import Config
 from alembic.runtime.migration import MigrationContext
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine, inspect, text
 
 REPOSITORY = Path(__file__).resolve().parents[1]
 SECRET_NAME_PATTERN = re.compile(r"ATCROSTER_UNIT_[1-9][0-9]*_DATABASE_URL")
 
 
-def upgrade_database(database_url: str, schema_role: str) -> str:
+def _ensure_info_annotation(database_url: str, unit_id: int) -> None:
+    """Idempotently seed the non-reportable INFO annotation."""
+    engine = create_engine(database_url, pool_pre_ping=True)
+    try:
+        with engine.begin() as connection:
+            if "annotation_type" not in inspect(connection).get_table_names():
+                return
+            exists = connection.execute(
+                text(
+                    "SELECT 1 FROM annotation_type "
+                    "WHERE unit_id = :unit_id AND code = 'INFO'"
+                ),
+                {"unit_id": unit_id},
+            ).first()
+            if exists:
+                return
+            connection.execute(
+                text(
+                    "INSERT INTO annotation_type "
+                    "(unit_id, code, label, category, colour, description, "
+                    "allow_suffix, suffixes, toil_half_days, tags, "
+                    "note_required, admin_only, has_been_used, is_active, "
+                    "sort_order) VALUES "
+                    "(:unit_id, 'INFO', 'Information', 'Information', "
+                    "'#6c757d', :description, false, '', 0, "
+                    "'info,report_exclude', false, false, false, true, 0)"
+                ),
+                {
+                    "unit_id": unit_id,
+                    "description": (
+                        "Additional roster information. Excluded from reports."
+                    ),
+                },
+            )
+    finally:
+        engine.dispose()
+
+
+def upgrade_database(
+    database_url: str,
+    schema_role: str,
+    unit_id: int | None = None,
+) -> str:
     if schema_role not in {"control", "operational", "combined"}:
         raise ValueError("schema_role must be control, operational, or combined")
     if (
@@ -32,6 +74,8 @@ def upgrade_database(database_url: str, schema_role: str) -> str:
         config = Config(str(REPOSITORY / "alembic.ini"))
         config.set_main_option("script_location", str(REPOSITORY / "migrations"))
         command.upgrade(config, "head")
+        if schema_role == "operational" and unit_id:
+            _ensure_info_annotation(database_url, unit_id)
         engine = create_engine(database_url, pool_pre_ping=True)
         try:
             with engine.connect() as connection:
@@ -101,7 +145,9 @@ def main() -> None:
             raise SystemExit(
                 f"Unit {unit_id} operational database must differ from control."
             )
-        version = upgrade_database(operational_url, "operational")
+        version = upgrade_database(
+            operational_url, "operational", unit_id=unit_id
+        )
         print(f"Operational database for unit {unit_id} upgraded to {version}.")
 
 

--- a/scripts/migrate_all_databases.py
+++ b/scripts/migrate_all_databases.py
@@ -54,11 +54,7 @@ def _ensure_info_annotation(database_url: str, unit_id: int) -> None:
         engine.dispose()
 
 
-def upgrade_database(
-    database_url: str,
-    schema_role: str,
-    unit_id: int | None = None,
-) -> str:
+def upgrade_database(database_url: str, schema_role: str) -> str:
     if schema_role not in {"control", "operational", "combined"}:
         raise ValueError("schema_role must be control, operational, or combined")
     if (
@@ -74,8 +70,6 @@ def upgrade_database(
         config = Config(str(REPOSITORY / "alembic.ini"))
         config.set_main_option("script_location", str(REPOSITORY / "migrations"))
         command.upgrade(config, "head")
-        if schema_role == "operational" and unit_id:
-            _ensure_info_annotation(database_url, unit_id)
         engine = create_engine(database_url, pool_pre_ping=True)
         try:
             with engine.connect() as connection:
@@ -145,7 +139,8 @@ def main() -> None:
             raise SystemExit(
                 f"Unit {unit_id} operational database must differ from control."
             )
-        version = upgrade_database(operational_url, "operational", unit_id=unit_id)
+        version = upgrade_database(operational_url, "operational")
+        _ensure_info_annotation(operational_url, unit_id)
         print(f"Operational database for unit {unit_id} upgraded to {version}.")
 
 

--- a/tests/test_provisioning_worker.py
+++ b/tests/test_provisioning_worker.py
@@ -2,6 +2,7 @@ import hashlib
 
 from cryptography.fernet import Fernet
 import pytest
+from sqlalchemy import create_engine, text
 
 import app
 from app import (
@@ -67,6 +68,19 @@ def test_worker_completes_once_and_token_is_one_time(tmp_path, monkeypatch):
         assert invitations[0].active_bootstrap_key == "active"
     assert pop_one_time_token(job_id, unit_id)
     assert pop_one_time_token(job_id, unit_id) is None
+    operational = create_engine(
+        f"sqlite:///{tmp_path / 'operational.db'}"
+    )
+    try:
+        with operational.connect() as connection:
+            info = connection.execute(text(
+                "SELECT label, tags FROM annotation_type "
+                "WHERE unit_id = :unit_id AND code = 'INFO'"
+            ), {"unit_id": unit_id}).one()
+        assert info.label == "Information"
+        assert "report_exclude" in info.tags
+    finally:
+        operational.dispose()
 
 
 def test_worker_recovers_abandoned_job(tmp_path, monkeypatch):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1029,12 +1029,18 @@ def test_annotation_totals_follow_unit_definitions_not_fixed_columns(client):
                 unit_id=1, staff_id=person.id, day=date(2026, 1, 11),
                 code="M", annotation="OLD", source="manual",
             ),
+            Assignment(
+                unit_id=1, staff_id=person.id, day=date(2026, 1, 12),
+                code="M", annotation="INFO",
+                annotation_note="Operational context only",
+                source="manual",
+            ),
         ])
         db.session.commit()
         app.refresh_annotation_cache()
 
     page = client.get(
-        "/metrics?start=2026-01-10&end=2026-01-11"
+        "/metrics?start=2026-01-10&end=2026-01-12"
     )
     assert page.status_code == 200
     assert b"Annotation Totals" in page.data
@@ -1043,14 +1049,18 @@ def test_annotation_totals_follow_unit_definitions_not_fixed_columns(client):
     assert b"historical" in page.data
     assert b"Ext Total" not in page.data
     assert b"AAVA Total" not in page.data
+    assert b">Information</th>" not in page.data
+    assert b"Operational context only" not in page.data
 
     exported = client.get(
-        "/metrics/export?start=2026-01-10&end=2026-01-11"
+        "/metrics/export?start=2026-01-10&end=2026-01-12"
     )
     assert exported.status_code == 200
     csv_text = exported.data.decode()
     assert "Custom Cover (CUSTOM)" in csv_text
     assert "Retired Marker (OLD)" in csv_text
+    assert "Information (INFO)" not in csv_text
+    assert "Operational context only" not in csv_text
     assert "Ext Total" not in csv_text
 
 


### PR DESCRIPTION
## Summary

- Add INFO as an active default annotation for all airports.
- Seed it idempotently into every existing operational airport database during deployment.
- Seed it automatically when a new airport database is provisioned.
- Tag INFO as `report_exclude` and omit it, its count and its free text from annotation reports and CSV exports.
- Keep INFO available on the roster with the existing click-to-add/edit text workflow.

## Validation

- Provisioning test confirms new airport INFO creation.
- Report test confirms INFO and its text are absent from screen and CSV output.
- Full clean suite: 131 passed, 2 skipped.
- `git diff --check` passed.
