### PR TITLE
Monitor apex TLS redirect

### DIFF
--- a/.github/workflows/production-health.yml
+++ b/.github/workflows/production-health.yml
@@ -37,6 +37,17 @@ jobs:
             --max-time 15 "$PRODUCTION_ORIGIN/login")"
           grep -Fq "<title>Login" <<<"$login"
 
+          apex_headers="$(curl --fail --show-error --silent --head \
+            --retry 3 --retry-all-errors --retry-delay 5 \
+            --max-time 15 https://atcroster.com)"
+          grep -Eiq '^location: https://www\.atcroster\.com/?\r?$' \
+            <<<"$apex_headers"
+
+          openssl x509 -checkend 1209600 -noout \
+            -in <(echo | openssl s_client \
+              -servername atcroster.com \
+              -connect atcroster.com:443 2>/dev/null)
+
           certificate_expiry="$(echo | openssl s_client \
             -servername www.atcroster.com \
             -connect www.atcroster.com:443 2>/dev/null |


### PR DESCRIPTION
## What changed
- probe `https://atcroster.com` from the scheduled production health workflow
- require the apex response to redirect to `https://www.atcroster.com`
- require the apex TLS certificate to remain valid for at least 14 days

## Why
The bare domain previously failed its TLS handshake while the `www` production service remained healthy, so the existing monitor could not detect the outage.

## Impact
A future apex certificate or redirect regression will fail the production health job and use the existing incident workflow to alert maintainers.

## Validation
- confirmed the live apex returns a secure redirect to `https://www.atcroster.com`
- confirmed the apex certificate is valid beyond 14 days
- `git diff --check`