### PR TITLE
Add Print and Save as PDF to all reports

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1928,7 +1928,23 @@ table.roster { zoom:var(--ui-scale); }
     margin:6mm;
   }
 
-  .site-header, .site-footer, .flashes, .month-nav, .main-nav, .btn, a.nav-link, .nav-toggle { display:none !important; }
+  .site-header, .site-footer, .flashes, .month-nav, .main-nav, .btn, a.nav-link, .nav-toggle,
+  .report-output-actions, .report-page .report-filter, .report-page .bar,
+  .report-page .admin-section-nav, .report-page .assurance-run-form,
+  .report-page .operations-form { display:none !important; }
+
+  .report-page .page-content{
+    width:100% !important;
+    max-width:none !important;
+    padding:0 !important;
+  }
+
+  .report-page .card,
+  .report-page .table-scroll,
+  .report-page .table-responsive{
+    overflow:visible !important;
+    box-shadow:none !important;
+  }
 
   table{
     width:100% !important;
@@ -2773,6 +2789,27 @@ body::before { display:none; }
   max-width:1680px;
   padding-inline:clamp(1rem, 2.4vw, 2.5rem);
   gap:1.25rem;
+}
+
+.report-output-actions{
+  display:flex;
+  align-items:center;
+  justify-content:flex-end;
+  gap:.65rem;
+  flex-wrap:wrap;
+  padding:.7rem .85rem;
+  border:1px solid var(--line);
+  border-radius:var(--radius-md);
+  background:var(--card);
+}
+
+.report-output-actions span{
+  color:var(--text-muted);
+  font-size:.8rem;
+}
+
+body.report-pdf-requested .report-output-actions{
+  border-color:var(--accent);
 }
 
 .roster-page .page-content{

--- a/templates/_report_actions.html
+++ b/templates/_report_actions.html
@@ -1,0 +1,9 @@
+<div class="report-output-actions" role="group" aria-label="Report output options">
+  <button class="btn" type="button" data-command="print-report">
+    <i class="fa-solid fa-print" aria-hidden="true"></i> Print
+  </button>
+  <button class="btn btn-primary" type="button" data-command="save-report-pdf">
+    <i class="fa-solid fa-file-pdf" aria-hidden="true"></i> Save as PDF
+  </button>
+  <span>For PDF, choose <strong>Save as PDF</strong> in the print destination.</span>
+</div>

--- a/templates/admin_sms_audit.html
+++ b/templates/admin_sms_audit.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}SMS Audit{% endblock %}
 {% block content %}
+{% include "_report_actions.html" %}
 <section class="compliance-hero">
   <div>
     <span class="admin-step">Operational communications</span>

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,11 @@
   {% set in_briefing_module = request.endpoint and request.endpoint.startswith('briefing.') %}
   {% set in_training_module = request.endpoint and request.endpoint.startswith('training_') %}
   {% set in_competency_module = request.endpoint and request.endpoint.startswith('competency_') %}
+  {% set report_endpoints = (
+    'report_leave', 'report_leave_year', 'report_sickness', 'report_fatigue',
+    'metrics', 'coverage_heatmap', 'operations_assurance', 'training_analytics',
+    'admin_sms_audit', 'briefing.audit', 'briefing.assurance'
+  ) %}
   <title>{% block title %}{% endblock %} – {{ 'ATC Competency' if in_competency_module else ('ATC Training' if in_training_module else ('ATC Briefing' if in_briefing_module else 'ATC Roster')) }}</title>
 
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-TbP2oT4maGdTKStZJ9+doRTO1D94avYVbwybXDq3s1ymUOI1IKXey9HvK+nZd9kpGdn6FQkR0fF6Bw7+Xw8FfA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
@@ -31,7 +36,7 @@
   {# allow pages to add their own head content (CSS/JS) #}
   {% block extra_head %}{% endblock %}
 </head>
-<body class="app-body{% if request.endpoint == 'login' %} login-shell{% endif %}{% if request.endpoint == 'roster_month' %} roster-page{% endif %}">
+<body class="app-body{% if request.endpoint == 'login' %} login-shell{% endif %}{% if request.endpoint == 'roster_month' %} roster-page{% endif %}{% if request.endpoint in report_endpoints %} report-page{% endif %}">
   <a class="skip-link" href="#main">Skip to main content</a>
   <header class="site-header">
     <div class="nav-container">
@@ -222,9 +227,15 @@
         history.back();
       } else if (target.dataset.command === 'print-roster') {
         window.printRoster?.();
-      } else if (target.dataset.command === 'print-fatigue') {
-        window.doPrint?.();
+      } else if (target.dataset.command === 'print-report') {
+        window.print();
+      } else if (target.dataset.command === 'save-report-pdf') {
+        document.body.classList.add('report-pdf-requested');
+        window.setTimeout(() => window.print(), 50);
       }
