### PR TITLE
Align CI with Python 3.14

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.12"
+          python-version: "3.14"
           cache: pip
       - run: pip install -r requirements-dev.txt
       - name: Formatting, lint and static analysis
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.12"
+          python-version: "3.14"
           cache: pip
       - run: pip install -r requirements-dev.txt
       - name: Create isolated integration databases

--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ fallback secret in production.
 
 ### Supported Python versions
 
-Python 3.12 is the production and CI runtime. A newer Python major version
+Python 3.14 is the production and CI runtime. A newer Python major version
 must not be adopted through an automated dependency update: it requires a
 dedicated compatibility pull request that builds the production image and
 passes the complete web, PostgreSQL, Redis, worker and desktop test matrix.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-target-version = "py312"
+target-version = "py314"
 
 [tool.ruff.lint]
 # Keep the established lint baseline explicit across Ruff upgrades.


### PR DESCRIPTION
## What changed
- run the main quality and PostgreSQL integration jobs on Python 3.14
- set Ruff's language target to Python 3.14
- update the README runtime statement from Python 3.12 to 3.14

## Why
The production Docker image and Railway deployment already use Python 3.14, while the active GitHub test jobs and contributor documentation still claimed Python 3.12. That allowed production to run a newer interpreter than the principal CI environment.

## Impact
GitHub now validates the same Python major version deployed to Railway, and lint parsing/documentation match the supported runtime.

## Validation
- Python 3.14 interpreter assertion passed locally
- Ruff 0.16 formatting and lint checks passed with target `py314`
- active CI/runtime references contain no remaining Python 3.12 setting
- `git diff --check` passed