### PR TITLE
Extract report routes into blueprint

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -20,14 +20,14 @@ jobs:
       - run: pip install -r requirements-dev.txt
       - name: Formatting, lint and static analysis
         run: |
-          ruff format --check atcroster absence_requests.py access_policy.py rate_limiting.py reporting.py roster_logic.py platform_provisioning.py signup_locking.py scripts/migrate_all_databases.py scripts/run_provisioning_worker.py auth_blueprint.py
-          ruff check atcroster absence_requests.py access_policy.py app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py reporting.py roster_logic.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts/*.py
+          ruff format --check atcroster absence_requests.py access_policy.py rate_limiting.py reporting.py reports_blueprint.py roster_logic.py platform_provisioning.py signup_locking.py scripts/migrate_all_databases.py scripts/run_provisioning_worker.py auth_blueprint.py
+          ruff check atcroster absence_requests.py access_policy.py app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py reporting.py reports_blueprint.py roster_logic.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts/*.py
           mypy --ignore-missing-imports --follow-imports=skip atcroster rate_limiting.py signup_locking.py
       - run: pip-audit -r requirements-prod.txt
       - name: Full maintained-application security scan
         run: |
-          bandit -q -ll -r atcroster absence_requests.py access_policy.py app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py reporting.py roster_logic.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts
-      - run: python -m compileall -q atcroster absence_requests.py access_policy.py app.py auth_blueprint.py briefing_module.py briefing_storage.py reporting.py roster_logic.py saas_models.py tenancy.py account_limits.py scripts
+          bandit -q -ll -r atcroster absence_requests.py access_policy.py app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py reporting.py reports_blueprint.py roster_logic.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts
+      - run: python -m compileall -q atcroster absence_requests.py access_policy.py app.py auth_blueprint.py briefing_module.py briefing_storage.py reporting.py reports_blueprint.py roster_logic.py saas_models.py tenancy.py account_limits.py scripts
       - run: python -m pytest --cov --cov-report=term-missing -q
       - name: Verify fresh split migrations
         run: |

--- a/app.py
+++ b/app.py
@@ -7320,44 +7320,6 @@ def _fy_start_for(d: date) -> date:
     return financial_year_start(d)
 
 
-def _reports_acknowledgement_key() -> str:
-    return f"{current_user.id}:{_current_unit_id()}"
-
-
-def _reports_sensitive_data_acknowledged() -> bool:
-    return session.get("reports_sensitive_data_ack") == _reports_acknowledgement_key()
-
-
-def _require_reports_sensitive_data_acknowledgement():
-    if _reports_sensitive_data_acknowledged():
-        return None
-    return redirect(url_for("reports_index"))
-
-
-@app.route("/metrics")
-@login_required
-def metrics():
-    if not (is_admin_user(current_user) or getattr(current_user, "role", "") in ("editor", "admin")):
-        abort(403)
-    acknowledgement = _require_reports_sensitive_data_acknowledgement()
-    if acknowledgement:
-        return acknowledgement
-    # ... existing body unchanged ...
-    today = date.today()
-    default_start = _fy_start_for(today)
-    start_str = request.args.get("start", default_start.isoformat())
-    end_str = request.args.get("end", today.isoformat())
-    start_day = date.fromisoformat(start_str)
-    end_day = date.fromisoformat(end_str)
-    staff_metrics, totals, annotation_columns = _compute_metrics_range(
-        start_day, end_day
-    )
-    return render_template("metrics.html",
-                           start=start_day, end=end_day,
-                           staff_metrics=staff_metrics, totals=totals,
-                           annotation_columns=annotation_columns)
-
-
 def _count_aava_soal_since_prev_april(staff_id: int, upto: date):
     start = date(upto.year if upto.month >= 4 else upto.year - 1, 4, 1)
     q = (Assignment.query
@@ -7420,62 +7382,6 @@ def _has_in_date_ue(s: Staff, ref_day: date) -> bool:
     tower_ok = valid(s.tower_ue_expiry, s.tower_ut)
     radar_ok = valid(s.radar_ue_expiry, s.radar_ut)
     return tower_ok or radar_ok
-
-
-@app.route("/metrics/export")
-@login_required
-def metrics_export():
-    if not _consume_rate_limit(
-        "metrics-export", current_user.id, limit=20,
-        window=timedelta(hours=1),
-    ):
-        abort(429)
-    if not is_admin_user(current_user):
-        abort(403)
-    acknowledgement = _require_reports_sensitive_data_acknowledgement()
-    if acknowledgement:
-        return acknowledgement
-    today = date.today()
-    default_start = _fy_start_for(today)
-    start_day = date.fromisoformat(
-        request.args.get("start", default_start.isoformat()))
-    end_day = date.fromisoformat(request.args.get("end", today.isoformat()))
-    staff_metrics, totals, annotation_columns = _compute_metrics_range(
-        start_day, end_day
-    )
-
-    output = io.StringIO()
-    w = csv.writer(output)
-    header = ["ATCO", "Staff #", "Watch"]
-    header.extend([
-        f"{column['label']} ({column['code']})"
-        for column in annotation_columns
-    ])
-    w.writerow(header)
-    for row in staff_metrics:
-        s = row["staff"]
-        watch = s.watch.name.replace("Watch ", "") if s.watch else "-"
-        annotation_values = [
-            row["annotations"].get(column["code"], 0)
-            for column in annotation_columns
-        ]
-        w.writerow([s.name, s.staff_no, watch] + annotation_values)
-    w.writerow([])
-    total_row = ["All ATCOs", "", ""]
-    total_row.extend([
-        totals["annotations"].get(column["code"], 0)
-        for column in annotation_columns
-    ])
-    w.writerow(total_row)
-
-    csv_bytes = output.getvalue().encode("utf-8")
-    filename = (
-        f"annotation-totals_{start_day.isoformat()}_to_"
-        f"{end_day.isoformat()}.csv"
-    )
-    return Response(csv_bytes,
-                    mimetype="text/csv; charset=utf-8",
-                    headers={"Content-Disposition": f"attachment; filename={filename}"})
 
 
 # -------------------- Overtime finder (admin/editor) --------------------
@@ -8033,87 +7939,6 @@ def _leave_summary_for_month(year: int, month: int, watch_id: int | None = None)
     )
 
 
-def _report_watch_selection():
-    unit_id = _current_unit_id()
-    watches = (
-        Watch.query
-        .filter(Watch.unit_id == unit_id)
-        .order_by(Watch.order_index, Watch.name)
-        .all()
-    )
-    raw_watch_id = (request.args.get("watch_id") or "").strip()
-    if not raw_watch_id:
-        return watches, None
-    try:
-        watch_id = int(raw_watch_id)
-    except ValueError:
-        abort(400, "Invalid watch.")
-    selected_watch = next((watch for watch in watches if watch.id == watch_id), None)
-    if selected_watch is None:
-        abort(404)
-    return watches, selected_watch
-
-
-@app.route("/reports/leave/<ym>")
-@login_required
-def report_leave(ym):
-    if not is_admin_user(current_user):
-        abort(403)
-    acknowledgement = _require_reports_sensitive_data_acknowledgement()
-    if acknowledgement:
-        return acknowledgement
-    year, month = parse_ym(ym)
-    ensure_month_requirement(year, month)
-    generate_month(year, month)
-    watches, selected_watch = _report_watch_selection()
-    rows, codes, totals, grand_total, days = _leave_summary_for_month(
-        year, month, selected_watch.id if selected_watch else None)
-    month_title = datetime(year, month, 1).strftime("%B %Y")
-    return render_template("report_leave.html",
-                           ym=ym, year=year, month=month, month_title=month_title,
-                           rows=rows, codes=codes,
-                           totals=totals, grand_total=grand_total,
-                           watches=watches, selected_watch=selected_watch)
-
-
-@app.route("/reports/leave.csv")
-@login_required
-def report_leave_csv():
-    if not is_admin_user(current_user):
-        abort(403)
-    acknowledgement = _require_reports_sensitive_data_acknowledgement()
-    if acknowledgement:
-        return acknowledgement
-    ym = request.args.get("ym")
-    if not ym:
-        abort(400)
-    year, month = parse_ym(ym)
-    ensure_month_requirement(year, month)
-    generate_month(year, month)
-    watches, selected_watch = _report_watch_selection()
-    rows, codes, totals, grand_total, days = _leave_summary_for_month(
-        year, month, selected_watch.id if selected_watch else None)
-
-    output = io.StringIO()
-    w = csv.writer(output)
-    w.writerow(["Name", "Staff #", "Watch", *codes, "Total"])
-    for r in rows:
-        s = r["staff"]
-        watch = s.watch.name.replace("Watch ", "") if s.watch else "-"
-        w.writerow([s.name, s.staff_no, watch, *[r["counts"].get(c, 0)
-                   for c in codes], r["total"]])
-    w.writerow([])
-    w.writerow(["Totals", "", "", *[totals.get(c, 0)
-               for c in codes], grand_total])
-
-    csv_bytes = output.getvalue().encode("utf-8")
-    watch_suffix = f"_watch-{selected_watch.id}" if selected_watch else ""
-    filename = f"leave_{year:04d}-{month:02d}{watch_suffix}.csv"
-    return Response(csv_bytes,
-                    mimetype="text/csv; charset=utf-8",
-                    headers={"Content-Disposition": f"attachment; filename={filename}"})
-
-
 # ===== Leave-Year report (per-person config; AL only; includes TOIL days) =====
 # (unchanged from your post)
 
@@ -8160,115 +7985,11 @@ def _toil_accrued_used_in_range_half_days(staff_id: int, start_day: date, end_da
     return acc, use
 
 
-@app.route("/reports/leave-year")
-@login_required
-def report_leave_year():
-    if not is_admin_user(current_user):
-        abort(403)
-    acknowledgement = _require_reports_sensitive_data_acknowledgement()
-    if acknowledgement:
-        return acknowledgement
-    today = date.today()
-    unit_id = _current_unit_id()
-    watches, selected_watch = _report_watch_selection()
-    people_query = (
-        Staff.query
-        .filter(Staff.unit_id == unit_id)
-        .outerjoin(Watch, Staff.watch_id == Watch.id)
-    )
-    if selected_watch:
-        people_query = people_query.filter(Staff.watch_id == selected_watch.id)
-    people = people_query.order_by(Watch.order_index, Staff.name).all()
-    rows = []
-    for s in people:
-        start, end = _current_leave_year_window(s, today)
-        q = (Assignment.query
-             .filter(Assignment.staff_id == s.id,
-                     Assignment.day >= start,
-                     Assignment.day <= end))
-        al_taken = sum(1 for a in q.all() if a.code == "AL")
-        entitlement = (s.leave_entitlement_days or 0)
-        ph = (s.leave_public_holidays or 0)
-        carry = (s.leave_carryover_days or 0)
-        remaining = entitlement + ph + carry - al_taken
-        acc_half, use_half = _toil_accrued_used_in_range_half_days(
-            s.id, start, end)
-        rows.append({
-            "staff": s,
-            "watch": s.watch.name.replace("Watch ", "") if s.watch else "-",
-            "leave_year_start": start,
-            "leave_year_end": end,
-            "entitlement": entitlement,
-            "public_holidays": ph,
-            "carryover": carry,
-            "al_taken": al_taken,
-            "remaining": remaining,
-            "toil_accrued_days": acc_half / 2.0,
-            "toil_used_days": use_half / 2.0,
-            "toil_balance_days": (s.toil_half_days or 0) / 2.0,
-        })
-    return render_template(
-        "report_leave_year.html",
-        rows=rows,
-        today=today,
-        watches=watches,
-        selected_watch=selected_watch,
-    )
-
-
 # ===== Sickness Report (unchanged) =====
 
 
 def _group_consecutive_days(days_set):
     return group_consecutive_days(days_set)
-
-
-@app.route("/reports/sickness")
-@login_required
-def report_sickness():
-    if not is_admin_user(current_user):
-        abort(403)
-    acknowledgement = _require_reports_sensitive_data_acknowledgement()
-    if acknowledgement:
-        return acknowledgement
-    today = date.today()
-    start = today - timedelta(days=365)
-    unit_id = _current_unit_id()
-    watches, selected_watch = _report_watch_selection()
-    people_query = (
-        Staff.query
-        .filter(Staff.unit_id == unit_id)
-        .outerjoin(Watch, Staff.watch_id == Watch.id)
-    )
-    if selected_watch:
-        people_query = people_query.filter(Staff.watch_id == selected_watch.id)
-    people = people_query.order_by(Watch.order_index, Staff.name).all()
-    sickness_types = get_absence_types("sickness", active_only=True)
-    codes = [item["code"] for item in sickness_types]
-    rows = []
-    totals = Counter()
-    for s in people:
-        q = (Assignment.query
-             .filter(Assignment.unit_id == unit_id,
-                     Assignment.staff_id == s.id,
-                     Assignment.day >= start,
-                     Assignment.day <= today))
-        assignments = [a for a in q.all() if a.code in codes]
-        sick_days = sorted(a.day for a in assignments)
-        counts = Counter(a.code for a in assignments)
-        totals.update(counts)
-        total = len(sick_days)
-        groups = _group_consecutive_days(set(sick_days))
-        rows.append({
-            "staff": s, "watch": s.watch.name.replace("Watch ", "") if s.watch else "-",
-            "total": total, "groups": groups, "counts": counts,
-        })
-    return render_template(
-        "report_sickness.html", start=start, end=today, rows=rows,
-        sickness_types=sickness_types, totals=totals,
-        watches=watches, selected_watch=selected_watch,
-        has_sickness=any(row["total"] > 0 for row in rows),
-    )
 
 
 # -------------------- Request Sheets (shift requests) --------------------
@@ -10753,72 +10474,6 @@ def admin_toil_new():
         return redirect(url_for("admin_toil_new"))
     return render_template("admin_toil_new.html", atcos=atcos)
 
-# -------------------- Reports hub --------------------
-
-
-@app.route("/reports", methods=["GET", "POST"])
-@login_required
-def reports_index():
-    can_view_reports = (
-        is_admin_user(current_user)
-        or getattr(current_user, "role", "") in ("editor", "admin")
-    )
-    if not can_view_reports:
-        abort(403)
-
-    if request.method == "POST":
-        _validate_csrf()
-        session["reports_sensitive_data_ack"] = _reports_acknowledgement_key()
-        # Permit exactly the redirect that opens the reports hub. A later
-        # navigation back to /reports is a new entry and must show the privacy
-        # warning again.
-        session["reports_sensitive_data_hub_entry"] = _reports_acknowledgement_key()
-        return redirect(url_for("reports_index"))
-
-    if not _reports_sensitive_data_acknowledged():
-        return render_template(
-            "reports_index.html",
-            requires_acknowledgement=True,
-        )
-
-    hub_entry_key = session.pop("reports_sensitive_data_hub_entry", None)
-    if hub_entry_key != _reports_acknowledgement_key():
-        session.pop("reports_sensitive_data_ack", None)
-        return render_template(
-            "reports_index.html",
-            requires_acknowledgement=True,
-        )
-
-    # Admin: show the hub
-    if is_admin_user(current_user):
-        today = date.today()
-        month_title = datetime(today.year, today.month, 1).strftime("%B %Y")
-        links = {
-            "leave_year": url_for("report_leave_year"),
-            "sickness": url_for("report_sickness"),
-            "roster": url_for("roster_month", ym=f"{today.year}-{today.month:02d}"),
-            "metrics": url_for("metrics"),
-        }
-        months = []  # hide month selector
-        return render_template(
-            "reports_index.html",
-            ym=f"{today.year}-{today.month:02d}",
-            year=today.year,
-            month=today.month,
-            month_title=month_title,
-            months=months,
-            links=links,
-            page_title="Annotation Totals",
-            requires_acknowledgement=False,
-        )
-
-    # Editor: annotation totals only
-    if getattr(current_user, "role", "") in ("editor", "admin"):
-        return redirect(url_for("metrics"))
-
-    abort(403)
-
-
 LOGIN_RATE_WINDOW = timedelta(minutes=15)
 LOGIN_RATE_LIMIT = 10
 
@@ -11668,6 +11323,7 @@ app.jinja_env.globals['ShiftType'] = ShiftType
 # -------------------- Run --------------------
 
 from auth_blueprint import AuthDependencies, create_auth_blueprint
+from reports_blueprint import ReportsDependencies, create_reports_blueprint
 
 app.register_blueprint(create_auth_blueprint(AuthDependencies(
     db=db,
@@ -11690,6 +11346,25 @@ app.register_blueprint(create_auth_blueprint(AuthDependencies(
     airport_login_endpoint=_airport_login_endpoint,
     initialize_authenticated_session=_initialize_authenticated_session,
     record_successful_login=_record_successful_login,
+)))
+app.register_blueprint(create_reports_blueprint(ReportsDependencies(
+    Assignment=Assignment,
+    Staff=Staff,
+    Watch=Watch,
+    is_admin_user=is_admin_user,
+    current_unit_id=_current_unit_id,
+    validate_csrf=_validate_csrf,
+    consume_rate_limit=_consume_rate_limit,
+    compute_metrics_range=_compute_metrics_range,
+    financial_year_start=_fy_start_for,
+    parse_year_month=parse_ym,
+    ensure_month_requirement=ensure_month_requirement,
+    generate_month=generate_month,
+    leave_summary_for_month=_leave_summary_for_month,
+    current_leave_year_window=_current_leave_year_window,
+    toil_accrued_used=_toil_accrued_used_in_range_half_days,
+    group_consecutive_days=_group_consecutive_days,
+    get_absence_types=get_absence_types,
 )))
 app.register_blueprint(briefing_blueprint)
 

--- a/reports_blueprint.py
+++ b/reports_blueprint.py
@@ -1,0 +1,421 @@
+"""Report routes extracted from the legacy application module.
+
+The blueprint deliberately registers the historical global endpoint names so
+existing templates, redirects, bookmarks and authorization tests remain valid.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from collections import Counter
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Any, Callable
+
+from flask import (
+    Blueprint,
+    Response,
+    abort,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
+from flask_login import current_user, login_required
+
+
+@dataclass(frozen=True)
+class ReportsDependencies:
+    Assignment: Any
+    Staff: Any
+    Watch: Any
+    is_admin_user: Callable[[Any], bool]
+    current_unit_id: Callable[[], int]
+    validate_csrf: Callable[[], None]
+    consume_rate_limit: Callable[..., bool]
+    compute_metrics_range: Callable[[date, date], tuple]
+    financial_year_start: Callable[[date], date]
+    parse_year_month: Callable[[str], tuple[int, int]]
+    ensure_month_requirement: Callable[[int, int], Any]
+    generate_month: Callable[[int, int], None]
+    leave_summary_for_month: Callable[..., tuple]
+    current_leave_year_window: Callable[[Any, date | None], tuple[date, date]]
+    toil_accrued_used: Callable[[int, date, date], tuple[int, int]]
+    group_consecutive_days: Callable[[set[date]], int]
+    get_absence_types: Callable[..., list]
+
+
+def create_reports_blueprint(dependencies: ReportsDependencies) -> Blueprint:
+    blueprint = Blueprint("reports", __name__)
+
+    def acknowledgement_key() -> str:
+        return f"{current_user.id}:{dependencies.current_unit_id()}"
+
+    def sensitive_data_acknowledged() -> bool:
+        return session.get("reports_sensitive_data_ack") == acknowledgement_key()
+
+    def require_acknowledgement():
+        if sensitive_data_acknowledged():
+            return None
+        return redirect(url_for("reports_index"))
+
+    def watch_selection():
+        unit_id = dependencies.current_unit_id()
+        watches = (
+            dependencies.Watch.query.filter(dependencies.Watch.unit_id == unit_id)
+            .order_by(dependencies.Watch.order_index, dependencies.Watch.name)
+            .all()
+        )
+        raw_watch_id = (request.args.get("watch_id") or "").strip()
+        if not raw_watch_id:
+            return watches, None
+        try:
+            watch_id = int(raw_watch_id)
+        except ValueError:
+            abort(400, "Invalid watch.")
+        selected = next((watch for watch in watches if watch.id == watch_id), None)
+        if selected is None:
+            abort(404)
+        return watches, selected
+
+    @login_required
+    def metrics():
+        if not (
+            dependencies.is_admin_user(current_user)
+            or getattr(current_user, "role", "") in ("editor", "admin")
+        ):
+            abort(403)
+        if acknowledgement := require_acknowledgement():
+            return acknowledgement
+        today = date.today()
+        default_start = dependencies.financial_year_start(today)
+        start_day = date.fromisoformat(
+            request.args.get("start", default_start.isoformat())
+        )
+        end_day = date.fromisoformat(request.args.get("end", today.isoformat()))
+        staff_metrics, totals, annotation_columns = dependencies.compute_metrics_range(
+            start_day, end_day
+        )
+        return render_template(
+            "metrics.html",
+            start=start_day,
+            end=end_day,
+            staff_metrics=staff_metrics,
+            totals=totals,
+            annotation_columns=annotation_columns,
+        )
+
+    @login_required
+    def metrics_export():
+        if not dependencies.consume_rate_limit(
+            "metrics-export",
+            current_user.id,
+            limit=20,
+            window=timedelta(hours=1),
+        ):
+            abort(429)
+        if not dependencies.is_admin_user(current_user):
+            abort(403)
+        if acknowledgement := require_acknowledgement():
+            return acknowledgement
+        today = date.today()
+        default_start = dependencies.financial_year_start(today)
+        start_day = date.fromisoformat(
+            request.args.get("start", default_start.isoformat())
+        )
+        end_day = date.fromisoformat(request.args.get("end", today.isoformat()))
+        staff_metrics, totals, annotation_columns = dependencies.compute_metrics_range(
+            start_day, end_day
+        )
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow(
+            ["ATCO", "Staff #", "Watch"]
+            + [f"{column['label']} ({column['code']})" for column in annotation_columns]
+        )
+        for row in staff_metrics:
+            person = row["staff"]
+            watch = person.watch.name.replace("Watch ", "") if person.watch else "-"
+            writer.writerow(
+                [person.name, person.staff_no, watch]
+                + [
+                    row["annotations"].get(column["code"], 0)
+                    for column in annotation_columns
+                ]
+            )
+        writer.writerow([])
+        writer.writerow(
+            ["All ATCOs", "", ""]
+            + [
+                totals["annotations"].get(column["code"], 0)
+                for column in annotation_columns
+            ]
+        )
+        filename = (
+            f"annotation-totals_{start_day.isoformat()}_to_{end_day.isoformat()}.csv"
+        )
+        return Response(
+            output.getvalue().encode("utf-8"),
+            mimetype="text/csv; charset=utf-8",
+            headers={"Content-Disposition": f"attachment; filename={filename}"},
+        )
+
+    @login_required
+    def report_leave(ym):
+        if not dependencies.is_admin_user(current_user):
+            abort(403)
+        if acknowledgement := require_acknowledgement():
+            return acknowledgement
+        year, month = dependencies.parse_year_month(ym)
+        dependencies.ensure_month_requirement(year, month)
+        dependencies.generate_month(year, month)
+        watches, selected_watch = watch_selection()
+        rows, codes, totals, grand_total, _days = dependencies.leave_summary_for_month(
+            year, month, selected_watch.id if selected_watch else None
+        )
+        month_title = datetime(year, month, 1).strftime("%B %Y")
+        return render_template(
+            "report_leave.html",
+            ym=ym,
+            year=year,
+            month=month,
+            month_title=month_title,
+            rows=rows,
+            codes=codes,
+            totals=totals,
+            grand_total=grand_total,
+            watches=watches,
+            selected_watch=selected_watch,
+        )
+
+    @login_required
+    def report_leave_csv():
+        if not dependencies.is_admin_user(current_user):
+            abort(403)
+        if acknowledgement := require_acknowledgement():
+            return acknowledgement
+        ym = request.args.get("ym")
+        if not ym:
+            abort(400)
+        year, month = dependencies.parse_year_month(ym)
+        dependencies.ensure_month_requirement(year, month)
+        dependencies.generate_month(year, month)
+        watches, selected_watch = watch_selection()
+        rows, codes, totals, grand_total, _days = dependencies.leave_summary_for_month(
+            year, month, selected_watch.id if selected_watch else None
+        )
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow(["Name", "Staff #", "Watch", *codes, "Total"])
+        for row in rows:
+            person = row["staff"]
+            watch = person.watch.name.replace("Watch ", "") if person.watch else "-"
+            writer.writerow(
+                [
+                    person.name,
+                    person.staff_no,
+                    watch,
+                    *[row["counts"].get(code, 0) for code in codes],
+                    row["total"],
+                ]
+            )
+        writer.writerow([])
+        writer.writerow(
+            ["Totals", "", "", *[totals.get(code, 0) for code in codes], grand_total]
+        )
+        watch_suffix = f"_watch-{selected_watch.id}" if selected_watch else ""
+        filename = f"leave_{year:04d}-{month:02d}{watch_suffix}.csv"
+        return Response(
+            output.getvalue().encode("utf-8"),
+            mimetype="text/csv; charset=utf-8",
+            headers={"Content-Disposition": f"attachment; filename={filename}"},
+        )
+
+    @login_required
+    def report_leave_year():
+        if not dependencies.is_admin_user(current_user):
+            abort(403)
+        if acknowledgement := require_acknowledgement():
+            return acknowledgement
+        today = date.today()
+        unit_id = dependencies.current_unit_id()
+        watches, selected_watch = watch_selection()
+        people_query = dependencies.Staff.query.filter(
+            dependencies.Staff.unit_id == unit_id
+        ).outerjoin(
+            dependencies.Watch,
+            dependencies.Staff.watch_id == dependencies.Watch.id,
+        )
+        if selected_watch:
+            people_query = people_query.filter(
+                dependencies.Staff.watch_id == selected_watch.id
+            )
+        people = people_query.order_by(
+            dependencies.Watch.order_index, dependencies.Staff.name
+        ).all()
+        rows = []
+        for person in people:
+            start, end = dependencies.current_leave_year_window(person, today)
+            assignments = dependencies.Assignment.query.filter(
+                dependencies.Assignment.staff_id == person.id,
+                dependencies.Assignment.day >= start,
+                dependencies.Assignment.day <= end,
+            ).all()
+            al_taken = sum(1 for assignment in assignments if assignment.code == "AL")
+            entitlement = person.leave_entitlement_days or 0
+            public_holidays = person.leave_public_holidays or 0
+            carryover = person.leave_carryover_days or 0
+            accrued, used = dependencies.toil_accrued_used(person.id, start, end)
+            rows.append(
+                {
+                    "staff": person,
+                    "watch": person.watch.name.replace("Watch ", "")
+                    if person.watch
+                    else "-",
+                    "leave_year_start": start,
+                    "leave_year_end": end,
+                    "entitlement": entitlement,
+                    "public_holidays": public_holidays,
+                    "carryover": carryover,
+                    "al_taken": al_taken,
+                    "remaining": entitlement + public_holidays + carryover - al_taken,
+                    "toil_accrued_days": accrued / 2.0,
+                    "toil_used_days": used / 2.0,
+                    "toil_balance_days": (person.toil_half_days or 0) / 2.0,
+                }
+            )
+        return render_template(
+            "report_leave_year.html",
+            rows=rows,
+            today=today,
+            watches=watches,
+            selected_watch=selected_watch,
+        )
+
+    @login_required
+    def report_sickness():
+        if not dependencies.is_admin_user(current_user):
+            abort(403)
+        if acknowledgement := require_acknowledgement():
+            return acknowledgement
+        today = date.today()
+        start = today - timedelta(days=365)
+        unit_id = dependencies.current_unit_id()
+        watches, selected_watch = watch_selection()
+        people_query = dependencies.Staff.query.filter(
+            dependencies.Staff.unit_id == unit_id
+        ).outerjoin(
+            dependencies.Watch,
+            dependencies.Staff.watch_id == dependencies.Watch.id,
+        )
+        if selected_watch:
+            people_query = people_query.filter(
+                dependencies.Staff.watch_id == selected_watch.id
+            )
+        people = people_query.order_by(
+            dependencies.Watch.order_index, dependencies.Staff.name
+        ).all()
+        sickness_types = dependencies.get_absence_types("sickness", active_only=True)
+        codes = [item["code"] for item in sickness_types]
+        rows = []
+        totals = Counter()
+        for person in people:
+            assignments = [
+                assignment
+                for assignment in dependencies.Assignment.query.filter(
+                    dependencies.Assignment.unit_id == unit_id,
+                    dependencies.Assignment.staff_id == person.id,
+                    dependencies.Assignment.day >= start,
+                    dependencies.Assignment.day <= today,
+                ).all()
+                if assignment.code in codes
+            ]
+            sick_days = sorted(assignment.day for assignment in assignments)
+            counts = Counter(assignment.code for assignment in assignments)
+            totals.update(counts)
+            rows.append(
+                {
+                    "staff": person,
+                    "watch": person.watch.name.replace("Watch ", "")
+                    if person.watch
+                    else "-",
+                    "total": len(sick_days),
+                    "groups": dependencies.group_consecutive_days(set(sick_days)),
+                    "counts": counts,
+                }
+            )
+        return render_template(
+            "report_sickness.html",
+            start=start,
+            end=today,
+            rows=rows,
+            sickness_types=sickness_types,
+            totals=totals,
+            watches=watches,
+            selected_watch=selected_watch,
+            has_sickness=any(row["total"] > 0 for row in rows),
+        )
+
+    @login_required
+    def reports_index():
+        can_view = dependencies.is_admin_user(current_user) or getattr(
+            current_user, "role", ""
+        ) in ("editor", "admin")
+        if not can_view:
+            abort(403)
+        if request.method == "POST":
+            dependencies.validate_csrf()
+            session["reports_sensitive_data_ack"] = acknowledgement_key()
+            session["reports_sensitive_data_hub_entry"] = acknowledgement_key()
+            return redirect(url_for("reports_index"))
+        if not sensitive_data_acknowledged():
+            return render_template("reports_index.html", requires_acknowledgement=True)
+        if (
+            session.pop("reports_sensitive_data_hub_entry", None)
+            != acknowledgement_key()
+        ):
+            session.pop("reports_sensitive_data_ack", None)
+            return render_template("reports_index.html", requires_acknowledgement=True)
+        if dependencies.is_admin_user(current_user):
+            today = date.today()
+            return render_template(
+                "reports_index.html",
+                ym=f"{today.year}-{today.month:02d}",
+                year=today.year,
+                month=today.month,
+                month_title=datetime(today.year, today.month, 1).strftime("%B %Y"),
+                months=[],
+                links={
+                    "leave_year": url_for("report_leave_year"),
+                    "sickness": url_for("report_sickness"),
+                    "roster": url_for(
+                        "roster_month", ym=f"{today.year}-{today.month:02d}"
+                    ),
+                    "metrics": url_for("metrics"),
+                },
+                page_title="Annotation Totals",
+                requires_acknowledgement=False,
+            )
+        if getattr(current_user, "role", "") in ("editor", "admin"):
+            return redirect(url_for("metrics"))
+        abort(403)
+
+    @blueprint.record_once
+    def register_routes(state):
+        routes = (
+            ("/metrics", "metrics", metrics, ["GET"]),
+            ("/metrics/export", "metrics_export", metrics_export, ["GET"]),
+            ("/reports/leave/<ym>", "report_leave", report_leave, ["GET"]),
+            ("/reports/leave.csv", "report_leave_csv", report_leave_csv, ["GET"]),
+            ("/reports/leave-year", "report_leave_year", report_leave_year, ["GET"]),
+            ("/reports/sickness", "report_sickness", report_sickness, ["GET"]),
+            ("/reports", "reports_index", reports_index, ["GET", "POST"]),
+        )
+        for rule, endpoint, view_func, methods in routes:
+            state.app.add_url_rule(
+                rule, endpoint=endpoint, view_func=view_func, methods=methods
+            )
+
+    return blueprint

--- a/tests/test_reports_blueprint.py
+++ b/tests/test_reports_blueprint.py
@@ -1,0 +1,28 @@
+REPORT_ENDPOINTS = {
+    "metrics": ("/metrics", {"GET"}),
+    "metrics_export": ("/metrics/export", {"GET"}),
+    "report_leave": ("/reports/leave/<ym>", {"GET"}),
+    "report_leave_csv": ("/reports/leave.csv", {"GET"}),
+    "report_leave_year": ("/reports/leave-year", {"GET"}),
+    "report_sickness": ("/reports/sickness", {"GET"}),
+    "reports_index": ("/reports", {"GET", "POST"}),
+}
+
+
+def test_reports_blueprint_preserves_global_endpoint_contract():
+    import app
+
+    rules = {rule.endpoint: rule for rule in app.app.url_map.iter_rules()}
+    for endpoint, (path, methods) in REPORT_ENDPOINTS.items():
+        assert endpoint in rules
+        assert rules[endpoint].rule == path
+        assert methods <= rules[endpoint].methods
+        assert rules[endpoint].endpoint == endpoint
+
+
+def test_report_routes_are_no_longer_declared_in_legacy_module():
+    from pathlib import Path
+
+    source = (Path(__file__).parents[1] / "app.py").read_text()
+    for path, _methods in REPORT_ENDPOINTS.values():
+        assert f'@app.route("{path}"' not in source


### PR DESCRIPTION
## What changed

- moved all seven report and metrics route handlers into `reports_blueprint.py`
- preserved the historical global endpoint names and URLs used by templates, redirects and bookmarks
- retained the existing privacy acknowledgement, role checks, rate limit, CSV exports and watch filtering
- added architecture tests proving endpoint compatibility and preventing report routes from returning to `app.py`
- included the blueprint in formatting, lint, security and compile checks

## Why

This is the first second-stage structural split. Report calculations were already isolated, so their HTTP routes can now live in a cohesive Flask blueprint instead of the legacy application module.

## Impact

No user-facing URL or workflow changes are intended. `app.py` is 325 lines smaller.

## Validation

- Ruff formatting and lint checks pass
- Bandit security scan passes
- focused blueprint/reporting tests: 5 passed
- full suite: 202 passed, 2 skipped