### PR TITLE
Harden briefing storage for staging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,10 +21,16 @@ ATCROSTER_LEGAL_ENTITY="Ian John Dickson trading as IDAviation"
 ATCROSTER_LEGAL_ADDRESS="Flat 0/2, 24 Caird Drive, Glasgow, Scotland, G11 5DT"
 
 # Controlled briefing documents. Railway injects these from a private bucket.
+# In production, use complete private S3 configuration (below), or set the
+# provider to "mounted" and point ATCROSTER_BRIEFING_DURABLE_DIR at an
+# explicitly provisioned durable volume. Relative paths and implicit instance
+# storage are rejected.
 BRIEFING_STORAGE_PROVIDER=s3
 BRIEFING_STORAGE_BUCKET=
 BRIEFING_STORAGE_ENDPOINT=
 BRIEFING_STORAGE_REGION=auto
 BRIEFING_STORAGE_ACCESS_KEY=
 BRIEFING_STORAGE_SECRET_KEY=
+# BRIEFING_STORAGE_PROVIDER=mounted
+# ATCROSTER_BRIEFING_DURABLE_DIR=/mnt/atcroster/briefing
 ATCROSTER_COMPANY_NUMBER=

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /srv/atcroster
 
 RUN addgroup --system atcroster && adduser --system --ingroup atcroster atcroster
+RUN apt-get update \
+    && apt-get install --no-install-recommends --yes libpq5 \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY requirements-prod.txt .
 RUN pip install --no-cache-dir -r requirements-prod.txt

--- a/app.py
+++ b/app.py
@@ -38,6 +38,7 @@ from sqlalchemy.exc import IntegrityError
 from rate_limiting import (
     LimiterUnavailable, MemoryRateLimiter, RedisRateLimiter, privacy_key,
 )
