### PR TITLE
Split access policy from app routes

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -20,14 +20,14 @@ jobs:
       - run: pip install -r requirements-dev.txt
       - name: Formatting, lint and static analysis
         run: |
-          ruff format --check atcroster absence_requests.py rate_limiting.py reporting.py roster_logic.py platform_provisioning.py signup_locking.py scripts/migrate_all_databases.py scripts/run_provisioning_worker.py auth_blueprint.py
-          ruff check atcroster absence_requests.py app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py reporting.py roster_logic.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts/*.py
+          ruff format --check atcroster absence_requests.py access_policy.py rate_limiting.py reporting.py roster_logic.py platform_provisioning.py signup_locking.py scripts/migrate_all_databases.py scripts/run_provisioning_worker.py auth_blueprint.py
+          ruff check atcroster absence_requests.py access_policy.py app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py reporting.py roster_logic.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts/*.py
           mypy --ignore-missing-imports --follow-imports=skip atcroster rate_limiting.py signup_locking.py
       - run: pip-audit -r requirements-prod.txt
       - name: Full maintained-application security scan
         run: |
-          bandit -q -ll -r atcroster absence_requests.py app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py reporting.py roster_logic.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts
-      - run: python -m compileall -q atcroster absence_requests.py app.py auth_blueprint.py briefing_module.py briefing_storage.py reporting.py roster_logic.py saas_models.py tenancy.py account_limits.py scripts
+          bandit -q -ll -r atcroster absence_requests.py access_policy.py app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py reporting.py roster_logic.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts
+      - run: python -m compileall -q atcroster absence_requests.py access_policy.py app.py auth_blueprint.py briefing_module.py briefing_storage.py reporting.py roster_logic.py saas_models.py tenancy.py account_limits.py scripts
       - run: python -m pytest --cov --cov-report=term-missing -q
       - name: Verify fresh split migrations
         run: |

--- a/access_policy.py
+++ b/access_policy.py
@@ -1,0 +1,84 @@
+"""Central role and unit-permission policy for ATCRoster."""
+
+from __future__ import annotations
+
+import json
+
+
+def is_admin(user) -> bool:
+    return bool(
+        getattr(user, "is_admin", False) or getattr(user, "role", "") == "admin"
+    )
+
+
+def is_editor(user) -> bool:
+    return getattr(user, "role", "") in ("editor", "admin")
+
+
+def permissions_for(user) -> dict[str, bool]:
+    try:
+        raw = json.loads(getattr(user, "permissions_json", "") or "{}")
+    except TypeError, ValueError, json.JSONDecodeError:
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    return {str(key): bool(value) for key, value in raw.items() if isinstance(key, str)}
+
+
+def has_permission(user, permission: str) -> bool:
+    return bool(permissions_for(user).get(permission, False))
+
+
+def is_trainee(user) -> bool:
+    return bool(
+        getattr(user, "is_trainee", False)
+        or getattr(user, "tower_ut", False)
+        or getattr(user, "radar_ut", False)
+        or getattr(user, "met_ut", False)
+    )
+
+
+def may_record_training(user) -> bool:
+    return bool(
+        is_admin(user)
+        or getattr(user, "has_ojti", False)
+        or getattr(user, "has_assessor", False)
+    )
+
+
+def may_manage_training(user) -> bool:
+    return bool(
+        is_admin(user)
+        or getattr(user, "has_assessor", False)
+        or getattr(user, "is_wm", False)
+        or getattr(user, "is_dwm", False)
+    )
+
+
+def may_edit_roster(user) -> bool:
+    return bool(
+        is_admin(user)
+        or is_editor(user)
+        or (
+            (getattr(user, "is_wm", False) or getattr(user, "is_dwm", False))
+            and has_permission(user, "edit_roster")
+        )
+    )
+
+
+def may_apply_annotations(user) -> bool:
+    return bool(
+        is_admin(user) or is_editor(user) or has_permission(user, "apply_annotations")
+    )
+
+
+def may_send_unit_messages(user) -> bool:
+    return bool(
+        is_admin(user)
+        or getattr(user, "is_wm", False)
+        or getattr(user, "is_dwm", False)
+    )
+
+
+def may_override_roster_conflicts(user) -> bool:
+    return is_admin(user) or has_permission(user, "override_roster_conflicts")

--- a/app.py
+++ b/app.py
@@ -66,6 +66,19 @@ from absence_requests import (
     request_month_is_locked,
     safe_admin_month,
 )
+from access_policy import (
+    has_permission,
+    is_admin,
+    is_editor,
+    is_trainee,
+    may_apply_annotations,
+    may_edit_roster,
+    may_manage_training,
+    may_override_roster_conflicts,
+    may_record_training,
+    may_send_unit_messages,
+    permissions_for,
+)
 from atcroster import create_app, get_runtime_settings
 from tenancy import (
     authenticated_unit_id,
@@ -2257,51 +2270,31 @@ _load_month_roster_fast = _memoize(seconds=300)(_load_month_roster_core)
 
 
 def is_admin_user(u) -> bool:
-    return bool(getattr(u, "is_admin", False) or getattr(u, "role", "") == "admin")
+    return is_admin(u)
 
 
 def is_editor_user(u) -> bool:
-    # admin counts as editor
-    return getattr(u, "role", "") in ("editor", "admin")
+    return is_editor(u)
 
 
 def user_permissions(u) -> dict[str, bool]:
-    try:
-        raw = json.loads(getattr(u, "permissions_json", "") or "{}")
-    except (TypeError, ValueError, json.JSONDecodeError):
-        return {}
-    return {
-        str(key): bool(value)
-        for key, value in raw.items()
-        if isinstance(key, str)
-    } if isinstance(raw, dict) else {}
+    return permissions_for(u)
 
 
 def has_unit_permission(u, permission: str) -> bool:
-    return bool(user_permissions(u).get(permission, False))
+    return has_permission(u, permission)
 
 
 def is_under_training(person) -> bool:
-    return bool(
-        getattr(person, "is_trainee", False)
-        or getattr(person, "tower_ut", False)
-        or getattr(person, "radar_ut", False)
-        or getattr(person, "met_ut", False)
-    )
+    return is_trainee(person)
 
 
 def can_record_training(u) -> bool:
-    return bool(
-        is_admin_user(u) or getattr(u, "has_ojti", False)
-        or getattr(u, "has_assessor", False)
-    )
+    return may_record_training(u)
 
 
 def can_manage_training(u) -> bool:
-    return bool(
-        is_admin_user(u) or getattr(u, "has_assessor", False)
-        or getattr(u, "is_wm", False) or getattr(u, "is_dwm", False)
-    )
+    return may_manage_training(u)
 
 
 def training_enabled(unit_id: int) -> bool:
@@ -2320,39 +2313,19 @@ def competency_enabled(unit_id: int) -> bool:
 
 
 def can_edit_roster(u) -> bool:
-    return (
-        is_admin_user(u)
-        or is_editor_user(u)
-        or (
-            (
-                bool(getattr(u, "is_wm", False))
-                or bool(getattr(u, "is_dwm", False))
-            )
-            and has_unit_permission(u, "edit_roster")
-        )
-    )
+    return may_edit_roster(u)
 
 
 def can_apply_annotations(u) -> bool:
-    return (
-        is_admin_user(u)
-        or is_editor_user(u)
-        or has_unit_permission(u, "apply_annotations")
-    )
+    return may_apply_annotations(u)
 
 
 def can_send_unit_messages(u) -> bool:
-    return bool(
-        is_admin_user(u)
-        or getattr(u, "is_wm", False)
-        or getattr(u, "is_dwm", False)
-    )
+    return may_send_unit_messages(u)
 
 
 def can_override_roster_conflicts(u) -> bool:
-    return is_admin_user(u) or has_unit_permission(
-        u, "override_roster_conflicts"
-    )
+    return may_override_roster_conflicts(u)
 
 
 def tenant_get(model, record_id: int):

--- a/tests/test_access_policy.py
+++ b/tests/test_access_policy.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+
+from access_policy import (
+    has_permission,
+    is_admin,
+    may_apply_annotations,
+    may_edit_roster,
+    may_manage_training,
+    may_override_roster_conflicts,
+    permissions_for,
+)
+
+
+def _user(**values):
+    defaults = {
+        "role": "viewer",
+        "is_admin": False,
+        "is_wm": False,
+        "is_dwm": False,
+        "has_assessor": False,
+        "permissions_json": "{}",
+    }
+    defaults.update(values)
+    return SimpleNamespace(**defaults)
+
+
+def test_admin_role_and_legacy_admin_flag_are_both_recognised():
+    assert is_admin(_user(role="admin")) is True
+    assert is_admin(_user(is_admin=True)) is True
+    assert is_admin(_user(role="editor")) is False
+
+
+def test_invalid_or_non_object_permissions_default_to_deny():
+    assert permissions_for(_user(permissions_json="not-json")) == {}
+    assert permissions_for(_user(permissions_json='["edit_roster"]')) == {}
+    assert has_permission(_user(), "edit_roster") is False
+
+
+def test_watch_manager_needs_explicit_permission_to_edit_roster():
+    assert may_edit_roster(_user(is_wm=True)) is False
+    assert (
+        may_edit_roster(_user(is_wm=True, permissions_json='{"edit_roster": true}'))
+        is True
+    )
+
+
+def test_annotation_and_conflict_permissions_are_independent():
+    annotation_user = _user(permissions_json='{"apply_annotations": true}')
+    override_user = _user(permissions_json='{"override_roster_conflicts": true}')
+    assert may_apply_annotations(annotation_user) is True
+    assert may_override_roster_conflicts(annotation_user) is False
+    assert may_override_roster_conflicts(override_user) is True
+
+
+def test_operational_manager_can_manage_training_without_admin_role():
+    assert may_manage_training(_user(is_dwm=True)) is True


### PR DESCRIPTION
## What changed

- centralized role and unit-permission decisions in `access_policy.py`
- retained compatibility wrappers in `app.py` so route behaviour and callers remain unchanged
- added direct tests for admin compatibility, default-deny malformed permissions, watch-manager roster editing, independent elevated permissions, and training management
- included the new module in formatting, lint, security and compile checks

## Why

This is phase four of reducing the Flask monolith. Centralizing authorization policy makes security decisions easier to audit and test consistently.

## Validation

- Ruff formatting and lint checks pass
- focused access-policy tests: 5 passed
- full suite: 200 passed, 2 skipped