### PR TITLE
Split roster calculations from app routes

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -20,14 +20,14 @@ jobs:
       - run: pip install -r requirements-dev.txt
       - name: Formatting, lint and static analysis
         run: |
-          ruff format --check atcroster rate_limiting.py reporting.py platform_provisioning.py signup_locking.py scripts/migrate_all_databases.py scripts/run_provisioning_worker.py auth_blueprint.py
-          ruff check atcroster app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py reporting.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts/*.py
+          ruff format --check atcroster rate_limiting.py reporting.py roster_logic.py platform_provisioning.py signup_locking.py scripts/migrate_all_databases.py scripts/run_provisioning_worker.py auth_blueprint.py
+          ruff check atcroster app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py reporting.py roster_logic.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts/*.py
           mypy --ignore-missing-imports --follow-imports=skip atcroster rate_limiting.py signup_locking.py
       - run: pip-audit -r requirements-prod.txt
       - name: Full maintained-application security scan
         run: |
-          bandit -q -ll -r atcroster app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py reporting.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts
-      - run: python -m compileall -q atcroster app.py auth_blueprint.py briefing_module.py briefing_storage.py reporting.py saas_models.py tenancy.py account_limits.py scripts
+          bandit -q -ll -r atcroster app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py reporting.py roster_logic.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts
+      - run: python -m compileall -q atcroster app.py auth_blueprint.py briefing_module.py briefing_storage.py reporting.py roster_logic.py saas_models.py tenancy.py account_limits.py scripts
       - run: python -m pytest --cov --cov-report=term-missing -q
       - name: Verify fresh split migrations
         run: |

--- a/app.py
+++ b/app.py
@@ -44,6 +44,19 @@ from reporting import (
     group_consecutive_days,
     leave_summary_for_month,
 )
+from roster_logic import (
+    add_months,
+    daily_requirements,
+    expand_pattern,
+    iter_year_months,
+    month_days,
+    normalise_assignment_snapshot,
+    parse_year_month,
+    roster_lock_date,
+    roster_month_is_locked,
+    shift_minutes,
+    validated_pattern,
+)
 from atcroster import create_app, get_runtime_settings
 from tenancy import (
     authenticated_unit_id,
@@ -2367,10 +2380,7 @@ def month_has_data(year: int, month: int) -> bool:
 
 
 def month_range(year: int, month: int):
-    start = date(year, month, 1)
-    stop = date(year + (month // 12), (month % 12) + 1, 1)
-    days = (stop - start).days
-    return start, [start + timedelta(d) for d in range(days)]
+    return month_days(year, month)
 
 
 def watch_id_for_staff_on(staff_id: int, on_date: date) -> int | None:
@@ -2400,8 +2410,7 @@ def _watch_id_for_staff_on(
 
 
 def parse_ym(ym: str):
-    y, m = ym.split("-")
-    return int(y), int(m)
+    return parse_year_month(ym)
 
 
 def get_shift(code: str, unit_id: int | None = None):
@@ -2432,30 +2441,11 @@ DEFAULT_BASE_PATTERN = "M,M,A,A,N,N,OFF,OFF,OFF,OFF"
 
 
 def _expand_pattern(raw_value: str | None) -> list[str]:
-    """Expand a stored CSV pattern, retaining legacy multiplier support."""
-    raw = [p.strip()
-           for p in (raw_value or "").split(",") if p.strip()]
-    out = []
-    for tok in raw:
-        tok_u = tok.upper()
-        m = re.match(r"^\s*(\d+)\s*[x\*]\s*([A-Z]+)\s*$", tok_u)
-        m2 = re.match(r"^\s*([A-Z]+)\s*[x\*]\s*(\d+)\s*$", tok_u)
-        if m:
-            n, code = int(m.group(1)), m.group(2)
-            out.extend([code] * n)
-        elif m2:
-            code, n = m2.group(1), int(m2.group(2))
-            out.extend([code] * n)
-        else:
-            out.append(tok_u)
-    return out
+    return expand_pattern(raw_value)
 
 
 def _validated_pattern(raw_value: str | None) -> list[str]:
-    values = _expand_pattern(raw_value)
-    if not values or any(value not in PATTERN_CODES for value in values):
-        return []
-    return values
+    return validated_pattern(raw_value)
 
 
 def _effective_watch(staff: Staff, on_date: date) -> Watch | None:
@@ -2625,13 +2615,7 @@ def refresh_day_from_pattern_and_leave(staff: Staff, d: date):
 
 
 def shift_duration_minutes(shift: ShiftType):
-    if not shift or not shift.start_time or not shift.end_time:
-        return 0
-    dt0 = datetime.combine(date(2000, 1, 1), shift.start_time)
-    dt1 = datetime.combine(date(2000, 1, 1), shift.end_time)
-    if dt1 <= dt0:
-        dt1 += timedelta(days=1)
-    return int((dt1 - dt0).total_seconds() // 60)
+    return shift_minutes(shift)
 
 
 def ensure_month_requirement(year, month, default=(4, 4, 4, 2)):
@@ -2658,22 +2642,7 @@ def requirements_for_day(
     day: date,
     special: SpecialRequirement | None = None,
 ) -> dict[str, int]:
-    """Return the effective M/D/A/N requirement for one roster date."""
-    source = special or requirement
-    if not source:
-        return {code: 0 for code in ("M", "D", "A", "N")}
-    prefix = ""
-    if not special:
-        prefix = "sat_" if day.weekday() == 5 else (
-            "sun_" if day.weekday() == 6 else ""
-        )
-    return {
-        code: max(
-            0,
-            int(getattr(source, f"req_{prefix}{code.lower()}", 0) or 0),
-        )
-        for code in ("M", "D", "A", "N")
-    }
+    return daily_requirements(requirement, day, special)
 
 # Idempotent month generation that preserves manual entries
 
@@ -3365,16 +3334,7 @@ def would_trigger_fatigue(staff: Staff, day: date, code: str):
 
 
 def _year_month_iter(start_date: date, end_date: date):
-    y, m = start_date.year, start_date.month
-    last = date(end_date.year, end_date.month, 1)
-    cur = date(y, m, 1)
-    while cur <= last:
-        yield y, m
-        m += 1
-        if m == 13:
-            m = 1
-            y += 1
-        cur = date(y, m, 1)
+    yield from iter_year_months(start_date, end_date)
 
 
 def generate_range(start_day: date, end_day: date):
@@ -4265,21 +4225,15 @@ def log_change(entity_type: str, entity_id: int, field: str, old, new, note: str
 
 
 def _month_add(y: int, m: int, delta: int) -> Tuple[int, int]:
-    idx = y * 12 + (m - 1) + delta
-    ny = idx // 12
-    nm = idx % 12 + 1
-    return ny, nm
+    return add_months(y, m, delta)
 
 
 def lock_date_for_month(y: int, m: int) -> date:
-    ly, lm = _month_add(y, m, -2)
-    return date(ly, lm, 20)
+    return roster_lock_date(y, m)
 
 
 def is_month_locked(y: int, m: int, today: Optional[date] = None) -> bool:
-    if today is None:
-        today = date.today()
-    return today >= lock_date_for_month(y, m)
+    return roster_month_is_locked(y, m, today)
 
 
 # Source protection: we never overwrite these
@@ -4551,17 +4505,10 @@ def _publication_matches_live_roster(publication, year: int, month: int) -> bool
     except (TypeError, json.JSONDecodeError):
         return False
     live_rows = _roster_snapshot(year, month)["assignments"]
-    normalise = lambda rows: sorted(
-        (
-            int(row["staff_id"]),
-            str(row["day"]),
-            str(row.get("code") or ""),
-            str(row.get("annotation") or ""),
-        )
-        for row in rows
-    )
     try:
-        return normalise(published_rows) == normalise(live_rows)
+        return normalise_assignment_snapshot(
+            published_rows
+        ) == normalise_assignment_snapshot(live_rows)
     except (KeyError, TypeError, ValueError):
         return False
 

--- a/roster_logic.py
+++ b/roster_logic.py
@@ -1,0 +1,114 @@
+"""Pure roster and assignment calculations used by Flask route handlers."""
+
+from __future__ import annotations
+
+import re
+from datetime import date, datetime, timedelta
+from typing import Iterable, Iterator
+
+
+PATTERN_CODES = ("M", "A", "D", "N", "OFF")
+
+
+def month_days(year: int, month: int) -> tuple[date, list[date]]:
+    start = date(year, month, 1)
+    stop = date(year + (month // 12), (month % 12) + 1, 1)
+    return start, [
+        start + timedelta(days=offset) for offset in range((stop - start).days)
+    ]
+
+
+def parse_year_month(value: str) -> tuple[int, int]:
+    year, month = value.split("-")
+    return int(year), int(month)
+
+
+def expand_pattern(raw_value: str | None) -> list[str]:
+    """Expand a CSV shift pattern, including legacy multiplier notation."""
+    raw = [part.strip() for part in (raw_value or "").split(",") if part.strip()]
+    expanded = []
+    for token in raw:
+        token = token.upper()
+        prefix_multiplier = re.match(r"^\s*(\d+)\s*[X\*]\s*([A-Z]+)\s*$", token)
+        suffix_multiplier = re.match(r"^\s*([A-Z]+)\s*[X\*]\s*(\d+)\s*$", token)
+        if prefix_multiplier:
+            count, code = int(prefix_multiplier.group(1)), prefix_multiplier.group(2)
+            expanded.extend([code] * count)
+        elif suffix_multiplier:
+            code, count = suffix_multiplier.group(1), int(suffix_multiplier.group(2))
+            expanded.extend([code] * count)
+        else:
+            expanded.append(token)
+    return expanded
+
+
+def validated_pattern(raw_value: str | None) -> list[str]:
+    values = expand_pattern(raw_value)
+    if not values or any(value not in PATTERN_CODES for value in values):
+        return []
+    return values
+
+
+def shift_minutes(shift) -> int:
+    if not shift or not shift.start_time or not shift.end_time:
+        return 0
+    start = datetime.combine(date(2000, 1, 1), shift.start_time)
+    end = datetime.combine(date(2000, 1, 1), shift.end_time)
+    if end <= start:
+        end += timedelta(days=1)
+    return int((end - start).total_seconds() // 60)
+
+
+def daily_requirements(requirement, day: date, special=None) -> dict[str, int]:
+    """Return the effective M/D/A/N staffing requirement for a roster date."""
+    source = special or requirement
+    if not source:
+        return {code: 0 for code in ("M", "D", "A", "N")}
+    prefix = ""
+    if not special:
+        prefix = (
+            "sat_" if day.weekday() == 5 else ("sun_" if day.weekday() == 6 else "")
+        )
+    return {
+        code: max(0, int(getattr(source, f"req_{prefix}{code.lower()}", 0) or 0))
+        for code in ("M", "D", "A", "N")
+    }
+
+
+def iter_year_months(start_day: date, end_day: date) -> Iterator[tuple[int, int]]:
+    year, month = start_day.year, start_day.month
+    last = date(end_day.year, end_day.month, 1)
+    current = date(year, month, 1)
+    while current <= last:
+        yield year, month
+        month += 1
+        if month == 13:
+            month = 1
+            year += 1
+        current = date(year, month, 1)
+
+
+def add_months(year: int, month: int, delta: int) -> tuple[int, int]:
+    index = year * 12 + (month - 1) + delta
+    return index // 12, index % 12 + 1
+
+
+def roster_lock_date(year: int, month: int) -> date:
+    lock_year, lock_month = add_months(year, month, -2)
+    return date(lock_year, lock_month, 20)
+
+
+def roster_month_is_locked(year: int, month: int, today: date | None = None) -> bool:
+    return (today or date.today()) >= roster_lock_date(year, month)
+
+
+def normalise_assignment_snapshot(rows: Iterable[dict[str, object]]) -> list[tuple]:
+    return sorted(
+        (
+            int(row["staff_id"]),
+            str(row["day"]),
+            str(row.get("code") or ""),
+            str(row.get("annotation") or ""),
+        )
+        for row in rows
+    )

--- a/tests/test_roster_logic.py
+++ b/tests/test_roster_logic.py
@@ -1,0 +1,69 @@
+from datetime import date, time
+from types import SimpleNamespace
+
+from roster_logic import (
+    daily_requirements,
+    expand_pattern,
+    iter_year_months,
+    month_days,
+    normalise_assignment_snapshot,
+    roster_month_is_locked,
+    shift_minutes,
+    validated_pattern,
+)
+
+
+def test_month_days_handles_leap_year():
+    start, days = month_days(2028, 2)
+    assert start == date(2028, 2, 1)
+    assert len(days) == 29
+    assert days[-1] == date(2028, 2, 29)
+
+
+def test_patterns_support_legacy_multipliers_and_reject_unknown_codes():
+    assert expand_pattern("2xM, A*2, off") == ["M", "M", "A", "A", "OFF"]
+    assert validated_pattern("M,A,N,OFF") == ["M", "A", "N", "OFF"]
+    assert validated_pattern("M,UNKNOWN") == []
+
+
+def test_shift_minutes_handles_overnight_duty():
+    shift = SimpleNamespace(start_time=time(22, 0), end_time=time(6, 0))
+    assert shift_minutes(shift) == 480
+
+
+def test_daily_requirements_select_weekend_values_and_clamp_negatives():
+    requirement = SimpleNamespace(
+        req_m=4,
+        req_d=4,
+        req_a=4,
+        req_n=2,
+        req_sat_m=3,
+        req_sat_d=-1,
+        req_sat_a=3,
+        req_sat_n=1,
+    )
+    assert daily_requirements(requirement, date(2026, 8, 1)) == {
+        "M": 3,
+        "D": 0,
+        "A": 3,
+        "N": 1,
+    }
+
+
+def test_year_month_iteration_and_lock_boundary():
+    assert list(iter_year_months(date(2026, 11, 4), date(2027, 2, 8))) == [
+        (2026, 11),
+        (2026, 12),
+        (2027, 1),
+        (2027, 2),
+    ]
+    assert roster_month_is_locked(2026, 8, date(2026, 6, 20)) is True
+    assert roster_month_is_locked(2026, 8, date(2026, 6, 19)) is False
+
+
+def test_assignment_snapshot_normalisation_is_order_independent():
+    first = {"staff_id": 2, "day": "2026-08-02", "code": "M"}
+    second = {"staff_id": 1, "day": "2026-08-01", "code": "A", "annotation": None}
+    assert normalise_assignment_snapshot(
+        [first, second]
+    ) == normalise_assignment_snapshot([second, first])


### PR DESCRIPTION
## What changed

- moved pure roster date, pattern, staffing, locking and publication calculations into `roster_logic.py`
- retained compatibility wrappers in `app.py` so existing routes and callers keep the same interface
- fixed legacy shift-pattern multipliers such as `2xM`, which were previously uppercased and then missed by a case-sensitive matcher
- added focused tests for leap months, pattern expansion, overnight shifts, weekend requirements, month boundaries and publication snapshots
- included the new module in formatting, lint, security and compile checks

## Why

This is phase two of reducing the Flask monolith. The extracted logic can now be tested without loading the web app or database.

## Validation

- Ruff formatting and lint checks pass
- focused roster tests: 6 passed
- full suite: 190 passed, 2 skipped