### PR TITLE
Keep daily roster totals on one line

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1078,6 +1078,11 @@ select.code-input{
 
 tfoot td{background:var(--card); font-weight:bold; color:var(--text);}
 .totcell{font-size:.7rem; line-height:1.2;}
+.totcell .daily-total{
+  display:block;
+  white-space:nowrap;
+  font-variant-numeric:tabular-nums;
+}
 
 .rag.green{color:#2ecc71;}
 .rag.amber{color:#f1c40f;}

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -308,7 +308,7 @@
         {% set n = counters[d]["N"] %}
         {% set total = m + dday + a + (n if night_active[d] else 0) %}
         <td class="totcell{% if d == today %} is-today{% endif %}">
-          <div><strong>Total {{ total }}</strong></div>
+          <div class="daily-total"><strong>Total {{ total }}</strong></div>
           <div class="rag {{ rag[d]['M'] }}">M {{ m }}/{{ req_by_day[d]['M'] }}</div>
           <div class="rag {{ rag[d]['D'] }}">D {{ dday }}/{{ req_by_day[d]['D'] }}</div>
           <div class="rag {{ rag[d]['A'] }}">A {{ a }}/{{ req_by_day[d]['A'] }}</div>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -443,6 +443,7 @@ def test_roster_publication_is_managed_from_monthly_roster(client):
     draft = client.get("/roster/2025-04")
     assert b"Draft roster" in draft.data
     assert b"Publish roster" in draft.data
+    assert b'class="daily-total"><strong>Total ' in draft.data
     token = csrf(client)
     published = client.post(
         "/roster/2025-04/publish",


### PR DESCRIPTION
## Summary

- Give the daily roster total a dedicated formatting hook.
- Prevent `Total 0` through `Total 99` from wrapping.
- Use tabular numerals for stable alignment between days.

## Validation

- Focused roster tests: 2 passed.
- Full clean suite: 132 passed, 2 skipped.
- `git diff --check` passed.
