### PR TITLE
Harden authentication boundaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 ATCROSTER_ENVIRONMENT=production
 ATCROSTER_SECURE_COOKIES=true
+# Migration escape hatch only; leave false once control-plane identities exist.
+ATCROSTER_ENABLE_LEGACY_LOGIN=false
 FLASK_SECRET_KEY=replace-with-at-least-32-random-characters
 ATCROSTER_FIELD_ENCRYPTION_KEYS=v1:replace-with-a-fernet-key
 ATCROSTER_TOKEN_ENCRYPTION_KEYS=v1:replace-with-a-different-fernet-key

--- a/app.py
+++ b/app.py
@@ -12054,9 +12054,30 @@ app.jinja_env.globals['ShiftType'] = ShiftType
 
 # -------------------- Run --------------------
 
-from auth_blueprint import create_auth_blueprint
+from auth_blueprint import AuthDependencies, create_auth_blueprint
 
-app.register_blueprint(create_auth_blueprint(__import__(__name__)))
+app.register_blueprint(create_auth_blueprint(AuthDependencies(
+    db=db,
+    PlatformIdentity=PlatformIdentity,
+    UnitMembership=UnitMembership,
+    DatabaseRoutingMetadata=DatabaseRoutingMetadata,
+    Staff=Staff,
+    Unit=Unit,
+    PlatformMfaCredential=PlatformMfaCredential,
+    MfaCredential=MfaCredential,
+    validate_csrf=_validate_csrf,
+    normalized_login=_normalized_login,
+    login_rate_key=_login_rate_key,
+    consume_rate_limit=_consume_rate_limit,
+    reset_rate_limit=_reset_rate_limit,
+    security_event=_security_event,
+    central_security_event=_central_security_event,
+    bind_authenticated_unit=bind_authenticated_unit,
+    canonical_login_redirect=_canonical_login_redirect,
+    airport_login_endpoint=_airport_login_endpoint,
+    initialize_authenticated_session=_initialize_authenticated_session,
+    record_successful_login=_record_successful_login,
+)))
 app.register_blueprint(briefing_blueprint)
 
 # -------------------- WSGI entry point --------------------

--- a/atcroster/config.py
+++ b/atcroster/config.py
@@ -55,6 +55,9 @@ def load_flask_config(
         }
     return {
         "ATCROSTER_ENVIRONMENT": deployment_environment,
+        "ATCROSTER_ENABLE_LEGACY_LOGIN": (
+            environ.get("ATCROSTER_ENABLE_LEGACY_LOGIN", "").lower() in TRUE_VALUES
+        ),
         "SECRET_KEY": environ.get("FLASK_SECRET_KEY", "fallback-change-me"),
         "SQLALCHEMY_DATABASE_URI": database_url,
         "SQLALCHEMY_ENGINE_OPTIONS": engine_options,
@@ -78,11 +81,14 @@ def load_flask_config(
             minutes=int(environ.get("ATCROSTER_SESSION_ABSOLUTE_MINUTES", "720"))
         ),
         "PREFERRED_URL_SCHEME": "https",
-        "TRUSTED_HOSTS": [
-            host.strip()
-            for host in environ.get("ATCROSTER_TRUSTED_HOSTS", "").split(",")
-            if host.strip()
-        ],
+        "TRUSTED_HOSTS": (
+            [
+                host.strip()
+                for host in environ.get("ATCROSTER_TRUSTED_HOSTS", "").split(",")
+                if host.strip()
+            ]
+            or None
+        ),
     }
 
 

--- a/auth_blueprint.py
+++ b/auth_blueprint.py
@@ -7,15 +7,68 @@ compatible while authentication can evolve outside ``app.py``.
 
 from __future__ import annotations
 
-from types import ModuleType
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
 
