### PR TITLE
Fix encrypted backup dump streaming

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -75,7 +75,7 @@ jobs:
             docker run --rm \
               -e DATABASE_URL="$database_url" postgres:18-alpine \
               sh -eu -c \
-              'pg_dump "$DATABASE_URL" --format=custom --no-owner --file=-' |
+              'pg_dump "$DATABASE_URL" --format=custom --no-owner' |
               gpg --batch --yes --trust-model always \
                 --recipient "$RECOVERY_KEY_FINGERPRINT" \
                 --output "$backup_dir/$label.dump.gpg" --encrypt


### PR DESCRIPTION
## What changed

Removes `--file=-` from the PostgreSQL dump command so `pg_dump` writes the custom-format archive to standard output and into GPG encryption.

## Why

The first restore rehearsal proved that PostgreSQL treated `-` as a filename inside the disposable container, producing an encrypted empty stream. The rehearsal correctly prevented that artifact from being accepted as recoverable.

## Validation

- Workflow YAML parsed successfully.
- `git diff --check` passed.
- A new production backup and isolated restore rehearsal will run after merge.