+    });
+    window.addEventListener('afterprint', () => {
+      document.body.classList.remove('report-pdf-requested');
     });
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => navigator.serviceWorker.register('/static/service-worker.js'));

--- a/templates/briefing/assurance.html
+++ b/templates/briefing/assurance.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Briefing reports{% endblock %}
 {% block content %}
+{% include "_report_actions.html" %}
 <section class="compliance-hero">
   <div><span class="admin-step">Real-time briefing oversight</span><h2>Reports</h2><p>Review logins, roster activity and outstanding briefing instructions.</p></div>
 </section>

--- a/templates/briefing/audit.html
+++ b/templates/briefing/audit.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Briefing audit{% endblock %}
 {% block content %}
+{% include "_report_actions.html" %}
 <section class="compliance-hero"><div><span class="admin-step">Append-only evidence</span><h2>Briefing audit</h2><p>Publication, access, acknowledgement and reporting activity.</p></div></section>
 <section class="card"><div class="table-responsive"><table class="table">
   <thead><tr><th>Time</th><th>Actor</th><th>Event</th><th>Briefing</th><th>Detail</th></tr></thead>

--- a/templates/coverage_heatmap.html
+++ b/templates/coverage_heatmap.html
@@ -2,6 +2,7 @@
 {% block title %}Coverage Heatmap{% endblock %}
 {% block content %}
 <div class="page-shell">
+{% include "_report_actions.html" %}
 <section class="compliance-hero">
   <div><span class="admin-step">Staffing assurance</span><h2>Coverage heatmap</h2><p>Morning, day, afternoon and night coverage for {{ ym }}.</p></div>
 </section>

--- a/templates/metrics.html
+++ b/templates/metrics.html
@@ -3,6 +3,7 @@
 
 {% block content %}
 <div class="page-shell">
+  {% include "_report_actions.html" %}
   <section class="compliance-hero">
     <div><span class="admin-step">Roster reporting</span><h2>Annotation totals</h2><p>Each column follows this airport’s configured annotations. Retired annotations remain visible as historical data.</p></div>
     <div class="compliance-actions"><a class="btn" href="{{ url_for('reports_index') }}">&larr; Reports</a></div>

--- a/templates/operations_assurance.html
+++ b/templates/operations_assurance.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Operational Assurance · {{ ym }}{% endblock %}
 {% block content %}
+{% include "_report_actions.html" %}
 <section class="compliance-hero">
   <div>
     <span class="admin-step">Production operations</span>

--- a/templates/report_fatigue.html
+++ b/templates/report_fatigue.html
@@ -35,8 +35,6 @@
   }
 </style>
 <script nonce="{{ csp_nonce() }}">
