### PR TITLE
Fix roster zoom and responsive layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1890,10 +1890,10 @@ tfoot td{background:var(--card); font-weight:bold; color:var(--text);}
 /* ==============================
    Responsive roster scaling
    ============================== */
-table.roster { transform-origin: top left; transform: scale(var(--ui-scale)); }
-.roster .cell .code-input { font-size: calc(.9rem * var(--ui-scale)); }
-.roster .cell .annot-select { font-size: calc(.72rem * var(--ui-scale)); height:22px; }
-.roster th, .roster td { font-size: calc(.82rem * var(--ui-scale)); }
+table.roster { zoom:var(--ui-scale); }
+.roster .cell .code-input { font-size:.9rem; }
+.roster .cell .annot-select { font-size:.72rem; height:22px; }
+.roster th, .roster td { font-size:.82rem; }
 
 /* ==============================
    Today column highlight (screen)
@@ -1937,6 +1937,7 @@ table.roster { transform-origin: top left; transform: scale(var(--ui-scale)); }
     background:#fff !important; color:#000 !important;
     border-color:#000 !important;
     font-size:0.74rem;
+    zoom:1 !important;
     transform:none !important;
   }
   thead{ display:table-header-group; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -330,15 +330,15 @@
       });
     });
 
-    const rosterZoomStorageKey = 'atcroster-roster-zoom';
-    let rosterZoomPreference = 'fit';
+    const rosterZoomStorageKey = 'atcroster-roster-zoom-v2';
+    let rosterZoomPreference = '1';
     try {
       const savedRosterZoom = window.localStorage.getItem(rosterZoomStorageKey);
       if (['fit', '0.75', '0.90', '1'].includes(savedRosterZoom)) {
         rosterZoomPreference = savedRosterZoom;
       }
     } catch (_error) {
-      rosterZoomPreference = 'fit';
+      rosterZoomPreference = '1';
     }
 
     function markRosterZoomPreset(value) {
@@ -361,7 +361,7 @@
 
     function setRosterZoomPreset(value) {
       rosterZoomPreference = ['fit', '0.75', '0.90', '1'].includes(value)
-        ? value : 'fit';
+        ? value : '1';
       try {
         window.localStorage.setItem(rosterZoomStorageKey, rosterZoomPreference);
       } catch (_error) {
@@ -400,12 +400,12 @@
       if (!tableWidth) return;
 
       const dayCount = host && host.dataset ? Number(host.dataset.dayCount || 0) : 0;
-      let minScale = 0.55;
+      let minScale = 0.30;
       if (dayCount) {
         if (dayCount <= 29) {
-          minScale = 0.70;
+          minScale = 0.38;
         } else if (dayCount === 30) {
-          minScale = 0.62;
+          minScale = 0.34;
         }
       }
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -583,6 +583,8 @@ def test_roster_has_persistent_zoom_presets(client):
     assert b"-webkit-appearance:none" in stylesheet.data
     assert b".roster-page .page-content" in stylesheet.data
     assert b"padding:.65rem 0" in stylesheet.data
+    assert b"table.roster { zoom:var(--ui-scale); }" in stylesheet.data
+    assert b"transform: scale(var(--ui-scale))" not in stylesheet.data
 
 
 def test_favicon_is_served(client):


### PR DESCRIPTION
## What changed

- makes 100% the default roster zoom for readable scrolling on all devices
- versions the stored zoom preference so existing incorrect Fit width selections reset once
- changes roster scaling from a visual transform to layout-aware CSS zoom
- removes the second font-size scaling that made roster text disproportionately tiny
- makes Fit width genuinely fit 28–31 day months when explicitly selected
- resets zoom for printing
- adds regression assertions against the old transform implementation

## Root cause

The live roster defaulted to Fit width, but the algorithm imposed a 55% minimum for a 31-day month. It therefore did not fit the width. At the same time the whole table was transformed and its font sizes were independently scaled, effectively shrinking text twice while leaving the original layout dimensions and blank space behind.

## User impact

The normal view is now readable at 100%, uses the full-width scroll area, and keeps the staff name pinned at the left. Users can still choose 75%, 90%, or a true Fit width view.

## Validation

- inspected the authenticated production roster and measured its live layout
- targeted roster regression test passed
- Ruff passed
- git diff whitespace validation passed