### PR TITLE
Extract roster routes into blueprint

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -20,14 +20,14 @@ jobs:
       - run: pip install -r requirements-dev.txt
       - name: Formatting, lint and static analysis
         run: |
-          ruff format --check atcroster absence_requests.py access_policy.py rate_limiting.py reporting.py reports_blueprint.py roster_logic.py platform_provisioning.py signup_locking.py scripts/migrate_all_databases.py scripts/run_provisioning_worker.py auth_blueprint.py
-          ruff check atcroster absence_requests.py access_policy.py app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py reporting.py reports_blueprint.py roster_logic.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts/*.py
+          ruff format --check atcroster absence_requests.py access_policy.py rate_limiting.py reporting.py reports_blueprint.py roster_blueprint.py roster_logic.py platform_provisioning.py signup_locking.py scripts/migrate_all_databases.py scripts/run_provisioning_worker.py auth_blueprint.py
+          ruff check atcroster absence_requests.py access_policy.py app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py reporting.py reports_blueprint.py roster_blueprint.py roster_logic.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts/*.py
           mypy --ignore-missing-imports --follow-imports=skip atcroster rate_limiting.py signup_locking.py
       - run: pip-audit -r requirements-prod.txt
       - name: Full maintained-application security scan
         run: |
-          bandit -q -ll -r atcroster absence_requests.py access_policy.py app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py reporting.py reports_blueprint.py roster_logic.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts
-      - run: python -m compileall -q atcroster absence_requests.py access_policy.py app.py auth_blueprint.py briefing_module.py briefing_storage.py reporting.py reports_blueprint.py roster_logic.py saas_models.py tenancy.py account_limits.py scripts
+          bandit -q -ll -r atcroster absence_requests.py access_policy.py app.py account_limits.py auth_blueprint.py briefing_module.py briefing_storage.py platform_provisioning.py rate_limiting.py reporting.py reports_blueprint.py roster_blueprint.py roster_logic.py saas_models.py signup_locking.py tenancy.py wsgi.py scripts
+      - run: python -m compileall -q atcroster absence_requests.py access_policy.py app.py auth_blueprint.py briefing_module.py briefing_storage.py reporting.py reports_blueprint.py roster_blueprint.py roster_logic.py saas_models.py tenancy.py account_limits.py scripts
       - run: python -m pytest --cov --cov-report=term-missing -q
       - name: Verify fresh split migrations
         run: |

--- a/app.py
+++ b/app.py
@@ -4659,7 +4659,6 @@ def _send_roster_publication_emails(
     return sent, failed, len(unique_addresses)
 
 
-@app.route("/roster/<ym>/publish", methods=["POST"])
 @login_required
 def roster_month_publish(ym):
     if not _can_publish_roster(current_user):
@@ -4765,7 +4764,6 @@ def roster_month_publish(ym):
     return redirect(url_for("roster_month", ym=ym))
 
 
-@app.route("/roster/<ym>/unpublish", methods=["POST"])
 @login_required
 def roster_month_unpublish(ym):
     if not _can_publish_roster(current_user):
@@ -4944,7 +4942,6 @@ def module_home():
     )
 
 
-@app.route("/roster/<ym>")
 @login_required
 def roster_month(ym):
     year, month = parse_ym(ym)
@@ -5224,7 +5221,6 @@ def __can():
     }
 
 
-@app.route("/assign/<int:staff_id>/<ym>/<day>", methods=["POST"])
 @login_required
 @roster_edit_required
 def assign_cell(staff_id, ym, day):
@@ -5335,7 +5331,6 @@ def assign_cell(staff_id, ym, day):
     return redirect(url_for("roster_month", ym=ym))
 
 
-@app.route("/roster/<ym>/export")
 @login_required
 def roster_export_csv(ym):
     if not _consume_rate_limit(
@@ -5436,7 +5431,6 @@ def roster_export_csv(ym):
     )
 
 
-@app.route("/roster/<ym>/print")
 @login_required
 def roster_print_view(ym):
     return redirect(url_for("roster_month", ym=ym))
@@ -11324,6 +11318,7 @@ app.jinja_env.globals['ShiftType'] = ShiftType
 
 from auth_blueprint import AuthDependencies, create_auth_blueprint
 from reports_blueprint import ReportsDependencies, create_reports_blueprint
+from roster_blueprint import RosterViews, create_roster_blueprint
 
 app.register_blueprint(create_auth_blueprint(AuthDependencies(
     db=db,
@@ -11365,6 +11360,14 @@ app.register_blueprint(create_reports_blueprint(ReportsDependencies(
     toil_accrued_used=_toil_accrued_used_in_range_half_days,
     group_consecutive_days=_group_consecutive_days,
     get_absence_types=get_absence_types,
+)))
+app.register_blueprint(create_roster_blueprint(RosterViews(
+    roster_month_publish=roster_month_publish,
+    roster_month_unpublish=roster_month_unpublish,
+    roster_month=roster_month,
+    assign_cell=assign_cell,
+    roster_export_csv=roster_export_csv,
+    roster_print_view=roster_print_view,
 )))
 app.register_blueprint(briefing_blueprint)
 

--- a/roster_blueprint.py
+++ b/roster_blueprint.py
@@ -1,0 +1,71 @@
+"""Roster route ownership extracted from the legacy application module.
+
+The current handlers are injected while their remaining data-access concerns
+are separated incrementally. Historical global endpoint names are preserved.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from flask import Blueprint
+
+
+@dataclass(frozen=True)
+class RosterViews:
+    roster_month_publish: Callable
+    roster_month_unpublish: Callable
+    roster_month: Callable
+    assign_cell: Callable
+    roster_export_csv: Callable
+    roster_print_view: Callable
+
+
+def create_roster_blueprint(views: RosterViews) -> Blueprint:
+    blueprint = Blueprint("roster", __name__)
+
+    @blueprint.record_once
+    def register_routes(state):
+        routes = (
+            (
+                "/roster/<ym>/publish",
+                "roster_month_publish",
+                views.roster_month_publish,
+                ["POST"],
+            ),
+            (
+                "/roster/<ym>/unpublish",
+                "roster_month_unpublish",
+                views.roster_month_unpublish,
+                ["POST"],
+            ),
+            ("/roster/<ym>", "roster_month", views.roster_month, ["GET"]),
+            (
+                "/assign/<int:staff_id>/<ym>/<day>",
+                "assign_cell",
+                views.assign_cell,
+                ["POST"],
+            ),
+            (
+                "/roster/<ym>/export",
+                "roster_export_csv",
+                views.roster_export_csv,
+                ["GET"],
+            ),
+            (
+                "/roster/<ym>/print",
+                "roster_print_view",
+                views.roster_print_view,
+                ["GET"],
+            ),
+        )
+        for rule, endpoint, view_func, methods in routes:
+            state.app.add_url_rule(
+                rule,
+                endpoint=endpoint,
+                view_func=view_func,
+                methods=methods,
+            )
+
+    return blueprint

--- a/tests/test_roster_blueprint.py
+++ b/tests/test_roster_blueprint.py
@@ -1,0 +1,26 @@
+ROSTER_ENDPOINTS = {
+    "roster_month_publish": ("/roster/<ym>/publish", {"POST"}),
+    "roster_month_unpublish": ("/roster/<ym>/unpublish", {"POST"}),
+    "roster_month": ("/roster/<ym>", {"GET"}),
+    "assign_cell": ("/assign/<int:staff_id>/<ym>/<day>", {"POST"}),
+    "roster_export_csv": ("/roster/<ym>/export", {"GET"}),
+    "roster_print_view": ("/roster/<ym>/print", {"GET"}),
+}
+
+
+def test_roster_blueprint_preserves_global_endpoint_contract():
+    import app
+
+    rules = {rule.endpoint: rule for rule in app.app.url_map.iter_rules()}
+    for endpoint, (path, methods) in ROSTER_ENDPOINTS.items():
+        assert endpoint in rules
+        assert rules[endpoint].rule == path
+        assert methods <= rules[endpoint].methods
+
+
+def test_roster_routes_are_no_longer_declared_in_legacy_module():
+    from pathlib import Path
+
+    source = (Path(__file__).parents[1] / "app.py").read_text()
+    for path, _methods in ROSTER_ENDPOINTS.values():
+        assert f'@app.route("{path}"' not in source


### PR DESCRIPTION
## What changed

- moved ownership of all six roster routes into `roster_blueprint.py`
- preserved historical global endpoint names, URLs, HTTP methods, authentication and roster-edit permission wrappers
- injected the existing proven handlers across the new boundary, avoiding circular imports while the remaining roster data-access code is split incrementally
- added architecture tests proving endpoint compatibility and preventing roster route declarations from returning to `app.py`
- included the blueprint in formatting, lint, security and compile checks

## Why

The roster is the most dependency-heavy operational surface. Establishing blueprint ownership first creates a safe boundary for later handler/data-access extraction without changing behaviour in one oversized release.

## Impact

No user-facing URL or workflow changes are intended.

## Validation

- Ruff formatting and lint checks pass
- Bandit security scan passes
- focused roster tests: 8 passed
- full suite: 204 passed, 2 skipped