### PR TITLE
Add production and backup incident alerts

### DIFF
--- a/.github/workflows/backup-freshness.yml
+++ b/.github/workflows/backup-freshness.yml
@@ -1,0 +1,81 @@
+name: Backup freshness
+
+on:
+  schedule:
+    - cron: "15 */3 * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+concurrency:
+  group: backup-freshness
+  cancel-in-progress: true
+
+jobs:
+  freshness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 4
+    env:
+      GH_TOKEN: ${{ github.token }}
+      INCIDENT_TITLE: "[monitor] Production backup is stale"
+    steps:
+      - name: Check latest successful backup and update incident
+        run: |
+          set -euo pipefail
+          latest_created_at="$(gh run list \
+            --repo "$GITHUB_REPOSITORY" \
+            --workflow database-backup.yml \
+            --status success \
+            --limit 1 \
+            --json createdAt \
+            --jq '.[0].createdAt // empty')"
+
+          stale=true
+          age_hours="unknown"
+          if [[ -n "$latest_created_at" ]]; then
+            latest_epoch="$(date -u -d "$latest_created_at" +%s)"
+            now_epoch="$(date -u +%s)"
+            age_seconds=$((now_epoch - latest_epoch))
+            age_hours=$((age_seconds / 3600))
+            if (( age_seconds <= 93600 )); then
+              stale=false
+            fi
+          fi
+
+          issue_number="$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --search "$INCIDENT_TITLE in:title" \
+            --json number,title \
+            --jq ".[] | select(.title == \"$INCIDENT_TITLE\") | .number" |
+            head -1)"
+
+          if [[ "$stale" == true ]]; then
+            if [[ -z "$issue_number" ]]; then
+              gh issue create \
+                --repo "$GITHUB_REPOSITORY" \
+                --title "$INCIDENT_TITLE" \
+                --label monitoring,bug \
+                --body "No successful encrypted production backup was found within the 26-hour recovery-point threshold. Last known age: $age_hours hours.
+
+          Check: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            else
+              gh issue comment "$issue_number" \
+                --repo "$GITHUB_REPOSITORY" \
+                --body "Backup remains stale. Last known age: $age_hours hours."
+            fi
+            exit 1
+          fi
+
+          echo "Latest successful backup age: $age_hours hours."
+          if [[ -n "$issue_number" ]]; then
+            gh issue comment "$issue_number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body "A successful backup is again within the 26-hour threshold."
+            gh issue close "$issue_number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --reason completed
+          fi

--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: encrypted-database-backup
@@ -115,3 +116,49 @@ jobs:
           if-no-files-found: error
           retention-days: 30
           compression-level: 0
+
+  alert:
+    name: Update backup incident
+    if: ${{ always() }}
+    needs: backup
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    env:
+      GH_TOKEN: ${{ github.token }}
+      INCIDENT_TITLE: "[monitor] Encrypted production backup failing"
+      CHECK_RESULT: ${{ needs.backup.result }}
+    steps:
+      - name: Open or resolve incident
+        run: |
+          set -euo pipefail
+          issue_number="$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --search "$INCIDENT_TITLE in:title" \
+            --json number,title \
+            --jq ".[] | select(.title == \"$INCIDENT_TITLE\") | .number" |
+            head -1)"
+          if [[ "$CHECK_RESULT" != "success" ]]; then
+            if [[ -z "$issue_number" ]]; then
+              gh issue create \
+                --repo "$GITHUB_REPOSITORY" \
+                --title "$INCIDENT_TITLE" \
+                --label monitoring,bug \
+                --body "The encrypted production backup failed.
+
+          Run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+
+          Treat recovery coverage as degraded until a new artifact succeeds and is restore-tested."
+            else
+              gh issue comment "$issue_number" \
+                --repo "$GITHUB_REPOSITORY" \
+                --body "The backup is still failing: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            fi
+          elif [[ -n "$issue_number" ]]; then
+            gh issue comment "$issue_number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body "Automated recovery confirmed by: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            gh issue close "$issue_number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --reason completed
+          fi

