### PR TITLE
Clarify staffing day groups

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1568,6 +1568,36 @@ tfoot td{background:var(--card); font-weight:bold; color:var(--text);}
   border-bottom:1px solid var(--control-border);
 }
 .requirements-matrix .table-input{min-width:48px; max-width:58px;}
+.requirements-matrix .requirements-day-group--weekday,
+.requirements-matrix .requirements-day-cell--weekday{
+  background-color:#17212b;
+}
+.requirements-matrix .requirements-day-group--saturday,
+.requirements-matrix .requirements-day-cell--saturday{
+  background-color:#18283a;
+}
+.requirements-matrix .requirements-day-group--sunday,
+.requirements-matrix .requirements-day-cell--sunday{
+  background-color:#282137;
+}
+.requirements-matrix .requirements-day-group--weekday{
+  box-shadow:inset 0 3px 0 #607d8b;
+}
+.requirements-matrix .requirements-day-group--saturday{
+  box-shadow:inset 0 3px 0 #4f8fd8;
+}
+.requirements-matrix .requirements-day-group--sunday{
+  box-shadow:inset 0 3px 0 #9a72c7;
+}
+.requirements-matrix .requirements-day-cell--start{
+  border-left:2px solid #526170;
+}
+.requirements-matrix tbody tr:hover .requirements-day-cell--weekday{background-color:#1c2a36;}
+.requirements-matrix tbody tr:hover .requirements-day-cell--saturday{background-color:#1d3249;}
+.requirements-matrix tbody tr:hover .requirements-day-cell--sunday{background-color:#322944;}
+.requirements-matrix .requirements-day-cell .table-input{
+  background:rgba(8,13,20,.66);
+}
 .special-requirements{
   margin-top:1rem;
   padding-top:1.25rem;

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -172,10 +172,19 @@
       <div class="table-scroll admin-requirements-table">
         <table class="mini admin-table requirements-matrix">
           <thead>
-            <tr><th rowspan="2">Month</th><th colspan="4">Monday–Friday</th><th colspan="4">Saturday</th><th colspan="4">Sunday</th><th rowspan="2">Apply</th></tr>
             <tr>
-              {% for _group in range(3) %}
-                <th title="Morning">M</th><th title="Day">D</th><th title="Afternoon">A</th><th title="Night">N</th>
+              <th rowspan="2">Month</th>
+              <th colspan="4" class="requirements-day-group requirements-day-group--weekday">Monday–Friday</th>
+              <th colspan="4" class="requirements-day-group requirements-day-group--saturday">Saturday</th>
+              <th colspan="4" class="requirements-day-group requirements-day-group--sunday">Sunday</th>
+              <th rowspan="2">Apply</th>
+            </tr>
+            <tr>
+              {% for day_type in ['weekday', 'saturday', 'sunday'] %}
+                <th class="requirements-day-cell requirements-day-cell--{{ day_type }} requirements-day-cell--start" title="Morning">M</th>
+                <th class="requirements-day-cell requirements-day-cell--{{ day_type }}" title="Day">D</th>
+                <th class="requirements-day-cell requirements-day-cell--{{ day_type }}" title="Afternoon">A</th>
+                <th class="requirements-day-cell requirements-day-cell--{{ day_type }}" title="Night">N</th>
               {% endfor %}
             </tr>
           </thead>
@@ -184,10 +193,10 @@
             {% set r = requirements_by_month.get((y,m)) %}
             <tr data-requirement-row>
               <td class="table-label"><input type="hidden" name="ym" value="{{ '%04d-%02d'|format(y,m) }}">{{ ['January','February','March','April','May','June','July','August','September','October','November','December'][m-1] }} {{ y }}</td>
-              {% for prefix, day_name in [('', 'weekday'), ('sat_', 'Saturday'), ('sun_', 'Sunday')] %}
+              {% for prefix, day_name, day_type in [('', 'weekday', 'weekday'), ('sat_', 'Saturday', 'saturday'), ('sun_', 'Sunday', 'sunday')] %}
                 {% for code, duty_name in [('m', 'Morning'), ('d', 'Day'), ('a', 'Afternoon'), ('n', 'Night')] %}
                   {% set field = 'req_' ~ prefix ~ code %}
-                  <td><input type="number" min="0" name="{{ field }}" value="{{ r|attr(field) if r else 0 }}" class="table-input" aria-label="{{ duty_name }} {{ day_name }} requirement for {{ '%04d-%02d'|format(y,m) }}"></td>
+                  <td class="requirements-day-cell requirements-day-cell--{{ day_type }}{% if loop.first %} requirements-day-cell--start{% endif %}"><input type="number" min="0" name="{{ field }}" value="{{ r|attr(field) if r else 0 }}" class="table-input" aria-label="{{ duty_name }} {{ day_name }} requirement for {{ '%04d-%02d'|format(y,m) }}"></td>
                 {% endfor %}
               {% endfor %}
               <td class="table-actions">

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1418,6 +1418,10 @@ def test_weekend_and_special_date_requirements_are_available(client):
     assert b"Monday\xe2\x80\x93Friday" in page.data
     assert b"Saturday" in page.data
     assert b"Sunday" in page.data
+    assert b"requirements-day-group--weekday" in page.data
+    assert b"requirements-day-group--saturday" in page.data
+    assert b"requirements-day-group--sunday" in page.data
+    assert b"requirements-day-cell--start" in page.data
     assert page.data.count(b'name="req_sat_m"') == 24
     assert page.data.count(b'name="req_sun_n"') == 24
     assert b"Special date requirements" in page.data


### PR DESCRIPTION
## Summary
- distinguish weekday, Saturday, and Sunday staffing columns with dedicated shading
- add stronger visual boundaries and group accent colours
- preserve group identity during row hover and improve input contrast

## Verification
- pytest -q (132 passed, 2 skipped)
- git diff --check