-  function doPrint(){ window.print(); }
-
   function toggleNoIssueRows(cbId, tableId){
     const checked = document.getElementById(cbId).checked;
     const rows = document.querySelectorAll(`#${tableId} tbody tr`);
@@ -79,12 +77,12 @@
 
 {% block content %}
 <div class="page-wrap">
+  {% include "_report_actions.html" %}
   <section class="compliance-hero">
     <div><span class="admin-step">Fatigue reporting</span><h2>Fatigue findings · {{ month_title }}</h2><p>Review explainable roster warnings by controller and day.</p></div>
     <div class="compliance-actions">
       <a class="btn" href="{{ url_for('reports_index') }}">&larr; Reports</a>
       <a class="btn" href="{{ url_for('roster_month', ym=ym) }}">Back to roster</a>
-      <button class="btn" type="button" data-command="print-fatigue">Print</button>
     </div>
   </section>
 

--- a/templates/report_leave.html
+++ b/templates/report_leave.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Leave – {{ month_title }}{% endblock %}
 {% block content %}
+{% include "_report_actions.html" %}
 <section class="compliance-hero">
   <div><span class="admin-step">Leave reporting</span><h2>Leave · {{ month_title }}</h2><p>Recorded leave totals by controller and leave type.</p></div>
   <div class="compliance-actions">

--- a/templates/report_leave_year.html
+++ b/templates/report_leave_year.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Leave Year{% endblock %}
 {% block content %}
+{% include "_report_actions.html" %}
 <section class="compliance-hero">
   <div><span class="admin-step">Leave reporting</span><h2>Leave year</h2><p>Entitlement and balances as of {{ today }}.</p></div>
   <div class="compliance-actions"><a class="btn" href="{{ url_for('reports_index') }}">&larr; Reports</a></div>

--- a/templates/report_sickness.html
+++ b/templates/report_sickness.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Sickness (12 months){% endblock %}
 {% block content %}
+{% include "_report_actions.html" %}
 <section class="compliance-hero">
   <div><span class="admin-step">Sickness reporting</span><h2>Sickness · last 12 months</h2><p>Recorded absence from {{ start }} to {{ end }}.</p></div>
   <div class="compliance-actions"><a class="btn" href="{{ url_for('reports_index') }}">&larr; Reports</a></div>

--- a/templates/training_analytics.html
+++ b/templates/training_analytics.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Training analytics{% endblock %}
 {% block content %}
+{% include "_report_actions.html" %}
 <section class="training-hero"><div><span class="admin-step">Management insight</span><h2>Training analytics</h2><p>Attainment trends, objective coverage and instructor hours.</p></div><div class="training-total"><span>Reports</span><strong>{{ sessions|length }}</strong></div></section>
 <section class="analytics-layout">
   <article class="card"><div class="card-hd">Attainment by objective</div><div class="card-bd analytics-bars">

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -278,6 +278,10 @@ def test_reports_require_sensitive_data_acknowledgement(client):
     opened = client.get("/reports/leave-year")
     assert opened.status_code == 200
     assert b"Leave year" in opened.data
+    assert b'<body class="app-body report-page">' in opened.data
+    assert b'data-command="print-report"' in opened.data
+    assert b'data-command="save-report-pdf"' in opened.data
+    assert b"choose <strong>Save as PDF</strong>" in opened.data
 
     # Returning to the Reports tab is a new entry and must require a fresh
     # privacy acknowledgement.


### PR DESCRIPTION
## What changed

- adds a shared report-output toolbar with Print and Save as PDF controls
- applies it to 11 reporting screens across roster, operations, training, communications, and briefing
- explains the browser-required Save as PDF destination step
- adds shared event handling instead of page-specific print scripts
- introduces report-specific print styling that removes navigation, filters, action forms, and screen-only controls
- expands report content to the printable page and removes clipped scrolling containers and decorative shadows
- adds regression coverage for report page classification and both output controls

## Why

Report output controls were inconsistent and mostly absent. The fatigue report had a one-off print implementation, while other reports required users to rely on browser menus and often printed screen-only controls.

## User impact

Every report now presents the same Print and Save as PDF options, with cleaner landscape output suitable for operational records.

## Validation

- Python 3.14: 181 passed, 2 skipped
- targeted report tests passed
- Ruff passed
- git diff whitespace validation passed