+from briefing_storage import configured_briefing_storage
 from tenancy import (
     authenticated_unit_id,
     bind_authenticated_unit,
@@ -155,6 +156,10 @@ if DEPLOYMENT_ENV == "production":
         FIELD_ENCRYPTION_KEYS = f"legacy:{FIELD_ENCRYPTION_KEY}"
     if not os.environ.get("REDIS_URL"):
         raise RuntimeError("Production requires REDIS_URL.")
+    # Validate controlled-document storage during process startup. Production
+    # must never fall back to the application's potentially ephemeral instance
+    # directory.
+    configured_briefing_storage(app.instance_path)
 else:
     FIELD_ENCRYPTION_KEY = base64.urlsafe_b64encode(
         hashlib.sha256(str(app.config["SECRET_KEY"]).encode()).digest()

--- a/briefing_module.py
+++ b/briefing_module.py
@@ -10,7 +10,6 @@ from datetime import date, datetime, time, timezone
 import hashlib
 import io
 import json
-import re
 import secrets
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -518,6 +517,16 @@ def document(item_id: int):
     except BriefingStorageError:
         current_app.logger.exception("briefing_document_read_failed")
         abort(404)
+    if not secrets.compare_digest(
+        hashlib.sha256(content).hexdigest(),
+        item.content_sha256 or "",
+    ):
+        current_app.logger.error(
+            "briefing_document_checksum_failed unit_id=%s briefing_id=%s",
+            current_user.unit_id,
+            item.id,
+        )
+        abort(503)
     download = request.args.get("download") == "1"
     response = send_file(
         io.BytesIO(content),

--- a/briefing_storage.py
+++ b/briefing_storage.py
@@ -150,11 +150,29 @@ class S3BriefingStorage(BriefingStorage):
 
 def configured_briefing_storage(instance_path: str) -> BriefingStorage:
     provider = os.environ.get("BRIEFING_STORAGE_PROVIDER", "local").strip().lower()
-    if provider == "local":
-        root = os.environ.get(
-            "ATCROSTER_BRIEFING_UPLOAD_DIR",
-            os.path.join(instance_path, "briefing_uploads"),
-        )
+    production = (
+        os.environ.get("ATCROSTER_ENVIRONMENT", "development").strip().lower()
+        == "production"
+    )
+    if provider in {"local", "mounted"}:
+        if production:
+            root = os.environ.get(
+                "ATCROSTER_BRIEFING_DURABLE_DIR", ""
+            ).strip()
+            if not root:
+                raise BriefingStorageError(
+                    "Production local briefing storage requires an explicit "
+                    "ATCROSTER_BRIEFING_DURABLE_DIR mounted on durable storage."
+                )
+            if not Path(root).is_absolute():
+                raise BriefingStorageError(
+                    "ATCROSTER_BRIEFING_DURABLE_DIR must be an absolute path."
+                )
+        else:
+            root = os.environ.get(
+                "ATCROSTER_BRIEFING_UPLOAD_DIR",
+                os.path.join(instance_path, "briefing_uploads"),
+            )
         return LocalBriefingStorage(Path(root))
     if provider == "s3":
         return S3BriefingStorage(

--- a/docs/briefing_module_rollback.md
+++ b/docs/briefing_module_rollback.md
@@ -12,21 +12,20 @@ routes. Roster behaviour and data are unchanged.
 ## Code and schema rollback
 
 1. Back up the airport operational database and inventory the private briefing
-   bucket.
+   object store or durable mounted directory.
 2. Disable `briefing_module`.
-3. Downgrade Alembic from `20260728_21` to `20260727_20`.
-4. Deploy the earlier application revision.
+3. Prefer a schema-compatible application rollback. Do not run an improvised
+   Alembic downgrade: later migrations contain briefing schema and data changes
+   beyond the original module tables.
+4. If schema rollback is required, restore the control and all airport
+   databases from the same verified pre-deployment recovery set, then deploy
+   the matching earlier application revision as described in the database
+   migration runbook.
 
-The downgrade removes only:
-
-- `briefing_item`
-- `briefing_delivery`
-- `briefing_audit`
-- `briefing_assurance_run`
-
-Uploaded objects are intentionally retained during database downgrade so an
-accidental rollback does not destroy controlled documents. After confirming
-that the module will not be restored, the airport prefix in the configured
-private bucket may be archived or deliberately removed under the approved
-retention process. Local development uses the directory beneath
-`ATCROSTER_BRIEFING_UPLOAD_DIR`.
+Briefing objects are outside the database backup. Retain and inventory them
+through rollback so controlled documents are not silently lost. After
+confirming that the module will not be restored, the airport prefix may be
+archived or deliberately removed only under the approved retention process.
+Development may use `ATCROSTER_BRIEFING_UPLOAD_DIR`; production requires
+complete private S3-compatible configuration or
+`ATCROSTER_BRIEFING_DURABLE_DIR` on an explicitly provisioned durable mount.

--- a/docs/migration_runbook.md
+++ b/docs/migration_runbook.md
@@ -1,6 +1,6 @@
 # Database migration runbook
 
-The current head is `20260726_09`. Production migration must use
+The current head is `20260730_28`. Production migration must use
 `scripts/migrate_all_databases.py`, which applies the `control` schema role to
 the control database and the `operational` role separately to every configured
 airport database. It is safe to rerun and does not create control-plane tables
@@ -41,8 +41,8 @@ application image.
 3. Run `python scripts/migrate_all_databases.py` once. It upgrades control
    first, then every route in unit order and fails closed for missing,
    malformed or control-equal secrets.
-4. Confirm `alembic current` reports `20260725_08` (or the later approved
-   release revision).
+4. Confirm `alembic current` reports the exact approved release head
+   (`20260730_28` for this release).
 5. Check `/health/live` and `/health/ready`.
 6. Smoke-test login, one unit-scoped roster, requests, annotations, publication
    history and Super Admin aggregate view.

--- a/docs/production_runbook.md
+++ b/docs/production_runbook.md
@@ -97,6 +97,11 @@ receive the same encrypted variables:
   `ATCROSTER_DB_STATEMENT_TIMEOUT_MS`, `ATCROSTER_DB_POOL_TIMEOUT_SECONDS`,
   `ATCROSTER_OPERATIONAL_POOL_SIZE` and
   `ATCROSTER_OPERATIONAL_MAX_OVERFLOW`
+- controlled briefing storage using either complete private S3-compatible
+  `BRIEFING_STORAGE_PROVIDER=s3`, bucket, endpoint, access-key and secret-key
+  configuration, or `BRIEFING_STORAGE_PROVIDER=mounted` with
+  `ATCROSTER_BRIEFING_DURABLE_DIR` set to the absolute path of an explicitly
+  provisioned durable volume
 
 The web service uses the repository `railway.toml`. Configure the worker
 service start command as `python scripts/run_provisioning_worker.py` and no
@@ -104,6 +109,11 @@ public endpoint. The pre-deploy command upgrades control first and then all
 configured operational databases. After the first healthy deployment, run
 `flask --app app bootstrap-platform` once with a unique administrator
 password. Do not upload acceptance data or local environment files.
+Confirm storage credentials are private, public object/container access is
+disabled, and an uploaded briefing remains retrievable after a service
+restart. Startup rejects incomplete S3 configuration and implicit local
+instance storage, but cannot prove that an operator-supplied directory is
+backed by a durable mount.
 
 For field-key rotation, prepend the new version, retain previous decrypt keys,
 take verified backups, and run:

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -5,17 +5,20 @@ production release.
 
 ## Automated evidence
 
-- [x] Full test suite passes: 67 tests on 25 July 2026.
+- [x] Full test suite passes: 152 passed and 2 intentionally skipped on
+  30 July 2026.
 - [x] Tenant-isolation and cross-unit IDOR tests pass.
 - [x] Super Admin privacy tests pass.
 - [x] Account-limit, request, annotation and publication tests pass.
-- [x] Clean SQLite fixtures and PostgreSQL 16 reach Alembic `20260725_08`.
+- [x] Fresh control, operational and combined SQLite and PostgreSQL 16
+  databases reach Alembic `20260730_28`.
 - [x] `pip-audit -r requirements-prod.txt` reports no known vulnerabilities.
 - [x] Changed-file and correctness/security lint checks pass; remaining legacy
   style debt is recorded as non-blocking.
 - [x] 30-airport/108,000-assignment smoke test passes locally.
-- [x] Production container builds and production configuration validation
-  passes.
+- [x] Production container builds, has no fixed HIGH/CRITICAL Trivy findings,
+  and production-style PostgreSQL/Redis/private-storage configuration
+  validation passes.
 
 ## Production controls
 

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -7,7 +7,7 @@ Flask-Login==0.6.3
 SQLAlchemy==2.0.51
 alembic==1.13.3
 Flask-Migrate==4.0.7
-psycopg[binary]==3.3.4
+psycopg==3.3.4
 
 # Security and MFA
 Werkzeug==3.1.8

--- a/tests/test_briefing_module.py
+++ b/tests/test_briefing_module.py
@@ -2,6 +2,7 @@ import io
 import json
 from datetime import datetime, timedelta
 import os
+from pathlib import Path
 import sys
 from zoneinfo import ZoneInfo
 
@@ -343,6 +344,18 @@ def test_admin_publishes_instruction_and_user_acknowledges(briefing_client):
     )
     assert download.status_code == 200
     assert "attachment" in download.headers["Content-Disposition"]
+    with app.app.app_context():
+        item = db.session.get(BriefingItem, item_id)
+        stored_path = (
+            Path(app.app.instance_path)
+            / "briefing_uploads"
+            / item.stored_filename
+        )
+        original_content = stored_path.read_bytes()
+        stored_path.write_bytes(b"%PDF-1.4 altered after storage")
+    corrupted = briefing_client.get(f"/briefing/item/{item_id}/document")
+    assert corrupted.status_code == 503
+    stored_path.write_bytes(original_content)
     response = briefing_client.post(
         f"/briefing/item/{item_id}/acknowledge",
         data={"_csrf_token": _csrf(briefing_client), "confirmation": "yes"},

--- a/tests/test_briefing_storage.py
+++ b/tests/test_briefing_storage.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+import pytest
+
+from briefing_storage import (
+    BriefingStorageError,
+    LocalBriefingStorage,
+    configured_briefing_storage,
+)
+
+
+def test_development_storage_can_use_instance_directory(monkeypatch, tmp_path):
+    monkeypatch.setenv("ATCROSTER_ENVIRONMENT", "development")
+    monkeypatch.delenv("BRIEFING_STORAGE_PROVIDER", raising=False)
+    monkeypatch.delenv("ATCROSTER_BRIEFING_UPLOAD_DIR", raising=False)
+
+    storage = configured_briefing_storage(str(tmp_path))
+
+    assert isinstance(storage, LocalBriefingStorage)
+    assert storage.root == tmp_path / "briefing_uploads"
+
+
+def test_production_storage_rejects_implicit_local_directory(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("ATCROSTER_ENVIRONMENT", "production")
+    monkeypatch.setenv("BRIEFING_STORAGE_PROVIDER", "local")
+    monkeypatch.delenv("ATCROSTER_BRIEFING_DURABLE_DIR", raising=False)
+    monkeypatch.setenv(
+        "ATCROSTER_BRIEFING_UPLOAD_DIR", str(tmp_path / "not-a-mount")
+    )
+
+    with pytest.raises(BriefingStorageError, match="durable"):
+        configured_briefing_storage(str(tmp_path))
+
+
+def test_production_storage_accepts_explicit_absolute_durable_mount(
+    monkeypatch, tmp_path
+):
+    durable_root = tmp_path / "briefing"
+    monkeypatch.setenv("ATCROSTER_ENVIRONMENT", "production")
+    monkeypatch.setenv("BRIEFING_STORAGE_PROVIDER", "mounted")
+    monkeypatch.setenv(
+        "ATCROSTER_BRIEFING_DURABLE_DIR", str(durable_root)
+    )
+
+    storage = configured_briefing_storage(str(tmp_path))
+
+    assert isinstance(storage, LocalBriefingStorage)
+    assert storage.root == durable_root
+
+
+def test_production_storage_rejects_relative_durable_mount(monkeypatch):
+    monkeypatch.setenv("ATCROSTER_ENVIRONMENT", "production")
+    monkeypatch.setenv("BRIEFING_STORAGE_PROVIDER", "mounted")
+    monkeypatch.setenv("ATCROSTER_BRIEFING_DURABLE_DIR", "briefing")
+
+    with pytest.raises(BriefingStorageError, match="absolute"):
+        configured_briefing_storage("/srv/atcroster")
+
+
+def test_s3_storage_rejects_incomplete_configuration(monkeypatch, tmp_path):
+    monkeypatch.setenv("ATCROSTER_ENVIRONMENT", "production")
+    monkeypatch.setenv("BRIEFING_STORAGE_PROVIDER", "s3")
+    for name in (
+        "BRIEFING_STORAGE_BUCKET",
+        "BRIEFING_STORAGE_ENDPOINT",
+        "BRIEFING_STORAGE_ACCESS_KEY",
+        "BRIEFING_STORAGE_SECRET_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    with pytest.raises(BriefingStorageError, match="incomplete"):
+        configured_briefing_storage(str(tmp_path))


### PR DESCRIPTION
## What changed

- require complete private S3-compatible storage or an explicit durable mounted directory for production briefing documents
- verify briefing document checksums when files are served
- remove the vulnerable bundled PCRE2 library from the production image by using system libpq with psycopg
- update migration, deployment, release and rollback documentation to Alembic head 20260730_28
- add regression tests for production storage validation and corrupted briefing documents

## Why

Production previously defaulted briefing documents to the application instance directory, which can be ephemeral on Railway. The production database wheel also introduced fixed HIGH/CRITICAL container findings through a bundled library.

## Validation

- complete test suite: 152 passed, 2 skipped
- fresh control, operational and combined migrations to 20260730_28 on SQLite and PostgreSQL 16
- production-style PostgreSQL/Redis/secure-cookie/trusted-host/encryption/private-storage startup and readiness: passed
- pip-audit, Bandit, Ruff, MyPy and compile checks: passed
- production image build: passed
- Trivy HIGH/CRITICAL fixed-vulnerability scan: 0 findings
