### PR TITLE
Split absence and request calculations

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -20,14 +20,14 @@ jobs:
       - run: pip install -r requirements-dev.txt
       - name: Formatting, lint and static analysis
         run: |
-          ruff format --check atcroster rate_limiting.py reporting.py roster_logic.py platform_provisioning.py signup_locking.py scripts/migrate_all_databases.py scripts/run_provisioning_worker.py auth_blueprint.py
-          ruff check atcroster app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py reporting.py roster_logic.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts/*.py
+          ruff format --check atcroster absence_requests.py rate_limiting.py reporting.py roster_logic.py platform_provisioning.py signup_locking.py scripts/migrate_all_databases.py scripts/run_provisioning_worker.py auth_blueprint.py
+          ruff check atcroster absence_requests.py app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py reporting.py roster_logic.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts/*.py
           mypy --ignore-missing-imports --follow-imports=skip atcroster rate_limiting.py signup_locking.py
       - run: pip-audit -r requirements-prod.txt
       - name: Full maintained-application security scan
         run: |
-          bandit -q -ll -r atcroster app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py reporting.py roster_logic.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts
-      - run: python -m compileall -q atcroster app.py auth_blueprint.py briefing_module.py briefing_storage.py reporting.py roster_logic.py saas_models.py tenancy.py account_limits.py scripts
+          bandit -q -ll -r atcroster absence_requests.py app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py reporting.py roster_logic.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts
+      - run: python -m compileall -q atcroster absence_requests.py app.py auth_blueprint.py briefing_module.py briefing_storage.py reporting.py roster_logic.py saas_models.py tenancy.py account_limits.py scripts
       - run: python -m pytest --cov --cov-report=term-missing -q
       - name: Verify fresh split migrations
         run: |

--- a/absence_requests.py
+++ b/absence_requests.py
@@ -1,0 +1,82 @@
+"""Pure absence grouping and shift-request date rules."""
+
+from __future__ import annotations
+
+import re
+from datetime import date, timedelta
+from typing import Iterable
+
+
+def group_sickness_instances(assignments: Iterable, month_start=None, month_end=None):
+    """Group consecutive sickness assignments into display-ready instances."""
+    instances = []
+    current = None
+    for assignment in sorted(assignments, key=lambda row: (row.staff_id, row.day)):
+        continues = (
+            current
+            and current["staff_id"] == assignment.staff_id
+            and assignment.day == current["end"] + timedelta(days=1)
+        )
+        if not continues:
+            current = {
+                "staff_id": assignment.staff_id,
+                "staff": assignment.staff,
+                "start": assignment.day,
+                "end": assignment.day,
+                "days": [],
+            }
+            instances.append(current)
+        current["days"].append(assignment)
+        current["end"] = assignment.day
+    if month_start and month_end:
+        instances = [
+            instance
+            for instance in instances
+            if instance["end"] >= month_start and instance["start"] <= month_end
+        ]
+    for instance in instances:
+        instance["duration"] = (instance["end"] - instance["start"]).days + 1
+        instance["codes"] = list(dict.fromkeys(day.code for day in instance["days"]))
+    return instances
+
+
+def normalise_request_rules(months_ahead, lock_day) -> tuple[int, int]:
+    months = max(1, min(int(months_ahead or 3), 24))
+    day = max(1, min(int(lock_day or 20), 28))
+    return months, day
+
+
+def add_months(first: date, count: int) -> date:
+    index = first.year * 12 + first.month - 1 + count
+    return date(index // 12, index % 12 + 1, 1)
+
+
+def request_lock_date(year: int, month: int, lock_day: int) -> date:
+    previous_month = month - 1
+    previous_year = year
+    if previous_month <= 0:
+        previous_month = 12
+        previous_year -= 1
+    return date(previous_year, previous_month, lock_day)
+
+
+def request_month_is_locked(
+    year: int,
+    month: int,
+    lock_day: int,
+    today: date | None = None,
+) -> bool:
+    return (today or date.today()) >= request_lock_date(year, month, lock_day)
+
+
+def request_date_bounds(today: date, months_ahead: int) -> tuple[date, date]:
+    start = add_months(date(today.year, today.month, 1), 1)
+    return start, add_months(start, months_ahead) - timedelta(days=1)
+
+
+def safe_admin_month(raw_value: str | None, fallback: date) -> str:
+    """Return a canonical admin month without allowing malformed redirects."""
+    candidate = (raw_value or "").strip()
+    if not re.fullmatch(r"\d{4}-(0[1-9]|1[0-2])", candidate):
+        return f"{fallback.year:04d}-{fallback.month:02d}"
+    return candidate

--- a/app.py
+++ b/app.py
@@ -57,6 +57,15 @@ from roster_logic import (
     shift_minutes,
     validated_pattern,
 )
+from absence_requests import (
+    add_months as add_request_months,
+    group_sickness_instances,
+    normalise_request_rules,
+    request_date_bounds,
+    request_lock_date,
+    request_month_is_locked,
+    safe_admin_month,
+)
 from atcroster import create_app, get_runtime_settings
 from tenancy import (
     authenticated_unit_id,
@@ -6523,42 +6532,7 @@ def change_log_page():
 
 
 def _group_sickness_instances(assignments, month_start=None, month_end=None):
-    """Group consecutive sickness assignments into human-readable instances."""
-    instances = []
-    current = None
-    for assignment in sorted(
-        assignments, key=lambda row: (row.staff_id, row.day)
-    ):
-        continues = (
-            current
-            and current["staff_id"] == assignment.staff_id
-            and assignment.day == current["end"] + timedelta(days=1)
-        )
-        if not continues:
-            current = {
-                "staff_id": assignment.staff_id,
-                "staff": assignment.staff,
-                "start": assignment.day,
-                "end": assignment.day,
-                "days": [],
-            }
-            instances.append(current)
-        current["days"].append(assignment)
-        current["end"] = assignment.day
-    if month_start and month_end:
-        instances = [
-            instance for instance in instances
-            if instance["end"] >= month_start
-            and instance["start"] <= month_end
-        ]
-    for instance in instances:
-        instance["duration"] = (
-            instance["end"] - instance["start"]
-        ).days + 1
-        instance["codes"] = list(dict.fromkeys(
-            day.code for day in instance["days"]
-        ))
-    return instances
+    return group_sickness_instances(assignments, month_start, month_end)
 
 
 @app.route("/leave", methods=["GET", "POST"])
@@ -8329,36 +8303,29 @@ def report_sickness():
 
 def _unit_request_rules(unit_id: int | None = None) -> tuple[int, int]:
     unit = db.session.get(Unit, unit_id or _current_unit_id())
-    months = max(1, min(int(getattr(unit, "request_months_ahead", 3) or 3), 24))
-    lock_day = max(1, min(int(getattr(unit, "request_lock_day", 20) or 20), 28))
-    return months, lock_day
+    return normalise_request_rules(
+        getattr(unit, "request_months_ahead", 3),
+        getattr(unit, "request_lock_day", 20),
+    )
 
 
 def _lock_date_for_target_month(y: int, m: int, unit_id: int | None = None):
     _, lock_day = _unit_request_rules(unit_id)
-    prev_m = m - 1
-    prev_y = y
-    if prev_m <= 0:
-        prev_m = 12
-        prev_y -= 1
-    return date(prev_y, prev_m, lock_day)
+    return request_lock_date(y, m, lock_day)
 
 
 def _is_month_locked(y: int, m: int, today: date | None = None, unit_id: int | None = None):
-    today = today or date.today()
-    return today >= _lock_date_for_target_month(y, m, unit_id)
+    _, lock_day = _unit_request_rules(unit_id)
+    return request_month_is_locked(y, m, lock_day, today)
 
 
 def _add_months(first: date, count: int) -> date:
-    idx = first.year * 12 + first.month - 1 + count
-    return date(idx // 12, idx % 12 + 1, 1)
+    return add_request_months(first, count)
 
 
 def _request_date_bounds(today: date, unit_id: int) -> tuple[date, date]:
     months, _ = _unit_request_rules(unit_id)
-    start = _add_months(date(today.year, today.month, 1), 1)
-    next_after_window = _add_months(start, months)
-    return start, next_after_window - timedelta(days=1)
+    return request_date_bounds(today, months)
 
 
 def _request_audit(req: ShiftRequest, actor_id: int, transition: str,
@@ -8397,11 +8364,7 @@ def _notify_requester(req: ShiftRequest) -> None:
 
 
 def _safe_request_admin_month(raw_value: str | None, fallback: date) -> str:
-    """Return a canonical admin month without allowing malformed redirects."""
-    candidate = (raw_value or "").strip()
-    if not re.fullmatch(r"\d{4}-(0[1-9]|1[0-2])", candidate):
-        return f"{fallback.year:04d}-{fallback.month:02d}"
-    return candidate
+    return safe_admin_month(raw_value, fallback)
 
 
 def staff_has_qualification(

--- a/tests/test_absence_requests.py
+++ b/tests/test_absence_requests.py
@@ -1,0 +1,62 @@
+from datetime import date
+from types import SimpleNamespace
+
+from absence_requests import (
+    group_sickness_instances,
+    normalise_request_rules,
+    request_date_bounds,
+    request_lock_date,
+    request_month_is_locked,
+    safe_admin_month,
+)
+
+
+def _sickness(staff_id, day, code="SC"):
+    return SimpleNamespace(
+        staff_id=staff_id,
+        staff=SimpleNamespace(id=staff_id),
+        day=day,
+        code=code,
+    )
+
+
+def test_sickness_instances_group_consecutive_days_per_person():
+    instances = group_sickness_instances(
+        [
+            _sickness(1, date(2026, 7, 2), "SSC"),
+            _sickness(2, date(2026, 7, 1)),
+            _sickness(1, date(2026, 7, 1)),
+            _sickness(1, date(2026, 7, 4)),
+        ]
+    )
+    assert [(item["staff_id"], item["duration"]) for item in instances] == [
+        (1, 2),
+        (1, 1),
+        (2, 1),
+    ]
+    assert instances[0]["codes"] == ["SC", "SSC"]
+
+
+def test_request_rules_are_clamped_to_safe_ranges():
+    assert normalise_request_rules(0, 0) == (3, 20)
+    assert normalise_request_rules(99, 31) == (24, 28)
+
+
+def test_request_window_starts_next_month_and_crosses_year_boundary():
+    assert request_date_bounds(date(2026, 11, 20), 3) == (
+        date(2026, 12, 1),
+        date(2027, 2, 28),
+    )
+
+
+def test_request_lock_date_and_boundary_cross_year():
+    assert request_lock_date(2027, 1, 20) == date(2026, 12, 20)
+    assert request_month_is_locked(2027, 1, 20, date(2026, 12, 20)) is True
+    assert request_month_is_locked(2027, 1, 20, date(2026, 12, 19)) is False
+
+
+def test_safe_admin_month_rejects_malformed_redirect_values():
+    fallback = date(2026, 7, 31)
+    assert safe_admin_month("2027-01", fallback) == "2027-01"
+    assert safe_admin_month("//external.example", fallback) == "2026-07"
+    assert safe_admin_month("2027-13", fallback) == "2026-07"


### PR DESCRIPTION
## What changed

- moved sickness-instance grouping and shift-request date rules into `absence_requests.py`
- retained compatibility wrappers in `app.py` so routes and templates are unchanged
- added direct coverage for sickness grouping, configured rule limits, cross-year request windows, lock boundaries, and safe admin-month redirects
- included the new module in formatting, lint, security and compile checks

## Why

This is phase three of reducing the Flask monolith. These calculations are now independently testable and no longer tied to route handling.

## Validation

- Ruff formatting and lint checks pass
- focused absence/request tests: 5 passed
- full suite: 195 passed, 2 skipped