### PR TITLE
Fix apex redirect probe

### DIFF
--- a/.github/workflows/production-health.yml
+++ b/.github/workflows/production-health.yml
@@ -37,11 +37,11 @@ jobs:
             --max-time 15 "$PRODUCTION_ORIGIN/login")"
           grep -Fq "<title>Login" <<<"$login"
 
-          apex_headers="$(curl --fail --show-error --silent --head \
+          apex_destination="$(curl --fail --show-error --silent --location \
             --retry 3 --retry-all-errors --retry-delay 5 \
-            --max-time 15 https://atcroster.com)"
-          grep -Eiq '^location: https://www\.atcroster\.com/?\r?$' \
-            <<<"$apex_headers"
+            --max-time 15 --output /dev/null --write-out '%{url_effective}' \
+            https://atcroster.com)"
+          [[ "$apex_destination" == "https://www.atcroster.com/" ]]
 
           openssl x509 -checkend 1209600 -noout \
             -in <(echo | openssl s_client \


### PR DESCRIPTION
## What changed
Follow the apex redirect and assert the final effective URL rather than matching the raw `Location` header.

## Why
IONOS can vary the redirect header representation by resolver/edge. The first production run failed the strict header assertion even though the secure redirect worked.

## Impact
The monitor now verifies the user-visible outcome—successful TLS and arrival at the canonical `www` URL—without depending on header formatting.

## Validation
- live redirect resolves to `https://www.atcroster.com/`
- `git diff --check`