### PR TITLE
Use full screen width for the roster

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -2312,7 +2312,7 @@ table.roster { transform-origin: top left; transform: scale(var(--ui-scale)); }
 .roster-status-banner--published { background:rgba(60,190,125,.12); border-color:rgba(60,190,125,.65); }
 .roster-status-banner--published > i { color:#54d696; }
 .roster-status-frame {
-  padding:.65rem;
+  padding:.65rem 0;
   border:1px solid;
   border-radius:12px;
 }
@@ -2772,6 +2772,16 @@ body::before { display:none; }
   max-width:1680px;
   padding-inline:clamp(1rem, 2.4vw, 2.5rem);
   gap:1.25rem;
+}
+
+.roster-page .page-content{
+  width:100%;
+  max-width:none;
+  padding-inline:0;
+}
+
+.roster-page .page-content > :not(#roster){
+  margin-inline:clamp(.75rem, 1.5vw, 1.5rem);
 }
 
 h1,h2,h3 {

--- a/templates/base.html
+++ b/templates/base.html
@@ -31,7 +31,7 @@
   {# allow pages to add their own head content (CSS/JS) #}
   {% block extra_head %}{% endblock %}
 </head>
-<body class="app-body{% if request.endpoint == 'login' %} login-shell{% endif %}">
+<body class="app-body{% if request.endpoint == 'login' %} login-shell{% endif %}{% if request.endpoint == 'roster_month' %} roster-page{% endif %}">
   <a class="skip-link" href="#main">Skip to main content</a>
   <header class="site-header">
     <div class="nav-container">

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -573,6 +573,7 @@ def test_roster_has_persistent_zoom_presets(client):
     assert b"Active unit" not in response.data
     assert b"data-operational-clock" in response.data
     assert b"Secure session" in response.data
+    assert b'<body class="app-body roster-page">' in response.data
 
     stylesheet = client.get("/static/styles.css")
     assert stylesheet.status_code == 200
@@ -580,6 +581,8 @@ def test_roster_has_persistent_zoom_presets(client):
     assert b"background: var(--off-blue)" in stylesheet.data
     assert b"select.code-input.code-len-5" in stylesheet.data
     assert b"-webkit-appearance:none" in stylesheet.data
+    assert b".roster-page .page-content" in stylesheet.data
+    assert b"padding:.65rem 0" in stylesheet.data
 
 
 def test_favicon_is_served(client):


### PR DESCRIPTION
## What changed

- gives the monthly roster page a dedicated page class
- removes the general 1680px content cap and outer page padding for the roster
- lets the roster scroller span the full available device width
- retains compact responsive margins around headings, controls, and supporting information
- removes horizontal padding inside the roster frame so the sticky staff-name column sits flush against the left scrolling edge
- adds regression assertions for the roster-specific layout

## Why

The roster was constrained inside the standard content window, reducing the number of visible days. Horizontal padding inside the scroll frame also left a gap beside the sticky name column where other cells could show through.

## User impact

The roster uses the maximum available screen width across desktop, tablet, and mobile layouts. Staff names remain against the hard left edge while scrolling.

## Validation

- targeted roster layout test passed
- git diff whitespace validation passed