### PR TITLE
Allow individual notification acknowledgement

### DIFF
--- a/app.py
+++ b/app.py
@@ -6965,6 +6965,24 @@ def notifications_read():
     )
 
 
+@app.post("/notifications/<int:notification_id>/read")
+@login_required
+def notification_read(notification_id):
+    _validate_csrf()
+    item = Notification.query.filter_by(
+        id=notification_id,
+        unit_id=_current_unit_id(),
+        recipient_id=current_user.id,
+    ).first_or_404()
+    if not item.read_at:
+        item.read_at = utcnow()
+        db.session.commit()
+        flash("Notification marked as read.", "ok")
+    return redirect(
+        url_for("staff_profile", sid=current_user.id) + "#notifications"
+    )
+
+
 @app.post("/notifications/<int:notification_id>/delete")
 @login_required
 def notification_delete(notification_id):

--- a/static/styles.css
+++ b/static/styles.css
@@ -2029,6 +2029,8 @@ table.roster { transform-origin: top left; transform: scale(var(--ui-scale)); }
 .profile-notifications article { padding:.7rem; border-left:3px solid transparent; display:flex; align-items:flex-start; justify-content:space-between; gap:1rem; }
 .profile-notifications article.unread { border-color:#58aef5; background:rgba(88,174,245,.07); }
 .profile-notification-copy { min-width:0; flex:1; }
+.profile-notification-actions { display:flex; flex:0 0 auto; }
+.profile-notification-actions form { margin:0; }
 .profile-notification-delete { padding:.2rem .5rem; font-size:.72rem; }
 .profile-notifications p { margin:.25rem 0; }
 .profile-notifications small { color:var(--muted,#aab7c4); }

--- a/templates/staff_profile.html
+++ b/templates/staff_profile.html
@@ -75,7 +75,7 @@
       {% if unread_notifications %}
         <form method="post" action="{{ url_for('notifications_read') }}">
           <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
-          <button class="btn btn-sm" type="submit">Mark read</button>
+          <button class="btn btn-sm" type="submit">Mark all as read</button>
         </form>
       {% endif %}
     </div>
@@ -87,12 +87,19 @@
             <p>{{ item.message }}</p>
             <small>{{ item.created_at.strftime('%d %b %Y %H:%M') }}</small>
           </div>
-          {% if item.read_at %}
-          <form method="post" action="{{ url_for('notification_delete', notification_id=item.id) }}" data-confirm="Delete this notification?">
-            <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
-            <button class="btn btn-sm profile-notification-delete" type="submit">Delete</button>
-          </form>
-          {% endif %}
+          <div class="profile-notification-actions">
+            {% if not item.read_at %}
+              <form method="post" action="{{ url_for('notification_read', notification_id=item.id) }}">
+                <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+                <button class="btn btn-sm" type="submit">Mark as read</button>
+              </form>
+            {% else %}
+              <form method="post" action="{{ url_for('notification_delete', notification_id=item.id) }}" data-confirm="Delete this notification?">
+                <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+                <button class="btn btn-sm profile-notification-delete" type="submit">Delete</button>
+              </form>
+            {% endif %}
+          </div>
         </article>
       {% else %}
         <p>No notifications.</p>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2111,6 +2111,51 @@ def test_users_can_delete_only_their_own_read_notifications(client):
         assert db.session.get(app.Notification, other_id) is not None
 
 
+def test_users_can_mark_their_notifications_read_individually(client):
+    login(client)
+    with app.app.app_context():
+        admin = Staff.query.filter_by(username="admin_test").one()
+        other = Staff.query.filter_by(username="staff_test").one()
+        app.Notification.query.filter_by(
+            unit_id=1, recipient_id=admin.id
+        ).delete()
+        first = app.Notification(
+            unit_id=1, recipient_id=admin.id,
+            kind="test", message="First unread notification",
+        )
+        second = app.Notification(
+            unit_id=1, recipient_id=admin.id,
+            kind="test", message="Second unread notification",
+        )
+        private = app.Notification(
+            unit_id=1, recipient_id=other.id,
+            kind="test", message="Another user's notification",
+        )
+        db.session.add_all([first, second, private])
+        db.session.commit()
+        first_id, second_id, private_id = first.id, second.id, private.id
+
+    marked = client.post(
+        f"/notifications/{first_id}/read",
+        data={"_csrf_token": csrf(client)},
+        follow_redirects=True,
+    )
+    assert marked.status_code == 200
+    assert b"Notification marked as read." in marked.data
+    assert b"1 new" in marked.data
+    with app.app.app_context():
+        assert db.session.get(app.Notification, first_id).read_at is not None
+        assert db.session.get(app.Notification, second_id).read_at is None
+
+    forbidden = client.post(
+        f"/notifications/{private_id}/read",
+        data={"_csrf_token": csrf(client)},
+    )
+    assert forbidden.status_code == 404
+    with app.app.app_context():
+        assert db.session.get(app.Notification, private_id).read_at is None
+
+
 def test_primary_navigation_matches_role_permissions():
     editor_client = app.app.test_client()
     editor_client.post(


### PR DESCRIPTION
## Summary

- Add an ownership-scoped endpoint to mark one notification as read.
- Show “Mark as read” on each unread profile notification.
- Keep Delete available only after that notification is read.
- Retain the bulk action and clarify its label as “Mark all as read”.
- Return users to the Notifications profile section after each action.

## Security

- Unit and recipient are both required when resolving a notification.
- Attempts to acknowledge another user’s notification return 404.

## Validation

- Notification-focused tests: 3 passed.
- Full clean suite: 132 passed, 2 skipped.
- `git diff --check` passed.
