### PR TITLE
Validate canonical apex host

### DIFF
--- a/.github/workflows/production-health.yml
+++ b/.github/workflows/production-health.yml
@@ -43,7 +43,7 @@ jobs:
             https://atcroster.com)"
           echo "Apex redirect reached: $apex_destination"
           [[ "$apex_destination" == "https://www.atcroster.com" ||
-             "$apex_destination" == "https://www.atcroster.com/" ]]
+             "$apex_destination" == "https://www.atcroster.com/"* ]]
 
           openssl x509 -checkend 1209600 -noout \
             -in <(echo | openssl s_client \


### PR DESCRIPTION
## What changed
Allow paths beneath the exact canonical `https://www.atcroster.com/` origin when validating the followed apex redirect.

## Why
After the apex redirect, the application legitimately routes unauthenticated requests from `/` to `/login?next=%2F`. GitHub runners therefore see the final login URL.

## Impact
The monitor still requires HTTPS and the exact canonical host, while accepting normal application routing after the domain redirect.

## Validation
- production run diagnosed the effective destination as `https://www.atcroster.com/login?next=%2F`
- `git diff --check`