### PR TITLE
Require valid credentials for roster counts

### DIFF
--- a/app.py
+++ b/app.py
@@ -1792,6 +1792,20 @@ def get_non_working_codes() -> set[str]:
     return _load_codes_setting("non_working_codes", DEFAULT_NON_WORKING_CODES)
 
 
+def staff_is_countable_on(person: Staff, on_date: date) -> bool:
+    """Return whether a person holds the credentials needed for staffing counts."""
+    if not person.medical_expiry or person.medical_expiry < on_date:
+        return False
+    return any(
+        expiry is not None and expiry >= on_date
+        for expiry in (
+            person.tower_ue_expiry,
+            person.radar_ue_expiry,
+            person.met_ue_expiry,
+        )
+    )
+
+
 def get_shift_counter_map(unit_id: int | None = None) -> dict[str, str]:
     resolved_unit_id = int(unit_id or _current_unit_id() or 1)
     raw = _roster_settings_snapshot(resolved_unit_id).get(
@@ -4575,6 +4589,7 @@ def _publication_preflight(year: int, month: int) -> dict:
             if (
                 shift and shift.is_working and not shift.is_training
                 and assignment.code not in get_exclude_from_counters()
+                and staff_is_countable_on(person, day)
             ):
                 group = shift_counter_group_for_day(
                     assignment.code, day, _current_unit_id()
@@ -5078,6 +5093,8 @@ def roster_month(ym):
             continue
         row = a_map.get(s.id, {})
         for d in days:
+            if not staff_is_countable_on(s, d):
+                continue
             c = (row.get(d) or "").upper()
             if not c:
                 continue
@@ -5421,6 +5438,8 @@ def roster_export_csv(ym):
         if not s.is_operational:
             continue
         for d in days:
+            if not staff_is_countable_on(s, d):
+                continue
             c = a_map[s.id].get(d)
             if not c or c in get_exclude_from_counters():
                 continue

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1805,6 +1805,38 @@ def test_counter_requires_created_shift_and_respects_closed_nights(client):
         assert app.shift_counter_group("UNCREATED", 1) == ""
 
 
+def test_roster_counter_requires_current_medical_and_unit_endorsement():
+    roster_day = date(2026, 7, 31)
+    person = Staff(
+        medical_expiry=roster_day,
+        tower_ue_expiry=roster_day,
+    )
+    assert app.staff_is_countable_on(person, roster_day)
+
+    person.medical_expiry = roster_day - timedelta(days=1)
+    assert not app.staff_is_countable_on(person, roster_day)
+
+    person.medical_expiry = roster_day
+    person.tower_ue_expiry = roster_day - timedelta(days=1)
+    person.radar_ue_expiry = None
+    person.met_ue_expiry = None
+    assert not app.staff_is_countable_on(person, roster_day)
+
+    person.met_ue_expiry = roster_day
+    assert app.staff_is_countable_on(person, roster_day)
+
+
+def test_under_training_flags_do_not_replace_an_in_date_endorsement():
+    roster_day = date(2026, 7, 31)
+    person = Staff(
+        medical_expiry=roster_day,
+        tower_ut=True,
+        radar_ut=True,
+        met_ut=True,
+    )
+    assert not app.staff_is_countable_on(person, roster_day)
+
+
 def test_roster_never_shows_fatigue_warning_on_off_shift(
     client, monkeypatch
 ):


### PR DESCRIPTION
## What changed

- adds a date-specific eligibility rule for operational staffing counts
- requires an in-date medical and at least one in-date Tower, Radar, or MET unit endorsement
- treats an expiry on the roster day as valid
- does not treat under-training flags as valid unit endorsements
- applies the same rule to the HTML roster counts, CSV count footer, and publication coverage preflight
- adds boundary tests for medical and UE expiry dates

## Why

The roster previously counted any operational person assigned to a qualifying shift, even when their medical or all unit endorsements had expired. This could overstate available operational coverage.

## User impact

Daily M/D/A/N totals and coverage status now reflect only staff who are credentialled on that specific date.

## Validation

- Python 3.14: 181 passed, 2 skipped
- Ruff passed for the changed application code
- git diff whitespace validation passed