### PR TITLE
Split report calculations from app routes

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -20,14 +20,14 @@ jobs:
       - run: pip install -r requirements-dev.txt
       - name: Formatting, lint and static analysis
         run: |
-          ruff format --check atcroster rate_limiting.py platform_provisioning.py signup_locking.py scripts/migrate_all_databases.py scripts/run_provisioning_worker.py auth_blueprint.py
-          ruff check atcroster app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts/*.py
+          ruff format --check atcroster rate_limiting.py reporting.py platform_provisioning.py signup_locking.py scripts/migrate_all_databases.py scripts/run_provisioning_worker.py auth_blueprint.py
+          ruff check atcroster app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py reporting.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts/*.py
           mypy --ignore-missing-imports --follow-imports=skip atcroster rate_limiting.py signup_locking.py
       - run: pip-audit -r requirements-prod.txt
       - name: Full maintained-application security scan
         run: |
-          bandit -q -ll -r atcroster app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts
-      - run: python -m compileall -q atcroster app.py auth_blueprint.py briefing_module.py briefing_storage.py saas_models.py tenancy.py account_limits.py scripts
+          bandit -q -ll -r atcroster app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py reporting.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts
+      - run: python -m compileall -q atcroster app.py auth_blueprint.py briefing_module.py briefing_storage.py reporting.py saas_models.py tenancy.py account_limits.py scripts
       - run: python -m pytest --cov --cov-report=term-missing -q
       - name: Verify fresh split migrations
         run: |

--- a/app.py
+++ b/app.py
@@ -37,6 +37,13 @@ from sqlalchemy.exc import IntegrityError
 from rate_limiting import (
     LimiterUnavailable, MemoryRateLimiter, RedisRateLimiter, privacy_key,
 )
+from reporting import (
+    compute_annotation_metrics,
+    current_leave_year_window,
+    financial_year_start,
+    group_consecutive_days,
+    leave_summary_for_month,
+)
 from atcroster import create_app, get_runtime_settings
 from tenancy import (
     authenticated_unit_id,
@@ -7402,99 +7409,21 @@ def notification_delete(notification_id):
 
 
 def _compute_metrics_range(start_day: date, end_day: date):
-    assignments = (Assignment.query
-                   .filter(Assignment.day >= start_day, Assignment.day <= end_day)
-                   .all())
-
-    annotation_snapshot = _annotation_snapshot(
-        int(_current_unit_id() or 1)
-    )["items"]
-    label_map = {item["code"]: item["label"] for item in annotation_snapshot}
-    report_excluded_codes = {
-        item["code"]
-        for item in annotation_snapshot
-        if "report_exclude" in set(item.get("tags") or ())
-    }
-
-    annotation_columns = [
-        {
-            "code": item["code"],
-            "label": item["label"] or item["code"],
-            "active": bool(item["is_active"]),
-        }
-        for item in annotation_snapshot
-        if item["is_active"] and item["code"] not in report_excluded_codes
-    ]
-    annotation_order = [
-        column["code"] for column in annotation_columns
-    ]
-    annotation_known = set(annotation_order)
-
-    staff_by_id = {s.id: s for s in Staff.query.all()}
-    metrics_map: dict[int, dict[str, object]] = {}
-
-    for a in assignments:
-        s = staff_by_id.get(a.staff_id)
-        if not s:
-            continue
-        if s.id not in metrics_map:
-            metrics_map[s.id] = {
-                "staff": s,
-                "annotations": {
-                    code: 0 for code in annotation_order
-                },
-            }
-        parsed = parse_annotation(a.annotation)
-        if not parsed:
-            continue
-        code = parsed["type"]
-        if code in report_excluded_codes:
-            continue
-        # Preserve historical totals when a definition was retired after use.
-        if code not in annotation_known:
-            annotation_known.add(code)
-            annotation_order.append(code)
-            annotation_columns.append({
-                "code": code,
-                "label": label_map.get(code, code),
-                "active": False,
-            })
-        metrics_map[s.id]["annotations"].setdefault(code, 0)
-        metrics_map[s.id]["annotations"][code] += 1
-
-    staff_order = (Staff.query
-                   .outerjoin(Watch, Staff.watch_id == Watch.id)
-                   .order_by(Watch.order_index, Staff.name).all())
-
-    staff_metrics = []
-    for s in staff_order:
-        base = {
-            "staff": s,
-            "annotations": {
-                code: 0 for code in annotation_order
-            },
-        }
-        row = metrics_map.get(s.id, base)
-        row["annotations"] = {
-            code: row["annotations"].get(code, 0)
-            for code in annotation_order
-        }
-        staff_metrics.append(row)
-
-    totals = {
-        "annotations": {
-            code: sum(
-                row["annotations"].get(code, 0)
-                for row in staff_metrics
-            )
-            for code in annotation_order
-        },
-    }
-    return staff_metrics, totals, annotation_columns
+    return compute_annotation_metrics(
+        start_day,
+        end_day,
+        Assignment=Assignment,
+        Staff=Staff,
+        Watch=Watch,
+        annotation_items=_annotation_snapshot(
+            int(_current_unit_id() or 1)
+        )["items"],
+        parse_annotation=parse_annotation,
+    )
 
 
 def _fy_start_for(d: date) -> date:
-    return date(d.year if d.month >= 4 else d.year - 1, 4, 1)
+    return financial_year_start(d)
 
 
 def _reports_acknowledgement_key() -> str:
@@ -8197,46 +8126,17 @@ def calendar_feed(sid, token):
 
 
 def _leave_summary_for_month(year: int, month: int, watch_id: int | None = None):
-    start, days = month_range(year, month)
-    month_end = (start.replace(day=28) + timedelta(days=10)).replace(day=1)
-    unit_id = _current_unit_id()
-
-    a_map = defaultdict(dict)
-    for a in Assignment.query.filter(
-        Assignment.unit_id == unit_id,
-        Assignment.day >= start,
-        Assignment.day < month_end,
-    ):
-        a_map[a.staff_id][a.day] = a.code
-
-    staff_query = (
-        Staff.query
-        .filter(Staff.unit_id == unit_id)
-        .outerjoin(Watch, Staff.watch_id == Watch.id)
+    return leave_summary_for_month(
+        year,
+        month,
+        watch_id,
+        unit_id=_current_unit_id(),
+        Assignment=Assignment,
+        Staff=Staff,
+        Watch=Watch,
+        month_range=month_range,
+        active_leave_types=get_absence_types("leave", active_only=True),
     )
-    if watch_id is not None:
-        staff_query = staff_query.filter(Staff.watch_id == watch_id)
-    staff = staff_query.order_by(Watch.order_index, Staff.name).all()
-
-    codes_sorted = [
-        item["code"] for item in get_absence_types("leave", active_only=True)
-    ]
-    rows = []
-    totals = Counter()
-
-    for s in staff:
-        counts = {c: 0 for c in codes_sorted}
-        for d in days:
-            code = a_map[s.id].get(d)
-            if code in counts:
-                counts[code] += 1
-        total = sum(counts.values())
-        for c, v in counts.items():
-            totals[c] += v
-        rows.append({"staff": s, "counts": counts, "total": total})
-
-    grand_total = sum(totals.values())
-    return rows, codes_sorted, totals, grand_total, days
 
 
 def _report_watch_selection():
@@ -8324,15 +8224,7 @@ def report_leave_csv():
 # (unchanged from your post)
 
 def _current_leave_year_window(s: Staff, today: date | None = None):
-    today = today or date.today()
-    start_month = s.leave_year_start_month or 4
-    start_year = today.year if today.month >= start_month else today.year - 1
-    start = date(start_year, start_month, 1)
-    end_year = start_year + 1 if start_month > 1 else start_year + 1
-    end_month = start_month - 1 if start_month > 1 else 12
-    _, end_days = month_range(end_year, end_month)
-    end = end_days[-1]
-    return start, end
+    return current_leave_year_window(s, today)
 
 
 def _toil_accrual_half_days_from_annotation(parsed):
@@ -8434,16 +8326,7 @@ def report_leave_year():
 
 
 def _group_consecutive_days(days_set):
-    if not days_set:
-        return 0
-    days = sorted(days_set)
-    groups = 0
-    prev = None
-    for d in days:
-        if prev is None or (d - prev).days > 1:
-            groups += 1
-        prev = d
-    return groups
+    return group_consecutive_days(days_set)
 
 
 @app.route("/reports/sickness")

--- a/reporting.py
+++ b/reporting.py
@@ -1,0 +1,163 @@
+"""Reusable report calculations, independent of Flask route handling."""
+
+from __future__ import annotations
+
+from calendar import monthrange
+from collections import Counter, defaultdict
+from datetime import date, timedelta
+from typing import Any, Callable, Iterable
+
+
+def compute_annotation_metrics(
+    start_day: date,
+    end_day: date,
+    *,
+    Assignment: Any,
+    Staff: Any,
+    Watch: Any,
+    annotation_items: Iterable[dict[str, object]],
+    parse_annotation: Callable[[str], dict[str, str] | None],
+):
+    assignments = Assignment.query.filter(
+        Assignment.day >= start_day,
+        Assignment.day <= end_day,
+    ).all()
+    items = list(annotation_items)
+    label_map = {item["code"]: item["label"] for item in items}
+    excluded = {
+        item["code"]
+        for item in items
+        if "report_exclude" in set(item.get("tags") or ())
+    }
+    columns = [
+        {
+            "code": item["code"],
+            "label": item["label"] or item["code"],
+            "active": bool(item["is_active"]),
+        }
+        for item in items
+        if item["is_active"] and item["code"] not in excluded
+    ]
+    order = [column["code"] for column in columns]
+    known = set(order)
+    staff_by_id = {person.id: person for person in Staff.query.all()}
+    metrics: dict[int, dict[str, object]] = {}
+
+    for assignment in assignments:
+        person = staff_by_id.get(assignment.staff_id)
+        if not person:
+            continue
+        metrics.setdefault(
+            person.id,
+            {
+                "staff": person,
+                "annotations": {code: 0 for code in order},
+            },
+        )
+        parsed = parse_annotation(assignment.annotation)
+        if not parsed or parsed["type"] in excluded:
+            continue
+        code = parsed["type"]
+        if code not in known:
+            known.add(code)
+            order.append(code)
+            columns.append(
+                {
+                    "code": code,
+                    "label": label_map.get(code, code),
+                    "active": False,
+                }
+            )
+        annotations = metrics[person.id]["annotations"]
+        annotations.setdefault(code, 0)
+        annotations[code] += 1
+
+    ordered_people = (
+        Staff.query.outerjoin(Watch, Staff.watch_id == Watch.id)
+        .order_by(Watch.order_index, Staff.name)
+        .all()
+    )
+    rows = []
+    for person in ordered_people:
+        row = metrics.get(
+            person.id,
+            {
+                "staff": person,
+                "annotations": {},
+            },
+        )
+        row["annotations"] = {code: row["annotations"].get(code, 0) for code in order}
+        rows.append(row)
+    totals = {
+        "annotations": {
+            code: sum(row["annotations"].get(code, 0) for row in rows) for code in order
+        }
+    }
+    return rows, totals, columns
+
+
+def leave_summary_for_month(
+    year: int,
+    month: int,
+    watch_id: int | None,
+    *,
+    unit_id: int,
+    Assignment: Any,
+    Staff: Any,
+    Watch: Any,
+    month_range: Callable,
+    active_leave_types: Iterable[dict[str, object]],
+):
+    start, days = month_range(year, month)
+    month_end = (start.replace(day=28) + timedelta(days=10)).replace(day=1)
+    assignments: dict[int, dict[date, str]] = defaultdict(dict)
+    for row in Assignment.query.filter(
+        Assignment.unit_id == unit_id,
+        Assignment.day >= start,
+        Assignment.day < month_end,
+    ):
+        assignments[row.staff_id][row.day] = row.code
+
+    query = Staff.query.filter(Staff.unit_id == unit_id).outerjoin(
+        Watch, Staff.watch_id == Watch.id
+    )
+    if watch_id is not None:
+        query = query.filter(Staff.watch_id == watch_id)
+    people = query.order_by(Watch.order_index, Staff.name).all()
+    codes = [item["code"] for item in active_leave_types]
+    rows = []
+    totals = Counter()
+    for person in people:
+        counts = {code: 0 for code in codes}
+        for day in days:
+            code = assignments[person.id].get(day)
+            if code in counts:
+                counts[code] += 1
+        total = sum(counts.values())
+        totals.update(counts)
+        rows.append({"staff": person, "counts": counts, "total": total})
+    return rows, codes, totals, sum(totals.values()), days
+
+
+def financial_year_start(day: date) -> date:
+    return date(day.year if day.month >= 4 else day.year - 1, 4, 1)
+
+
+def current_leave_year_window(person: Any, today: date | None = None):
+    today = today or date.today()
+    start_month = person.leave_year_start_month or 4
+    start_year = today.year if today.month >= start_month else today.year - 1
+    start = date(start_year, start_month, 1)
+    end_month = start_month - 1 if start_month > 1 else 12
+    _, end_days = monthrange(start_year + 1, end_month)
+    return start, date(start_year + 1, end_month, end_days)
+
+
+def group_consecutive_days(days: Iterable[date]) -> int:
+    groups = 0
+    previous = None
+    for day in sorted(set(days)):
+        if previous is None or (day - previous).days > 1:
+            groups += 1
+        previous = day
+    return groups

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,34 @@
+from datetime import date
+from types import SimpleNamespace
+
+from reporting import (
+    current_leave_year_window,
+    financial_year_start,
+    group_consecutive_days,
+)
+
+
+def test_financial_year_start_handles_both_sides_of_april_boundary():
+    assert financial_year_start(date(2026, 3, 31)) == date(2025, 4, 1)
+    assert financial_year_start(date(2026, 4, 1)) == date(2026, 4, 1)
+
+
+def test_group_consecutive_days_counts_distinct_periods():
+    assert group_consecutive_days([]) == 0
+    assert (
+        group_consecutive_days([date(2026, 5, 1), date(2026, 5, 2), date(2026, 5, 4)])
+        == 2
+    )
+
+
+def test_current_leave_year_window_uses_configured_start_month():
+    person = SimpleNamespace(leave_year_start_month=4)
+
+    assert current_leave_year_window(person, date(2026, 3, 31)) == (
+        date(2025, 4, 1),
+        date(2026, 3, 31),
+    )
+    assert current_leave_year_window(person, date(2026, 4, 1)) == (
+        date(2026, 4, 1),
+        date(2027, 3, 31),
+    )


### PR DESCRIPTION
## What changed

- moved reusable metrics, leave and sickness report calculations into `reporting.py`
- retained thin compatibility wrappers in `app.py`, so existing routes and templates are unchanged
- added focused tests for financial-year, leave-year and sickness-period boundaries
- included the new module in formatting, lint, security and compile checks

## Why

This is the first low-risk phase of reducing the Flask monolith. Keeping report calculations separate makes them easier to test and maintain without changing user-facing behaviour.

## Validation

- `ruff check reporting.py app.py tests/test_reporting.py`
- `python -m compileall -q atcroster app.py reporting.py`
- `python -m pytest -q` — 184 passed, 2 skipped