### PR TITLE
Introduce application configuration factory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,8 +4,15 @@
 env
 __pycache__
 *.pyc
+.coverage
+.mypy_cache
+.pytest_cache
+.ruff_cache
 *.db
 instance
+tests
+docs
+deliverables
 1 Version to deploy
 2 Working Version
 3 Last Known Working

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -20,14 +20,14 @@ jobs:
       - run: pip install -r requirements-dev.txt
       - name: Formatting, lint and static analysis
         run: |
-          ruff format --check rate_limiting.py platform_provisioning.py signup_locking.py scripts/migrate_all_databases.py scripts/run_provisioning_worker.py auth_blueprint.py
-          ruff check app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py desktop_app.py platform_provisioning.py rate_limiting.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts/*.py
-          mypy --ignore-missing-imports rate_limiting.py signup_locking.py
+          ruff format --check atcroster rate_limiting.py platform_provisioning.py signup_locking.py scripts/migrate_all_databases.py scripts/run_provisioning_worker.py auth_blueprint.py
+          ruff check atcroster app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py desktop_app.py platform_provisioning.py rate_limiting.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts/*.py
+          mypy --ignore-missing-imports --follow-imports=skip atcroster rate_limiting.py signup_locking.py
       - run: pip-audit -r requirements-prod.txt
       - name: Full maintained-application security scan
         run: |
-          bandit -q -ll -r app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py desktop_app.py platform_provisioning.py rate_limiting.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts
-      - run: python -m compileall -q app.py auth_blueprint.py briefing_module.py briefing_storage.py saas_models.py tenancy.py account_limits.py scripts
+          bandit -q -ll -r atcroster app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py desktop_app.py platform_provisioning.py rate_limiting.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts
+      - run: python -m compileall -q atcroster app.py auth_blueprint.py briefing_module.py briefing_storage.py saas_models.py tenancy.py account_limits.py scripts
       - run: python -m pytest --cov --cov-report=term-missing -q
       - name: Verify fresh split migrations
         run: |

--- a/app.py
+++ b/app.py
@@ -30,7 +30,6 @@ from flask_login import (
     LoginManager, UserMixin, login_user, logout_user,
     current_user, login_required
 )
-from werkzeug.middleware.proxy_fix import ProxyFix
 from werkzeug.security import generate_password_hash, check_password_hash
 from werkzeug.exceptions import HTTPException, SecurityError
 from sqlalchemy import text
@@ -38,7 +37,7 @@ from sqlalchemy.exc import IntegrityError
 from rate_limiting import (
     LimiterUnavailable, MemoryRateLimiter, RedisRateLimiter, privacy_key,
 )
-from briefing_storage import configured_briefing_storage
+from atcroster import create_app, get_runtime_settings
 from tenancy import (
     authenticated_unit_id,
     bind_authenticated_unit,
@@ -56,121 +55,20 @@ except Exception:
     Cache = None
 
 # -------------------- App setup --------------------
-app = Flask(__name__)
+app = create_app()
+_runtime_settings = get_runtime_settings(app)
 
 # Writable ./instance folder (works locally & on PythonAnywhere)
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-INSTANCE_DIR = os.path.join(BASE_DIR, "instance")
+INSTANCE_DIR = app.instance_path
 os.makedirs(INSTANCE_DIR, exist_ok=True)
 
-# Secrets & DB config (env-overridable)
-# On PythonAnywhere set: FLASK_SECRET_KEY (and optionally DATABASE_URL)
-app.config["SECRET_KEY"] = os.environ.get(
-    "FLASK_SECRET_KEY", "fallback-change-me")
-app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv(
-    "DATABASE_URL",
-    f"sqlite:///{os.path.join(INSTANCE_DIR, 'roster.db')}"
-)
-app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {
-    "pool_pre_ping": True,
-    "pool_recycle": 280,
-    "pool_size": 5,
-    "max_overflow": 5,
-    "pool_timeout": int(os.environ.get("ATCROSTER_DB_POOL_TIMEOUT_SECONDS", "10")),
-}
-if str(app.config["SQLALCHEMY_DATABASE_URI"]).startswith("postgresql"):
-    app.config["SQLALCHEMY_ENGINE_OPTIONS"]["connect_args"] = {
-        "connect_timeout": int(
-            os.environ.get("ATCROSTER_DB_CONNECT_TIMEOUT_SECONDS", "5")
-        ),
-        "options": (
-            "-c statement_timeout="
-            + str(int(os.environ.get(
-                "ATCROSTER_DB_STATEMENT_TIMEOUT_MS", "15000"
-            )))
-        ),
-    }
-app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
-app.config["MAX_CONTENT_LENGTH"] = int(
-    os.environ.get("ATCROSTER_MAX_REQUEST_BYTES", 2 * 1024 * 1024)
-)
-app.config["SESSION_COOKIE_HTTPONLY"] = True
-app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
-app.config["SESSION_COOKIE_NAME"] = os.environ.get(
-    "ATCROSTER_SESSION_COOKIE_NAME",
-    "__Host-atcroster"
-    if os.environ.get("ATCROSTER_ENVIRONMENT", "").lower() == "production"
-    else "atcroster_session",
-)
-app.config["SESSION_COOKIE_SECURE"] = os.environ.get("ATCROSTER_SECURE_COOKIES", "").lower() in {
-    "1", "true", "yes"
-}
-app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(
-    minutes=int(os.environ.get("ATCROSTER_SESSION_ABSOLUTE_MINUTES", "720"))
-)
-
-# Make external URLs prefer https behind PA’s proxy
-app.config["PREFERRED_URL_SCHEME"] = "https"
-_trusted_proxy_hops = int(os.environ.get("ATCROSTER_TRUSTED_PROXY_HOPS", "0"))
-if not 0 <= _trusted_proxy_hops <= 3:
-    raise RuntimeError("ATCROSTER_TRUSTED_PROXY_HOPS must be between 0 and 3.")
-if _trusted_proxy_hops:
-    app.wsgi_app = ProxyFix(
-        app.wsgi_app, x_for=_trusted_proxy_hops,
-        x_proto=_trusted_proxy_hops, x_host=_trusted_proxy_hops,
-    )
-
-DEPLOYMENT_ENV = os.environ.get("ATCROSTER_ENVIRONMENT", "development").lower()
-FIELD_ENCRYPTION_KEY = os.environ.get("ATCROSTER_FIELD_ENCRYPTION_KEY", "")
-FIELD_ENCRYPTION_KEYS = os.environ.get("ATCROSTER_FIELD_ENCRYPTION_KEYS", "")
-if DEPLOYMENT_ENV == "production":
-    trusted_hosts = [
-        host.strip()
-        for host in os.environ.get("ATCROSTER_TRUSTED_HOSTS", "").split(",")
-        if host.strip()
-    ]
-    if not trusted_hosts:
-        raise RuntimeError("Production requires ATCROSTER_TRUSTED_HOSTS.")
-    app.config["TRUSTED_HOSTS"] = trusted_hosts
-    if "ATCROSTER_TRUSTED_PROXY_HOPS" not in os.environ:
-        raise RuntimeError(
-            "Production requires an explicit ATCROSTER_TRUSTED_PROXY_HOPS value."
-        )
-    if app.config["SECRET_KEY"] == "fallback-change-me" or len(
-        app.config["SECRET_KEY"]
-    ) < 32:
-        raise RuntimeError(
-            "Production requires FLASK_SECRET_KEY with at least 32 characters."
-        )
-    if str(app.config["SQLALCHEMY_DATABASE_URI"]).startswith("sqlite"):
-        raise RuntimeError("Production requires PostgreSQL; SQLite is not supported.")
-    if not app.config["SESSION_COOKIE_SECURE"]:
-        raise RuntimeError(
-            "Production requires ATCROSTER_SECURE_COOKIES=true."
-        )
-    if not FIELD_ENCRYPTION_KEY and not FIELD_ENCRYPTION_KEYS:
-        raise RuntimeError(
-            "Production requires ATCROSTER_FIELD_ENCRYPTION_KEYS."
-        )
-    if not FIELD_ENCRYPTION_KEYS:
-        FIELD_ENCRYPTION_KEYS = f"legacy:{FIELD_ENCRYPTION_KEY}"
-    if not os.environ.get("REDIS_URL"):
-        raise RuntimeError("Production requires REDIS_URL.")
-    # Validate controlled-document storage during process startup. Production
-    # must never fall back to the application's potentially ephemeral instance
-    # directory.
-    configured_briefing_storage(app.instance_path)
-else:
-    FIELD_ENCRYPTION_KEY = base64.urlsafe_b64encode(
-        hashlib.sha256(str(app.config["SECRET_KEY"]).encode()).digest()
-    ).decode()
-    FIELD_ENCRYPTION_KEYS = f"dev:{FIELD_ENCRYPTION_KEY}"
+DEPLOYMENT_ENV = _runtime_settings.deployment_environment
+FIELD_ENCRYPTION_KEY = _runtime_settings.field_encryption_key
+FIELD_ENCRYPTION_KEYS = _runtime_settings.field_encryption_keys
 
 if DEPLOYMENT_ENV == "production":
     import redis
-    from platform_provisioning import validate_token_encryption_config
-
-    validate_token_encryption_config()
     _rate_limiter = RedisRateLimiter(redis.from_url(
         os.environ["REDIS_URL"], socket_connect_timeout=2,
         socket_timeout=2, decode_responses=True,

--- a/atcroster/__init__.py
+++ b/atcroster/__init__.py
@@ -1,0 +1,75 @@
+"""ATCRoster application construction."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from flask import Flask
+from werkzeug.middleware.proxy_fix import ProxyFix
+
+from atcroster.config import (
+    RuntimeSettings,
+    environment_snapshot,
+    load_flask_config,
+    runtime_settings,
+)
+
+
+def create_app(
+    config_object: Mapping[str, Any] | object | None = None,
+    *,
+    validate_external_services: bool = True,
+) -> Flask:
+    """Create a configured Flask application without importing legacy routes."""
+
+    repository = Path(__file__).resolve().parents[1]
+    app = Flask(
+        "atcroster",
+        instance_path=str(repository / "instance"),
+        template_folder=str(repository / "templates"),
+        static_folder=str(repository / "static"),
+    )
+    environ = environment_snapshot()
+    app.config.from_mapping(load_flask_config(environ, app.instance_path))
+    explicit_keys: set[str] = set()
+    if config_object is not None:
+        if isinstance(config_object, Mapping):
+            explicit_keys = set(config_object)
+            app.config.from_mapping(config_object)
+        else:
+            app.config.from_object(config_object)
+    if (
+        str(app.config.get("ATCROSTER_ENVIRONMENT", "")).lower() == "production"
+        and "SESSION_COOKIE_NAME" not in explicit_keys
+    ):
+        app.config["SESSION_COOKIE_NAME"] = "__Host-atcroster"
+
+    settings = runtime_settings(app.config, environ)
+    app.extensions["atcroster_runtime_settings"] = settings
+    if settings.trusted_proxy_hops:
+        app.wsgi_app = ProxyFix(  # type: ignore[method-assign]
+            app.wsgi_app,
+            x_for=settings.trusted_proxy_hops,
+            x_proto=settings.trusted_proxy_hops,
+            x_host=settings.trusted_proxy_hops,
+        )
+
+    if validate_external_services and settings.deployment_environment == "production":
+        _validate_external_services(app)
+    return app
+
+
+def _validate_external_services(app: Flask) -> None:
+    """Validate required production integrations without opening databases."""
+
+    from briefing_storage import configured_briefing_storage
+    from platform_provisioning import validate_token_encryption_config
+
+    configured_briefing_storage(app.instance_path)
+    validate_token_encryption_config()
+
+
+def get_runtime_settings(app: Flask) -> RuntimeSettings:
+    return app.extensions["atcroster_runtime_settings"]

--- a/atcroster/cli.py
+++ b/atcroster/cli.py
@@ -1,0 +1,1 @@
+"""CLI registration boundary for the next extraction step."""

--- a/atcroster/config.py
+++ b/atcroster/config.py
@@ -1,0 +1,179 @@
+"""Explicit application configuration loading and production validation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import timedelta
+import base64
+import hashlib
+import os
+from pathlib import Path
+from typing import Any
+
+
+TRUE_VALUES = frozenset({"1", "true", "yes"})
+
+
+@dataclass(frozen=True)
+class RuntimeSettings:
+    """Security-sensitive settings used outside Flask's config mapping."""
+
+    deployment_environment: str
+    field_encryption_key: str
+    field_encryption_keys: str
+    trusted_proxy_hops: int
+
+
+def load_flask_config(
+    environ: Mapping[str, str],
+    instance_path: str,
+) -> dict[str, Any]:
+    """Build Flask configuration without connecting to external services."""
+
+    deployment_environment = environ.get("ATCROSTER_ENVIRONMENT", "development").lower()
+    database_url = environ.get(
+        "DATABASE_URL",
+        f"sqlite:///{Path(instance_path) / 'roster.db'}",
+    )
+    engine_options: dict[str, Any] = {
+        "pool_pre_ping": True,
+        "pool_recycle": 280,
+        "pool_size": 5,
+        "max_overflow": 5,
+        "pool_timeout": int(environ.get("ATCROSTER_DB_POOL_TIMEOUT_SECONDS", "10")),
+    }
+    if database_url.startswith("postgresql"):
+        engine_options["connect_args"] = {
+            "connect_timeout": int(
+                environ.get("ATCROSTER_DB_CONNECT_TIMEOUT_SECONDS", "5")
+            ),
+            "options": (
+                "-c statement_timeout="
+                + str(int(environ.get("ATCROSTER_DB_STATEMENT_TIMEOUT_MS", "15000")))
+            ),
+        }
+    return {
+        "ATCROSTER_ENVIRONMENT": deployment_environment,
+        "SECRET_KEY": environ.get("FLASK_SECRET_KEY", "fallback-change-me"),
+        "SQLALCHEMY_DATABASE_URI": database_url,
+        "SQLALCHEMY_ENGINE_OPTIONS": engine_options,
+        "SQLALCHEMY_TRACK_MODIFICATIONS": False,
+        "MAX_CONTENT_LENGTH": int(
+            environ.get("ATCROSTER_MAX_REQUEST_BYTES", str(2 * 1024 * 1024))
+        ),
+        "SESSION_COOKIE_HTTPONLY": True,
+        "SESSION_COOKIE_SAMESITE": "Lax",
+        "SESSION_COOKIE_NAME": environ.get(
+            "ATCROSTER_SESSION_COOKIE_NAME",
+            (
+                "__Host-atcroster"
+                if deployment_environment == "production"
+                else "atcroster_session"
+            ),
+        ),
+        "SESSION_COOKIE_SECURE": environ.get("ATCROSTER_SECURE_COOKIES", "").lower()
+        in TRUE_VALUES,
+        "PERMANENT_SESSION_LIFETIME": timedelta(
+            minutes=int(environ.get("ATCROSTER_SESSION_ABSOLUTE_MINUTES", "720"))
+        ),
+        "PREFERRED_URL_SCHEME": "https",
+        "TRUSTED_HOSTS": [
+            host.strip()
+            for host in environ.get("ATCROSTER_TRUSTED_HOSTS", "").split(",")
+            if host.strip()
+        ],
+    }
+
+
+def runtime_settings(
+    config: Mapping[str, Any],
+    environ: Mapping[str, str],
+) -> RuntimeSettings:
+    """Resolve and validate non-Flask runtime settings."""
+
+    deployment_environment = str(
+        config.get("ATCROSTER_ENVIRONMENT", "development")
+    ).lower()
+    try:
+        trusted_proxy_hops = int(
+            config.get(
+                "ATCROSTER_TRUSTED_PROXY_HOPS",
+                environ.get("ATCROSTER_TRUSTED_PROXY_HOPS", "0"),
+            )
+        )
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("ATCROSTER_TRUSTED_PROXY_HOPS must be an integer.") from exc
+    if not 0 <= trusted_proxy_hops <= 3:
+        raise RuntimeError("ATCROSTER_TRUSTED_PROXY_HOPS must be between 0 and 3.")
+
+    field_encryption_key = str(
+        config.get(
+            "ATCROSTER_FIELD_ENCRYPTION_KEY",
+            environ.get("ATCROSTER_FIELD_ENCRYPTION_KEY", ""),
+        )
+    )
+    field_encryption_keys = str(
+        config.get(
+            "ATCROSTER_FIELD_ENCRYPTION_KEYS",
+            environ.get("ATCROSTER_FIELD_ENCRYPTION_KEYS", ""),
+        )
+    )
+    if deployment_environment == "production":
+        _validate_production_config(
+            config=config,
+            environ=environ,
+            field_encryption_key=field_encryption_key,
+            field_encryption_keys=field_encryption_keys,
+        )
+        if not field_encryption_keys:
+            field_encryption_keys = f"legacy:{field_encryption_key}"
+    else:
+        field_encryption_key = base64.urlsafe_b64encode(
+            hashlib.sha256(str(config["SECRET_KEY"]).encode()).digest()
+        ).decode()
+        field_encryption_keys = f"dev:{field_encryption_key}"
+
+    return RuntimeSettings(
+        deployment_environment=deployment_environment,
+        field_encryption_key=field_encryption_key,
+        field_encryption_keys=field_encryption_keys,
+        trusted_proxy_hops=trusted_proxy_hops,
+    )
+
+
+def _validate_production_config(
+    *,
+    config: Mapping[str, Any],
+    environ: Mapping[str, str],
+    field_encryption_key: str,
+    field_encryption_keys: str,
+) -> None:
+    if not config.get("TRUSTED_HOSTS"):
+        raise RuntimeError("Production requires ATCROSTER_TRUSTED_HOSTS.")
+    if (
+        "ATCROSTER_TRUSTED_PROXY_HOPS" not in environ
+        and "ATCROSTER_TRUSTED_PROXY_HOPS" not in config
+    ):
+        raise RuntimeError(
+            "Production requires an explicit ATCROSTER_TRUSTED_PROXY_HOPS value."
+        )
+    secret_key = str(config.get("SECRET_KEY", ""))
+    if secret_key == "fallback-change-me" or len(secret_key) < 32:
+        raise RuntimeError(
+            "Production requires FLASK_SECRET_KEY with at least 32 characters."
+        )
+    if str(config.get("SQLALCHEMY_DATABASE_URI", "")).startswith("sqlite"):
+        raise RuntimeError("Production requires PostgreSQL; SQLite is not supported.")
+    if not config.get("SESSION_COOKIE_SECURE"):
+        raise RuntimeError("Production requires ATCROSTER_SECURE_COOKIES=true.")
+    if not field_encryption_key and not field_encryption_keys:
+        raise RuntimeError("Production requires ATCROSTER_FIELD_ENCRYPTION_KEYS.")
+    if not environ.get("REDIS_URL") and not config.get("REDIS_URL"):
+        raise RuntimeError("Production requires REDIS_URL.")
+
+
+def environment_snapshot() -> dict[str, str]:
+    """Return a copy so factory tests cannot mutate process configuration."""
+
+    return dict(os.environ)

--- a/atcroster/errors.py
+++ b/atcroster/errors.py
@@ -1,0 +1,1 @@
+"""Error-handler registration boundary for the next extraction step."""

--- a/atcroster/extensions.py
+++ b/atcroster/extensions.py
@@ -1,0 +1,5 @@
+"""Extension ownership for incremental migration out of the legacy module.
+
+Database and login extensions remain in ``app.py`` until their model and
+session-routing dependencies are extracted. New extensions belong here.
+"""

--- a/docs/quality_baseline.md
+++ b/docs/quality_baseline.md
@@ -11,8 +11,9 @@ late imports, duplicate compatibility definitions, one lambda assignment,
 unused imports and one unused local. Two document/import scripts retain
 unused-import exceptions. New modules receive the default rule set.
 
-Formatting remains enforced on the already-formatted service modules and on
-newly extracted modules. Expand that list one module at a time; format
+Formatting remains enforced on the already-formatted service modules and the
+`atcroster` application-factory package. MyPy also checks the factory package
+alongside the existing typed services. Expand those lists one module at a time; format
 `app.py` only in a dedicated, behaviour-neutral change after its routes have
 been reduced.
 

--- a/docs/railway_topology_reconciliation.md
+++ b/docs/railway_topology_reconciliation.md
@@ -1,0 +1,153 @@
+# Railway topology reconciliation
+
+Evidence date: 31 July 2026
+
+## Current state
+
+The Railway project `ATCRoster Production` contains two persistent
+environments whose names do not match their current responsibilities.
+
+### `pilot-staging` is the public production stack
+
+It contains:
+
+- `web`, serving `www.atcroster.com`, `pilot.atcroster.com` and the Railway
+  service domain;
+- control PostgreSQL;
+- `Postgres-IWLD`, the additional operational PostgreSQL service;
+- Redis;
+- a provisioning worker;
+- the private `briefing-documents` bucket;
+- configuration names for control and two operational databases, Redis,
+  versioned encryption keys, trusted hosts/proxies, private briefing storage,
+  SMTP and optional SMS.
+
+Its web and worker deployments succeeded on 30 July 2026 using the current
+multi-database migration and service commands.
+
+### `production` is a legacy stack
+
+It contains only:
+
+- `web`, exposed at its Railway-generated domain;
+- one PostgreSQL service.
+
+Its web service runs repository commit `57b0189` from 24 July 2026. Its
+variable-name inventory lacks Redis, trusted hosts/proxy configuration,
+versioned token encryption, operational database routes, worker configuration
+and durable briefing storage required by current `main`. Deploying current
+`main` into this environment without first provisioning those dependencies
+must fail closed.
+
+No secret values were copied or recorded during this inventory.
+
+## Safety decision
+
+Do not:
+
+- deploy current `main` to the legacy `production` web service;
+- copy production secret values into source control, logs or tickets;
+- duplicate the public environment if that would clone personal or
+  operational data into a staging context;
+- move `www.atcroster.com` until the target has passed database, Redis, worker,
+  storage and authenticated smoke tests;
+- delete either environment until backup and data ownership are verified.
+
+## Reconciliation procedure
+
+This procedure is intentionally separate from an application-code pull
+request.
+
+### 1. Establish ownership and backups
+
+1. Record the accountable owner, change window and rollback owner.
+2. Confirm which PostgreSQL services contain live control and airport data.
+3. Take encrypted custom-format backups of control and every airport database.
+4. Record checksums, Alembic revisions and backup object references.
+5. Verify the private briefing bucket's versioning and recovery mechanism.
+6. Retain the currently running web and worker image digests.
+
+### 2. Verify the public stack
+
+Against the current `pilot-staging` environment:
+
+1. Confirm every required configuration **name** from
+   `docs/production_runbook.md`; do not export values.
+2. Confirm control and operational database URLs are distinct.
+3. Confirm Redis health and a current worker heartbeat.
+4. Confirm the private bucket denies public access.
+5. Run the migration command in report/compatibility mode against restored
+   copies before changing the live databases.
+6. Run liveness, readiness, login, MFA, tenant-routing, upload/download and
+   provisioning smoke tests.
+7. Confirm `ATCROSTER_ENVIRONMENT=production` and secure-cookie/trusted-host
+   controls on both web and worker services.
+
+### 3. Reconcile names without moving data
+
+The lowest-risk target is to rename environments, not copy live databases:
+
+1. Rename the old `production` environment to
+   `legacy-production-20260724`.
+2. Rename `pilot-staging` to `production`.
+3. Verify that service IDs, database volumes, bucket, domains and active
+   deployments did not change.
+4. Verify Railway-provided environment metadata changed as expected while
+   explicit application security variables remained unchanged.
+5. Re-run public and authenticated smoke tests.
+
+The exact Railway commands must be generated from fresh environment IDs at
+the change window. Do not embed IDs in this document.
+
+### 4. Create a real staging environment
+
+Create a new `staging` environment from infrastructure definitions, not from
+live data:
+
+1. provision empty control and operational PostgreSQL services;
+2. provision independent Redis, worker and private object storage;
+3. create staging-only secrets and encryption keys;
+4. migrate clean databases;
+5. seed synthetic acceptance data only;
+6. attach `pilot.atcroster.com` after validation;
+7. leave `www.atcroster.com` attached only to production.
+
+Update `.github/workflows/staging-health.yml` to the new staging service
+domain after it is healthy.
+
+### 5. Retire the legacy stack
+
+Only after the retention period and witnessed restore:
+
+1. confirm the legacy PostgreSQL service is not authoritative;
+2. archive required logs and backup evidence;
+3. remove public access;
+4. stop the legacy web service;
+5. delete it only through the approved retention/change process.
+
+## Rollback
+
+If an environment rename or domain verification fails:
+
+1. restore the previous environment names;
+2. keep `www.atcroster.com` on the previously healthy service;
+3. redeploy the retained image digest only if the running deployment changed;
+4. do not restore a database unless a write or migration changed it;
+5. record the failure and request IDs before retrying.
+
+Environment renaming alone must not run migrations or change application
+variables. Any operation that would do so is a separate release and requires
+fresh backup evidence.
+
+## Completion evidence
+
+Reconciliation is complete only when:
+
+- Railway has one clearly named production environment containing web,
+  worker, Redis, control PostgreSQL, per-airport PostgreSQL and private object
+  storage;
+- `www.atcroster.com` points only to that environment;
+- a separate staging environment uses synthetic data and independent secrets;
+- both health workflows target the intended environments;
+- backups, restore evidence, smoke tests, image digests and rollback ownership
+  are recorded.

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from atcroster import create_app, get_runtime_settings
+
+
+def production_config() -> dict[str, object]:
+    return {
+        "ATCROSTER_ENVIRONMENT": "production",
+        "ATCROSTER_TRUSTED_PROXY_HOPS": 1,
+        "ATCROSTER_FIELD_ENCRYPTION_KEYS": (
+            "v1:QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE="
+        ),
+        "SECRET_KEY": "production-test-secret-with-32-characters",
+        "SQLALCHEMY_DATABASE_URI": "postgresql+psycopg://example.invalid/control",
+        "SESSION_COOKIE_SECURE": True,
+        "TRUSTED_HOSTS": ["example.invalid"],
+        "REDIS_URL": "redis://example.invalid/0",
+    }
+
+
+def test_create_app_returns_isolated_configured_applications():
+    first = create_app(
+        {"TESTING": True, "SECRET_KEY": "first"},
+        validate_external_services=False,
+    )
+    second = create_app(
+        {"TESTING": True, "SECRET_KEY": "second"},
+        validate_external_services=False,
+    )
+
+    assert first is not second
+    assert first.config["SECRET_KEY"] == "first"
+    assert second.config["SECRET_KEY"] == "second"
+    assert get_runtime_settings(first).deployment_environment == "development"
+    assert get_runtime_settings(second).deployment_environment == "development"
+
+
+@pytest.mark.parametrize(
+    ("update", "message"),
+    [
+        ({"TRUSTED_HOSTS": []}, "ATCROSTER_TRUSTED_HOSTS"),
+        ({"ATCROSTER_TRUSTED_PROXY_HOPS": 4}, "between 0 and 3"),
+        ({"SECRET_KEY": "short"}, "FLASK_SECRET_KEY"),
+        ({"SQLALCHEMY_DATABASE_URI": "sqlite:///unsafe.db"}, "PostgreSQL"),
+        ({"SESSION_COOKIE_SECURE": False}, "SECURE_COOKIES"),
+        (
+            {
+                "ATCROSTER_FIELD_ENCRYPTION_KEYS": "",
+                "ATCROSTER_FIELD_ENCRYPTION_KEY": "",
+            },
+            "FIELD_ENCRYPTION_KEYS",
+        ),
+        ({"REDIS_URL": ""}, "REDIS_URL"),
+    ],
+)
+def test_production_configuration_fails_closed(update, message):
+    config = deepcopy(production_config())
+    config.update(update)
+
+    with pytest.raises(RuntimeError, match=message):
+        create_app(config, validate_external_services=False)
+
+
+def test_proxy_hops_must_be_an_integer():
+    config = production_config()
+    config["ATCROSTER_TRUSTED_PROXY_HOPS"] = "not-an-integer"
+
+    with pytest.raises(RuntimeError, match="must be an integer"):
+        create_app(config, validate_external_services=False)
+
+
+def test_production_configuration_uses_host_allowlist_and_host_cookie():
+    app = create_app(production_config(), validate_external_services=False)
+
+    assert app.config["TRUSTED_HOSTS"] == ["example.invalid"]
+    assert app.config["SESSION_COOKIE_NAME"] == "__Host-atcroster"
+    assert app.config["SESSION_COOKIE_SECURE"] is True
+    assert get_runtime_settings(app).trusted_proxy_hops == 1

--- a/tests/test_repository_quality.py
+++ b/tests/test_repository_quality.py
@@ -24,6 +24,22 @@ def test_generated_repository_artifacts_are_ignored_and_removed():
     assert not (ROOT / "app for website").exists()
 
 
+def test_production_container_excludes_local_quality_and_test_artifacts():
+    ignored = (ROOT / ".dockerignore").read_text().splitlines()
+
+    for path in {
+        ".coverage",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        "instance",
+        "tests",
+        "docs",
+        "deliverables",
+    }:
+        assert path in ignored
+
+
 def test_authentication_blueprint_preserves_public_route_contract():
     from app import app
 


### PR DESCRIPTION
## Problem

Flask construction and security-sensitive production configuration were embedded directly in the legacy `app.py` import path. This made production validation difficult to test independently and kept proxy, storage and token validation coupled to the monolith.

The Railway project also has misleading environment names: the publicly routed complete stack is `pilot-staging`, while `production` is an older incomplete stack that cannot safely run current `main`.

## Risk reduced

- Production configuration is now built and validated through one explicit, directly tested boundary.
- Utility code can import the factory/configuration package without constructing the legacy application or connecting to databases, Redis or storage.
- Invalid secret, database, cookie, host, proxy, field-encryption and Redis configuration fails closed in focused tests.
- The Railway reconciliation procedure prevents an unsafe deploy, secret copy or database duplication.
- Local test and quality artifacts are excluded from the production container context.

## What changed

### Commit 1 — application factory foundation

- Added `atcroster.create_app(config_object=None)`.
- Added pure Flask configuration loading and typed `RuntimeSettings`.
- Moved proxy construction and production configuration validation out of `app.py`.
- Preserved the existing global `app`, WSGI, Railway, routes, endpoint names, models and CLI behaviour.
- Added isolated factory and production failure tests.
- Added the factory package to Ruff, MyPy, Bandit and compile checks.
- Added explicit extension, error and CLI extraction boundaries for later bounded work.

### Commit 2 — Railway reconciliation evidence

- Added `docs/railway_topology_reconciliation.md` with current topology, safety constraints, cutover steps and rollback.
- Reduced the Docker build context by excluding test, documentation and local quality artifacts.
- Added a repository-quality regression test for the container exclusions.

## Behaviour preserved

All existing routes and endpoint names remain registered by the legacy module. Database models, tenant session routing, CLI commands and local compatibility schema behaviour are unchanged. There are no migrations.

## Validation

- 175 passed, 2 skipped.
- Coverage: 69.01% (60% threshold met).
- Ruff lint and format: passed.
- MyPy factory/service scope: passed.
- Bandit medium/high scan: passed.
- `pip-audit`: no known vulnerabilities.
- Fresh control, operational and combined databases upgraded to Alembic head.
- Python compilation: passed.
- Production Docker image: built successfully.
- Docker context reduced from about 62.8 MB to 14.5 KB.

## Migration impact

None.

## Rollback

Revert the two commits. WSGI continues to expose `wsgi:application`; no database rollback is required.

## Railway/deployment impact

Do **not** deploy this branch to the legacy Railway environment named `production`: it lacks current Redis, worker, operational database, trusted-host and durable-storage configuration. The complete public stack remains unchanged. The included runbook defines the backup, rename, verification and rollback process required before reconciling environment names or domains.

## Security considerations

No secret values, URLs containing credentials, personnel data or briefing contents were recorded. External production storage and token validation still occurs when the real application is created; direct factory tests can deliberately disable only those external checks while retaining configuration validation.

## Follow-up debt

- Move SQLAlchemy/LoginManager ownership into `atcroster.extensions` after extracting routed session dependencies.
- Register errors and CLI commands through their new package boundaries.
- Move route registration into blueprints so `create_app` constructs the complete application without the legacy global compatibility layer.
- Execute Railway reconciliation only in an approved change window with verified backups.