--- a/.github/workflows/production-health.yml
+++ b/.github/workflows/production-health.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: production-health
@@ -35,3 +36,59 @@ jobs:
             --retry 2 --retry-all-errors --retry-delay 3 \
             --max-time 15 "$PRODUCTION_ORIGIN/login")"
           grep -Fq "<title>Login" <<<"$login"
+
+          certificate_expiry="$(echo | openssl s_client \
+            -servername www.atcroster.com \
+            -connect www.atcroster.com:443 2>/dev/null |
+            openssl x509 -noout -enddate | cut -d= -f2)"
+          openssl x509 -checkend 1209600 -noout \
+            -in <(echo | openssl s_client \
+              -servername www.atcroster.com \
+              -connect www.atcroster.com:443 2>/dev/null)
+          echo "TLS certificate is valid beyond 14 days: $certificate_expiry"
+
+  alert:
+    name: Update production incident
+    if: ${{ always() }}
+    needs: health
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    env:
+      GH_TOKEN: ${{ github.token }}
+      INCIDENT_TITLE: "[monitor] Production health check failing"
+      CHECK_RESULT: ${{ needs.health.result }}
+    steps:
+      - name: Open or resolve incident
+        run: |
+          set -euo pipefail
+          issue_number="$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --search "$INCIDENT_TITLE in:title" \
+            --json number,title \
+            --jq ".[] | select(.title == \"$INCIDENT_TITLE\") | .number" |
+            head -1)"
+          if [[ "$CHECK_RESULT" != "success" ]]; then
+            if [[ -z "$issue_number" ]]; then
+              gh issue create \
+                --repo "$GITHUB_REPOSITORY" \
+                --title "$INCIDENT_TITLE" \
+                --label monitoring,bug \
+                --body "The scheduled production health probe failed.
+
+          Run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+
+          Check liveness, readiness, login availability, DNS and TLS before closing this incident."
+            else
+              gh issue comment "$issue_number" \
+                --repo "$GITHUB_REPOSITORY" \
+                --body "The health probe is still failing: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            fi
+          elif [[ -n "$issue_number" ]]; then
+            gh issue comment "$issue_number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body "Automated recovery confirmed by: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            gh issue close "$issue_number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --reason completed
+          fi

--- a/docs/operations/monitoring_and_alerting.md
+++ b/docs/operations/monitoring_and_alerting.md
@@ -7,6 +7,12 @@ Monitor from outside Railway and from a different provider/region:
 The repository's `production-health.yml` provides a baseline independent
 scheduled probe through GitHub Actions. It is not a substitute for a dedicated
 monitor with paging and a public status page; scheduled Actions can be delayed.
+Failed production probes and backup jobs create or update a single labelled
+GitHub incident, and a later successful check records recovery and closes it.
+`backup-freshness.yml` checks every three hours and opens an incident when no
+successful encrypted backup exists within the 26-hour threshold. Repository
+owners must enable GitHub email/mobile notifications for monitoring issues;
+GitHub issues are not a substitute for 24/7 paging.
 
 | Signal | Check | Interval | Alert |
 |---|---|---:|---|


### PR DESCRIPTION
## What changed

- Extends the production probe with TLS-expiry validation.
- Opens or updates one labelled GitHub incident when production health fails and closes it after confirmed recovery.
- Adds equivalent incident handling to encrypted backup failures.
- Adds a three-hourly backup-freshness monitor with a 26-hour threshold.
- Documents the alerting behaviour and the remaining need for a dedicated paging provider.

## Why

Scheduled health and backup workflows existed, but failures could be missed and there was no recovery-point age alarm. This converts failures into durable, deduplicated incidents that notify subscribed repository owners.

## Validation

- All workflow YAML files parsed successfully.
- Live production TLS certificate passed the 14-day expiry threshold.
- `git diff --check` passed.
- Both monitoring workflows will be manually triggered after merge.