-from flask import Blueprint, abort, flash, g, redirect, render_template, request
-from flask import session, url_for
+from flask import (
+    Blueprint,
+    abort,
+    current_app,
+    flash,
+    g,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
 from flask_login import login_required, login_user, logout_user
 from werkzeug.security import check_password_hash
 
 
-def create_auth_blueprint(core: ModuleType) -> Blueprint:
+@dataclass(frozen=True)
+class AuthDependencies:
+    """The deliberately small application surface required by login routes."""
+
+    db: Any
+    PlatformIdentity: Any
+    UnitMembership: Any
+    DatabaseRoutingMetadata: Any
+    Staff: Any
+    Unit: Any
+    PlatformMfaCredential: Any
+    MfaCredential: Any
+    validate_csrf: Callable[[], None]
+    normalized_login: Callable[[str], str]
+    login_rate_key: Callable[[str], str]
+    consume_rate_limit: Callable[[str, str], bool]
+    reset_rate_limit: Callable[[str, str], None]
+    security_event: Callable[..., None]
+    central_security_event: Callable[..., None]
+    bind_authenticated_unit: Callable[[int, str | None], Any]
+    canonical_login_redirect: Callable[..., str]
+    airport_login_endpoint: Callable[[Any], str]
+    initialize_authenticated_session: Callable[[Any], None]
+    record_successful_login: Callable[[Any], None]
+
+
+@dataclass(frozen=True)
+class OperationalPrincipal:
+    user: Any
+    identity: Any | None
+
+
+@dataclass(frozen=True)
+class PlatformPrincipal:
+    user: Any
+    identity: Any
+
+
+LoginPrincipal = OperationalPrincipal | PlatformPrincipal
+
+
+def create_auth_blueprint(dependencies: AuthDependencies) -> Blueprint:
     blueprint = Blueprint("authentication", __name__)
 
     @login_required
@@ -28,31 +81,40 @@ def create_auth_blueprint(core: ModuleType) -> Blueprint:
 
     def signin_form():
         if request.method == "POST":
-            core._validate_csrf()
-            username = core._normalized_login(request.form.get("username") or "")
-            password = (request.form.get("password") or "").strip()
-            rate_key = core._login_rate_key(username)
-            if not core._consume_rate_limit("password-login", username):
-                core._security_event("login_rate_limited", principal=rate_key[-16:])
+            dependencies.validate_csrf()
+            username = dependencies.normalized_login(request.form.get("username") or "")
+            # Passwords are opaque secrets. Trimming changes valid credentials
+            # and can unexpectedly authenticate a different submitted value.
+            password = request.form.get("password") or ""
+            rate_key = dependencies.login_rate_key(username)
+            if not dependencies.consume_rate_limit("password-login", username):
+                dependencies.security_event(
+                    "login_rate_limited", principal=rate_key[-16:]
+                )
                 abort(429, "Too many login attempts. Try again later.")
-            identity = core.PlatformIdentity.query.filter_by(username=username).first()
-            user = None
-            platform_login = False
+            identity = dependencies.PlatformIdentity.query.filter_by(
+                username=username
+            ).first()
+            principal: LoginPrincipal | None = None
             credentials_valid = False
             if identity:
                 credentials_valid = check_password_hash(
                     identity.password_hash, password
                 )
                 if credentials_valid:
-                    membership = core.UnitMembership.query.filter_by(
+                    membership = dependencies.UnitMembership.query.filter_by(
                         identity_id=identity.id, status="active"
                     ).first()
                     if membership and membership.person_id:
-                        routing = core.db.session.get(
-                            core.DatabaseRoutingMetadata, membership.unit_id
+                        routing = dependencies.db.session.get(
+                            dependencies.DatabaseRoutingMetadata,
+                            membership.unit_id,
                         )
-                        if core.DEPLOYMENT_ENV == "production" and not routing:
-                            core._security_event(
+                        if (
+                            current_app.config["ATCROSTER_ENVIRONMENT"] == "production"
+                            and not routing
+                        ):
+                            dependencies.security_event(
                                 "operational_route_missing",
                                 unit_id=membership.unit_id,
                             )
@@ -60,38 +122,47 @@ def create_auth_blueprint(core: ModuleType) -> Blueprint:
                                 503,
                                 "Operational database routing is unavailable.",
                             )
-                        g.tenant_context_token = core.bind_authenticated_unit(
+                        g.tenant_context_token = dependencies.bind_authenticated_unit(
                             membership.unit_id,
                             routing.secret_name if routing else None,
                         )
-                        user = core.db.session.get(core.Staff, membership.person_id)
+                        user = dependencies.db.session.get(
+                            dependencies.Staff, membership.person_id
+                        )
+                        if user:
+                            principal = OperationalPrincipal(user, identity)
                     else:
-                        user = identity
-                        platform_login = identity.public_id.startswith("platform-")
-            elif core.DEPLOYMENT_ENV != "production":
-                user = core.Staff.query.filter_by(username=username).first()
+                        if identity.public_id.startswith("platform-"):
+                            principal = PlatformPrincipal(identity, identity)
+            elif current_app.config.get("ATCROSTER_ENABLE_LEGACY_LOGIN", False):
+                user = dependencies.Staff.query.filter_by(username=username).first()
                 credentials_valid = bool(user and user.check_password(password))
+                if user:
+                    principal = OperationalPrincipal(user, None)
             else:
-                # Production authentication always begins in control. Unknown
+                # Authentication normally always begins in control. Unknown
                 # principals never trigger an operational database query.
                 credentials_valid = False
             if (
                 identity
                 and credentials_valid
-                and not user
+                and not principal
                 and not identity.public_id.startswith("platform-")
             ):
                 credentials_valid = False
-            if user and credentials_valid:
-                core._reset_rate_limit("password-login", username)
+            if principal and credentials_valid:
+                user = principal.user
+                dependencies.reset_rate_limit("password-login", username)
                 if user.membership_status != "active":
                     flash("This account is not active.", "error")
                     return render_template("login.html"), 403
-                login_unit = core.db.session.get(core.Unit, user.unit_id)
+                login_unit = dependencies.db.session.get(
+                    dependencies.Unit, user.unit_id
+                )
                 if user.role != "superadmin" and (
                     not login_unit or login_unit.status != "active"
                 ):
-                    core._security_event(
+                    dependencies.security_event(
                         "suspended_unit_login_blocked",
                         principal=rate_key[-16:],
                         unit_id=user.unit_id,
@@ -99,8 +170,8 @@ def create_auth_blueprint(core: ModuleType) -> Blueprint:
                     flash("This airport account is not active.", "error")
                     return render_template("login.html"), 403
                 session.clear()
-                if platform_login:
-                    credential = core.PlatformMfaCredential.query.filter_by(
+                if isinstance(principal, PlatformPrincipal):
+                    credential = dependencies.PlatformMfaCredential.query.filter_by(
                         identity_id=identity.id,
                         enabled=True,
                         reset_required=False,
@@ -108,18 +179,20 @@ def create_auth_blueprint(core: ModuleType) -> Blueprint:
                     session["_platform_mfa_identity_id"] = identity.id
                     session["_platform_mfa_user_id"] = user.id
                     session["_platform_mfa_rate_key"] = rate_key
-                    session["_platform_mfa_next"] = core._canonical_login_redirect(
-                        request.args.get("next"),
-                        default_endpoint="platform_admin",
-                        user_id=user.id,
+                    session["_platform_mfa_next"] = (
+                        dependencies.canonical_login_redirect(
+                            request.args.get("next"),
+                            default_endpoint="platform_admin",
+                            user_id=user.id,
+                        )
                     )
-                    core._central_security_event(
+                    dependencies.central_security_event(
                         "platform_password_verified",
                         "challenge",
                         identity.id,
                         rate_key[-16:],
                     )
-                    core.db.session.commit()
+                    dependencies.db.session.commit()
                     return redirect(
                         url_for(
                             "platform_mfa_challenge"
@@ -127,44 +200,44 @@ def create_auth_blueprint(core: ModuleType) -> Blueprint:
                             else "platform_mfa_setup"
                         )
                     )
-                credential = core.MfaCredential.query.filter_by(
+                credential = dependencies.MfaCredential.query.filter_by(
                     person_id=user.id, enabled=True
                 ).first()
                 if credential:
                     session["_mfa_user_id"] = user.id
                     session["_mfa_unit_id"] = user.unit_id
                     session["_mfa_rate_key"] = rate_key
-                    session["_mfa_next"] = core._canonical_login_redirect(
+                    session["_mfa_next"] = dependencies.canonical_login_redirect(
                         request.args.get("next"),
-                        default_endpoint=core._airport_login_endpoint(user),
+                        default_endpoint=dependencies.airport_login_endpoint(user),
                         user_id=user.id,
                     )
                     return redirect(url_for("mfa_challenge"))
                 login_user(user)
-                core._initialize_authenticated_session(user)
-                core._security_event(
+                dependencies.initialize_authenticated_session(user)
+                dependencies.security_event(
                     "login_succeeded",
                     principal=rate_key[-16:],
                     unit_id=user.unit_id,
                 )
-                core._record_successful_login(user)
+                dependencies.record_successful_login(user)
                 flash("Logged in successfully", "ok")
                 return redirect(
-                    core._canonical_login_redirect(
+                    dependencies.canonical_login_redirect(
                         request.args.get("next"),
-                        default_endpoint=core._airport_login_endpoint(user),
+                        default_endpoint=dependencies.airport_login_endpoint(user),
                         user_id=user.id,
                     )
                 )
             if identity:
-                core._central_security_event(
+                dependencies.central_security_event(
                     "platform_login_failed",
                     "denied",
                     identity.id,
                     rate_key[-16:],
                 )
-                core.db.session.commit()
-            core._security_event("login_failed", principal=rate_key[-16:])
+                dependencies.db.session.commit()
+            dependencies.security_event("login_failed", principal=rate_key[-16:])
             flash("Invalid username or password.", "error")
         return render_template("login.html")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,3 +33,9 @@ else:
                 pass
 
     atexit.register(_remove_test_database)
+
+
+# Most route tests intentionally exercise pre-control-plane fixture accounts.
+# Production and normal development remain fail-closed unless this migration
+# escape hatch is explicitly enabled.
+os.environ.setdefault("ATCROSTER_ENABLE_LEGACY_LOGIN", "true")

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 import pytest
 
 from atcroster import create_app, get_runtime_settings
+from atcroster.config import load_flask_config
 
 
 def production_config() -> dict[str, object]:
@@ -37,6 +38,17 @@ def test_create_app_returns_isolated_configured_applications():
     assert second.config["SECRET_KEY"] == "second"
     assert get_runtime_settings(first).deployment_environment == "development"
     assert get_runtime_settings(second).deployment_environment == "development"
+
+
+def test_legacy_login_is_disabled_unless_explicitly_enabled():
+    default = load_flask_config({}, "/tmp/atcroster-test")
+    enabled = load_flask_config(
+        {"ATCROSTER_ENABLE_LEGACY_LOGIN": "true"},
+        "/tmp/atcroster-test",
+    )
+
+    assert default["ATCROSTER_ENABLE_LEGACY_LOGIN"] is False
+    assert enabled["ATCROSTER_ENABLE_LEGACY_LOGIN"] is True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -380,6 +380,83 @@ def test_login_rejects_missing_and_invalid_csrf_tokens(client):
     assert invalid.status_code == 400
 
 
+@pytest.mark.parametrize(
+    ("username", "password"),
+    [
+        ("unknown-central-identity", "irrelevant"),
+        (ADMIN_CREDENTIALS["username"], "wrong-password"),
+    ],
+)
+def test_login_returns_same_generic_error_for_unknown_and_wrong_credentials(
+    client, username, password,
+):
+    client.get("/login")
+    with client.session_transaction() as session:
+        token = session["_csrf_token"]
+    response = client.post(
+        "/login",
+        data={
+            "_csrf_token": token,
+            "username": username,
+            "password": password,
+        },
+    )
+
+    assert response.status_code == 200
+    assert b"Invalid username or password." in response.data
+
+
+def test_legacy_login_requires_explicit_migration_switch(client):
+    original = app.app.config["ATCROSTER_ENABLE_LEGACY_LOGIN"]
+    app.app.config["ATCROSTER_ENABLE_LEGACY_LOGIN"] = False
+    try:
+        client.get("/login")
+        with client.session_transaction() as session:
+            token = session["_csrf_token"]
+        response = client.post(
+            "/login",
+            data={"_csrf_token": token, **ADMIN_CREDENTIALS},
+        )
+    finally:
+        app.app.config["ATCROSTER_ENABLE_LEGACY_LOGIN"] = original
+
+    assert response.status_code == 200
+    assert b"Invalid username or password." in response.data
+
+
+def test_login_preserves_password_whitespace_and_rotates_session(client):
+    with app.app.app_context():
+        admin = Staff.query.filter_by(
+            username=ADMIN_CREDENTIALS["username"]
+        ).one()
+        admin.set_password(" password with spaces ")
+        db.session.commit()
+    try:
+        client.get("/login")
+        with client.session_transaction() as session:
+            session["attacker_supplied_marker"] = "must-not-survive"
+            token = session["_csrf_token"]
+        response = client.post(
+            "/login",
+            data={
+                "_csrf_token": token,
+                "username": ADMIN_CREDENTIALS["username"],
+                "password": " password with spaces ",
+            },
+        )
+        assert response.status_code == 302
+        with client.session_transaction() as session:
+            assert "attacker_supplied_marker" not in session
+            assert "_user_id" in session
+    finally:
+        with app.app.app_context():
+            admin = Staff.query.filter_by(
+                username=ADMIN_CREDENTIALS["username"]
+            ).one()
+            admin.set_password(ADMIN_CREDENTIALS["password"])
+            db.session.commit()
+
+
 def test_login_and_logout_require_valid_csrf_tokens(client):
     signed_in = login_as(
         client,


### PR DESCRIPTION
## What changed

- stop trimming submitted passwords, preserving the exact credential bytes users chose
- replace the authentication blueprint's broad application-module dependency with an explicit typed dependency object
- model platform and operational login principals separately
- make operational legacy-login fallback an explicit `ATCROSTER_ENABLE_LEGACY_LOGIN` migration switch that defaults to disabled
- treat an empty trusted-host environment value as unset outside production while keeping production validation fail-closed
- add focused tests for unknown and incorrect credentials, legacy fallback gating, password whitespace, CSRF, redirect safety, MFA paths, and session fixation protection

## Why

The previous development fallback queried the operational staff table whenever a central identity was unknown. It was disabled in production, but the environment-based exception was broad and made the authentication boundary harder to reason about. Password trimming also changed the submitted secret before verification, and the blueprint depended on the entire legacy application module.

This change makes central identity lookup the default boundary in every environment and keeps the legacy path available only as a deliberate migration escape hatch.

## Impact

Normal control-plane and MFA logins retain their existing routes and endpoint names. Pre-control-plane deployments must explicitly set `ATCROSTER_ENABLE_LEGACY_LOGIN=true` until those accounts are migrated, then remove or disable the setting.

## Validation

- 181 passed, 2 skipped
- 69.19% total coverage (authentication blueprint 91%)
- Ruff formatting and lint passed
- mypy passed
- Bandit passed
- pip-audit found no known vulnerabilities
- Python compilation passed
- fresh control, operational, and combined Alembic migrations passed