### PR TITLE
Allow canonical apex URL forms

### DIFF
--- a/.github/workflows/production-health.yml
+++ b/.github/workflows/production-health.yml
@@ -41,7 +41,9 @@ jobs:
             --retry 3 --retry-all-errors --retry-delay 5 \
             --max-time 15 --output /dev/null --write-out '%{url_effective}' \
             https://atcroster.com)"
-          [[ "$apex_destination" == "https://www.atcroster.com/" ]]
+          echo "Apex redirect reached: $apex_destination"
+          [[ "$apex_destination" == "https://www.atcroster.com" ||
+             "$apex_destination" == "https://www.atcroster.com/" ]]
 
           openssl x509 -checkend 1209600 -noout \
             -in <(echo | openssl s_client \


### PR DESCRIPTION
## What changed
Accept the canonical `www` URL both with and without a trailing slash, and log the effective destination for diagnostics.

## Why
IONOS edge responses normalize the root URL differently across locations. Both forms represent the same secure canonical destination.

## Impact
The monitor remains strict about scheme and host while avoiding a false alert caused solely by root-slash normalization.

## Validation
- local effective URL is the accepted canonical `https://www.atcroster.com/`
- `git diff --check`