### PR TITLE
Move roster publication and export handlers

### DIFF
--- a/app.py
+++ b/app.py
@@ -4659,158 +4659,6 @@ def _send_roster_publication_emails(
     return sent, failed, len(unique_addresses)
 
 
-@login_required
-def roster_month_publish(ym):
-    if not _can_publish_roster(current_user):
-        abort(403)
-    _validate_csrf()
-    year, month = parse_ym(ym)
-    unit_id = _current_unit_id()
-    if not month_has_data(year, month):
-        ensure_month_requirement(year, month)
-        generate_month(year, month)
-    active = _active_roster_publication(year, month)
-    if active and _publication_matches_live_roster(active, year, month):
-        flash(
-            f"The {date(year, month, 1).strftime('%B %Y')} roster is already published.",
-            "info",
-        )
-        return redirect(url_for("roster_month", ym=ym))
-
-    published_at = utcnow()
-    latest_version = (
-        db.session.query(db.func.max(RosterPublication.version))
-        .filter(
-            RosterPublication.unit_id == unit_id,
-            RosterPublication.year == year,
-            RosterPublication.month == month,
-        )
-        .scalar()
-        or 0
-    )
-    if active:
-        active.state = "superseded"
-        active.superseded_at = published_at
-    snapshot = _roster_snapshot(year, month)
-    snapshot["published_by"] = {
-        "id": current_user.id,
-        "name": current_user.name,
-        "published_at": published_at.isoformat(),
-    }
-    publication = RosterPublication(
-        unit_id=unit_id,
-        year=year,
-        month=month,
-        version=latest_version + 1,
-        state="published",
-        snapshot_json=json.dumps(snapshot),
-        published_at=published_at,
-    )
-    db.session.add(publication)
-    for person in Staff.query.filter_by(
-        unit_id=unit_id,
-        is_operational=True,
-        membership_status="active",
-    ).all():
-        if person.id != current_user.id:
-            db.session.add(Notification(
-                unit_id=unit_id,
-                recipient_id=person.id,
-                kind="roster_published",
-                message=(
-                    f"The {date(year, month, 1).strftime('%B %Y')} roster "
-                    f"was published on {published_at.strftime('%d %B %Y')}."
-                ),
-            ))
-    db.session.commit()
-    email_sent, email_failed, email_recipients = (
-        _send_roster_publication_emails(
-            unit_id, year, month, published_at
-        )
-    )
-    if email_failed:
-        app.logger.warning(
-            "roster_publication_email_delivery_incomplete "
-            "unit_id=%s year=%s month=%s sent=%s failed=%s",
-            unit_id, year, month, email_sent, email_failed,
-        )
-    log_change(
-        "RosterPublication",
-        publication.id,
-        "state",
-        "draft",
-        "published",
-        note=f"Published directly from the monthly roster by {current_user.name}.",
-        context_day=date(year, month, 1),
-    )
-    publication_message = (
-        f"{date(year, month, 1).strftime('%B %Y')} roster published."
-    )
-    if email_recipients:
-        publication_message += (
-            f" Email sent to {email_sent} registered "
-            f"user{'s' if email_sent != 1 else ''}."
-        )
-        if email_failed:
-            publication_message += (
-                f" {email_failed} email"
-                f"{'s' if email_failed != 1 else ''} could not be delivered."
-            )
-    else:
-        publication_message += (
-            " No registered users have an email address."
-        )
-    flash(publication_message, "ok" if not email_failed else "warning")
-    return redirect(url_for("roster_month", ym=ym))
-
-
-@login_required
-def roster_month_unpublish(ym):
-    if not _can_publish_roster(current_user):
-        abort(403)
-    _validate_csrf()
-    year, month = parse_ym(ym)
-    unit_id = _current_unit_id()
-    publication = _active_roster_publication(year, month)
-    if not publication:
-        flash("This roster is already in Draft.", "info")
-        return redirect(url_for("roster_month", ym=ym))
-
-    publication.state = "withdrawn"
-    publication.superseded_at = utcnow()
-    for person in Staff.query.filter_by(
-        unit_id=unit_id,
-        is_operational=True,
-        membership_status="active",
-    ).all():
-        if person.id != current_user.id:
-            db.session.add(Notification(
-                unit_id=unit_id,
-                recipient_id=person.id,
-                kind="roster_unpublished",
-                message=(
-                    f"The {date(year, month, 1).strftime('%B %Y')} roster "
-                    "has returned to Draft and may be subject to change."
-                ),
-            ))
-    db.session.commit()
-    log_change(
-        "RosterPublication",
-        publication.id,
-        "state",
-        "published",
-        "withdrawn",
-        note=f"Publication undone by {current_user.name}; roster returned to Draft.",
-        context_day=date(year, month, 1),
-    )
-    flash(
-        f"{date(year, month, 1).strftime('%B %Y')} roster returned to Draft.",
-        "ok",
-    )
-    return redirect(url_for("roster_month", ym=ym))
-
-
-
 def _clamp_prev_next(year, month):
     """Clamp navigation so you cannot go earlier than MIN_MONTH."""
     prev_y, prev_m = (year - 1, 12) if month == 1 else (year, month - 1)
@@ -5328,111 +5176,6 @@ def assign_cell(staff_id, ym, day):
                 ))
 
     db.session.commit()
-    return redirect(url_for("roster_month", ym=ym))
-
-
-@login_required
-def roster_export_csv(ym):
-    if not _consume_rate_limit(
-        "roster-export", current_user.id, limit=30,
-        window=timedelta(hours=1),
-    ):
-        abort(429)
-    year, month = parse_ym(ym)
-    start, days = month_range(year, month)
-
-    staff = (Staff.query
-             .outerjoin(Watch, Staff.watch_id == Watch.id)
-             .order_by(Watch.order_index,
-                       Staff.name).all())
-
-    a_map = defaultdict(dict)
-    month_end = (start.replace(day=28) + timedelta(days=10)).replace(day=1)
-    for a in Assignment.query.filter(Assignment.day >= start, Assignment.day < month_end):
-        a_map[a.staff_id][a.day] = a.code
-
-    # compute daily counters + RAG for footer (prefix grouping) — EXCLUDE training shifts & excluded codes
-    req = Requirement.query.filter_by(year=year, month=month).first()
-    special_by_day = {
-        row.day: row
-        for row in SpecialRequirement.query.filter(
-            SpecialRequirement.day >= start,
-            SpecialRequirement.day < month_end,
-        ).all()
-    }
-    req_by_day = {
-        d: requirements_for_day(req, d, special_by_day.get(d))
-        for d in days
-    }
-    counters = {d: Counter() for d in days}
-    for s in staff:
-        if not s.is_operational:
-            continue
-        for d in days:
-            if not staff_is_countable_on(s, d):
-                continue
-            c = a_map[s.id].get(d)
-            if not c or c in get_exclude_from_counters():
-                continue
-            sh = get_shift(c) if c else None
-            if not c or not sh or sh.is_training:
-                continue
-            grp = shift_counter_group_for_day(
-                c, d, _current_unit_id()
-            )
-            if grp:
-                counters[d][grp] += 1
-
-    # Replicate the RAG calculation used in the HTML view so the CSV footer
-    # includes consistent status flags instead of raising a NameError.
-    rag = {}
-    for d in days:
-        rag[d] = {}
-        for code in ("M", "D", "A", "N"):
-            have = counters[d][code]
-            need = (
-                0
-                if code == "N" and not _night_active_on(
-                    _current_unit_id(), d
-                )
-                else req_by_day[d][code]
-            )
-            rag[d][code] = (
-                "green" if have >= need
-                else ("amber" if have >= max(0, need - 1) else "red")
-            )
-
-    output = io.StringIO()
-    w = csv.writer(output)
-    header = ["Name", "Staff #", "Watch"] + [d.isoformat() for d in days]
-    w.writerow(header)
-    for s in staff:
-        row = [s.name, s.staff_no, (s.watch.name.replace(
-            "Watch ", "") if s.watch else "-")]
-        for d in days:
-            row.append(a_map[s.id].get(d, ""))
-        w.writerow(row)
-
-    w.writerow([])
-    w.writerow(["Totals (M/D/A/N)", "", ""] + [
-        f"M:{counters[d]['M']}/{req_by_day[d]['M']}-{rag[d]['M']} | "
-        f"D:{counters[d]['D']}/{req_by_day[d]['D']}-{rag[d]['D']} | "
-        f"A:{counters[d]['A']}/{req_by_day[d]['A']}-{rag[d]['A']} | "
-        f"N:{counters[d]['N']}/{req_by_day[d]['N']}-{rag[d]['N']}"
-        for d in days
-    ])
-
-    csv_bytes = output.getvalue().encode("utf-8")
-    filename = f"roster_{year:04d}-{month:02d}.csv"
-    return Response(
-        csv_bytes,
-        mimetype="text/csv; charset=utf-8",
-        headers={"Content-Disposition": f"attachment; filename={filename}"}
-    )
-
-
-@login_required
-def roster_print_view(ym):
     return redirect(url_for("roster_month", ym=ym))
 
 
@@ -11318,7 +11061,7 @@ app.jinja_env.globals['ShiftType'] = ShiftType
 
 from auth_blueprint import AuthDependencies, create_auth_blueprint
 from reports_blueprint import ReportsDependencies, create_reports_blueprint
-from roster_blueprint import RosterViews, create_roster_blueprint
+from roster_blueprint import RosterDependencies, create_roster_blueprint
 
 app.register_blueprint(create_auth_blueprint(AuthDependencies(
     db=db,
@@ -11361,13 +11104,38 @@ app.register_blueprint(create_reports_blueprint(ReportsDependencies(
     group_consecutive_days=_group_consecutive_days,
     get_absence_types=get_absence_types,
 )))
-app.register_blueprint(create_roster_blueprint(RosterViews(
-    roster_month_publish=roster_month_publish,
-    roster_month_unpublish=roster_month_unpublish,
+app.register_blueprint(create_roster_blueprint(RosterDependencies(
+    db=db,
+    RosterPublication=RosterPublication,
+    Staff=Staff,
+    Notification=Notification,
+    Assignment=Assignment,
+    Watch=Watch,
+    Requirement=Requirement,
+    SpecialRequirement=SpecialRequirement,
     roster_month=roster_month,
     assign_cell=assign_cell,
-    roster_export_csv=roster_export_csv,
-    roster_print_view=roster_print_view,
+    can_publish_roster=_can_publish_roster,
+    validate_csrf=_validate_csrf,
+    parse_year_month=parse_ym,
+    current_unit_id=_current_unit_id,
+    month_has_data=month_has_data,
+    ensure_month_requirement=ensure_month_requirement,
+    generate_month=generate_month,
+    active_publication=_active_roster_publication,
+    publication_matches_live=_publication_matches_live_roster,
+    roster_snapshot=_roster_snapshot,
+    utcnow=utcnow,
+    send_publication_emails=_send_roster_publication_emails,
+    log_change=log_change,
+    consume_rate_limit=_consume_rate_limit,
+    month_range=month_range,
+    requirements_for_day=requirements_for_day,
+    staff_is_countable_on=staff_is_countable_on,
+    exclude_from_counters=get_exclude_from_counters,
+    get_shift=get_shift,
+    shift_counter_group_for_day=shift_counter_group_for_day,
+    night_active_on=_night_active_on,
 )))
 app.register_blueprint(briefing_blueprint)
 

--- a/roster_blueprint.py
+++ b/roster_blueprint.py
@@ -1,29 +1,334 @@
-"""Roster route ownership extracted from the legacy application module.
-
-The current handlers are injected while their remaining data-access concerns
-are separated incrementally. Historical global endpoint names are preserved.
-"""
+"""Roster routes extracted incrementally from the legacy application module."""
 
 from __future__ import annotations
 
+import csv
+import io
+import json
+from collections import Counter, defaultdict
 from dataclasses import dataclass
-from typing import Callable
+from datetime import date, timedelta
+from typing import Any, Callable
 
-from flask import Blueprint
+from flask import (
+    Blueprint,
+    Response,
+    abort,
+    current_app,
+    flash,
+    redirect,
+    url_for,
+)
+from flask_login import current_user, login_required
 
 
 @dataclass(frozen=True)
-class RosterViews:
-    roster_month_publish: Callable
-    roster_month_unpublish: Callable
+class RosterDependencies:
+    db: Any
+    RosterPublication: Any
+    Staff: Any
+    Notification: Any
+    Assignment: Any
+    Watch: Any
+    Requirement: Any
+    SpecialRequirement: Any
     roster_month: Callable
     assign_cell: Callable
-    roster_export_csv: Callable
-    roster_print_view: Callable
+    can_publish_roster: Callable[[Any], bool]
+    validate_csrf: Callable[[], None]
+    parse_year_month: Callable[[str], tuple[int, int]]
+    current_unit_id: Callable[[], int]
+    month_has_data: Callable[[int, int], bool]
+    ensure_month_requirement: Callable[[int, int], Any]
+    generate_month: Callable[[int, int], None]
+    active_publication: Callable[[int, int], Any]
+    publication_matches_live: Callable[[Any, int, int], bool]
+    roster_snapshot: Callable[[int, int], dict]
+    utcnow: Callable[[], Any]
+    send_publication_emails: Callable[[int, int, int, Any], tuple[int, int, int]]
+    log_change: Callable[..., None]
+    consume_rate_limit: Callable[..., bool]
+    month_range: Callable[[int, int], tuple[date, list[date]]]
+    requirements_for_day: Callable[..., dict[str, int]]
+    staff_is_countable_on: Callable[[Any, date], bool]
+    exclude_from_counters: Callable[[], set[str]]
+    get_shift: Callable[[str], Any]
+    shift_counter_group_for_day: Callable[[str, date, int], str | None]
+    night_active_on: Callable[[int, date], bool]
 
 
-def create_roster_blueprint(views: RosterViews) -> Blueprint:
+def create_roster_blueprint(dependencies: RosterDependencies) -> Blueprint:
     blueprint = Blueprint("roster", __name__)
+
+    @login_required
+    def roster_month_publish(ym):
+        if not dependencies.can_publish_roster(current_user):
+            abort(403)
+        dependencies.validate_csrf()
+        year, month = dependencies.parse_year_month(ym)
+        unit_id = dependencies.current_unit_id()
+        if not dependencies.month_has_data(year, month):
+            dependencies.ensure_month_requirement(year, month)
+            dependencies.generate_month(year, month)
+        active = dependencies.active_publication(year, month)
+        if active and dependencies.publication_matches_live(active, year, month):
+            flash(
+                f"The {date(year, month, 1).strftime('%B %Y')} roster is already published.",
+                "info",
+            )
+            return redirect(url_for("roster_month", ym=ym))
+
+        published_at = dependencies.utcnow()
+        latest_version = (
+            dependencies.db.session.query(
+                dependencies.db.func.max(dependencies.RosterPublication.version)
+            )
+            .filter(
+                dependencies.RosterPublication.unit_id == unit_id,
+                dependencies.RosterPublication.year == year,
+                dependencies.RosterPublication.month == month,
+            )
+            .scalar()
+            or 0
+        )
+        if active:
+            active.state = "superseded"
+            active.superseded_at = published_at
+        snapshot = dependencies.roster_snapshot(year, month)
+        snapshot["published_by"] = {
+            "id": current_user.id,
+            "name": current_user.name,
+            "published_at": published_at.isoformat(),
+        }
+        publication = dependencies.RosterPublication(
+            unit_id=unit_id,
+            year=year,
+            month=month,
+            version=latest_version + 1,
+            state="published",
+            snapshot_json=json.dumps(snapshot),
+            published_at=published_at,
+        )
+        dependencies.db.session.add(publication)
+        for person in dependencies.Staff.query.filter_by(
+            unit_id=unit_id,
+            is_operational=True,
+            membership_status="active",
+        ).all():
+            if person.id != current_user.id:
+                dependencies.db.session.add(
+                    dependencies.Notification(
+                        unit_id=unit_id,
+                        recipient_id=person.id,
+                        kind="roster_published",
+                        message=(
+                            f"The {date(year, month, 1).strftime('%B %Y')} roster "
+                            f"was published on {published_at.strftime('%d %B %Y')}."
+                        ),
+                    )
+                )
+        dependencies.db.session.commit()
+        email_sent, email_failed, email_recipients = (
+            dependencies.send_publication_emails(unit_id, year, month, published_at)
+        )
+        if email_failed:
+            current_app.logger.warning(
+                "roster_publication_email_delivery_incomplete "
+                "unit_id=%s year=%s month=%s sent=%s failed=%s",
+                unit_id,
+                year,
+                month,
+                email_sent,
+                email_failed,
+            )
+        dependencies.log_change(
+            "RosterPublication",
+            publication.id,
+            "state",
+            "draft",
+            "published",
+            note=(
+                f"Published directly from the monthly roster by {current_user.name}."
+            ),
+            context_day=date(year, month, 1),
+        )
+        message = f"{date(year, month, 1).strftime('%B %Y')} roster published."
+        if email_recipients:
+            message += (
+                f" Email sent to {email_sent} registered "
+                f"user{'s' if email_sent != 1 else ''}."
+            )
+            if email_failed:
+                message += (
+                    f" {email_failed} email"
+                    f"{'s' if email_failed != 1 else ''} could not be delivered."
+                )
+        else:
+            message += " No registered users have an email address."
+        flash(message, "ok" if not email_failed else "warning")
+        return redirect(url_for("roster_month", ym=ym))
+
+    @login_required
+    def roster_month_unpublish(ym):
+        if not dependencies.can_publish_roster(current_user):
+            abort(403)
+        dependencies.validate_csrf()
+        year, month = dependencies.parse_year_month(ym)
+        unit_id = dependencies.current_unit_id()
+        publication = dependencies.active_publication(year, month)
+        if not publication:
+            flash("This roster is already in Draft.", "info")
+            return redirect(url_for("roster_month", ym=ym))
+        publication.state = "withdrawn"
+        publication.superseded_at = dependencies.utcnow()
+        for person in dependencies.Staff.query.filter_by(
+            unit_id=unit_id,
+            is_operational=True,
+            membership_status="active",
+        ).all():
+            if person.id != current_user.id:
+                dependencies.db.session.add(
+                    dependencies.Notification(
+                        unit_id=unit_id,
+                        recipient_id=person.id,
+                        kind="roster_unpublished",
+                        message=(
+                            f"The {date(year, month, 1).strftime('%B %Y')} roster "
+                            "has returned to Draft and may be subject to change."
+                        ),
+                    )
+                )
+        dependencies.db.session.commit()
+        dependencies.log_change(
+            "RosterPublication",
+            publication.id,
+            "state",
+            "published",
+            "withdrawn",
+            note=(
+                f"Publication undone by {current_user.name}; roster returned to Draft."
+            ),
+            context_day=date(year, month, 1),
+        )
+        flash(
+            f"{date(year, month, 1).strftime('%B %Y')} roster returned to Draft.",
+            "ok",
+        )
+        return redirect(url_for("roster_month", ym=ym))
+
+    @login_required
+    def roster_export_csv(ym):
+        if not dependencies.consume_rate_limit(
+            "roster-export",
+            current_user.id,
+            limit=30,
+            window=timedelta(hours=1),
+        ):
+            abort(429)
+        year, month = dependencies.parse_year_month(ym)
+        start, days = dependencies.month_range(year, month)
+        staff = (
+            dependencies.Staff.query.outerjoin(
+                dependencies.Watch,
+                dependencies.Staff.watch_id == dependencies.Watch.id,
+            )
+            .order_by(dependencies.Watch.order_index, dependencies.Staff.name)
+            .all()
+        )
+        assignment_map = defaultdict(dict)
+        month_end = (start.replace(day=28) + timedelta(days=10)).replace(day=1)
+        for assignment in dependencies.Assignment.query.filter(
+            dependencies.Assignment.day >= start,
+            dependencies.Assignment.day < month_end,
+        ):
+            assignment_map[assignment.staff_id][assignment.day] = assignment.code
+        requirement = dependencies.Requirement.query.filter_by(
+            year=year, month=month
+        ).first()
+        special_by_day = {
+            row.day: row
+            for row in dependencies.SpecialRequirement.query.filter(
+                dependencies.SpecialRequirement.day >= start,
+                dependencies.SpecialRequirement.day < month_end,
+            ).all()
+        }
+        requirements = {
+            day: dependencies.requirements_for_day(
+                requirement, day, special_by_day.get(day)
+            )
+            for day in days
+        }
+        counters = {day: Counter() for day in days}
+        excluded = dependencies.exclude_from_counters()
+        unit_id = dependencies.current_unit_id()
+        for person in staff:
+            if not person.is_operational:
+                continue
+            for day in days:
+                if not dependencies.staff_is_countable_on(person, day):
+                    continue
+                code = assignment_map[person.id].get(day)
+                if not code or code in excluded:
+                    continue
+                shift = dependencies.get_shift(code)
+                if not shift or shift.is_training:
+                    continue
+                group = dependencies.shift_counter_group_for_day(code, day, unit_id)
+                if group:
+                    counters[day][group] += 1
+        rag = {}
+        for day in days:
+            rag[day] = {}
+            for code in ("M", "D", "A", "N"):
+                available = counters[day][code]
+                needed = (
+                    0
+                    if code == "N" and not dependencies.night_active_on(unit_id, day)
+                    else requirements[day][code]
+                )
+                rag[day][code] = (
+                    "green"
+                    if available >= needed
+                    else ("amber" if available >= max(0, needed - 1) else "red")
+                )
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow(
+            ["Name", "Staff #", "Watch"] + [day.isoformat() for day in days]
+        )
+        for person in staff:
+            writer.writerow(
+                [
+                    person.name,
+                    person.staff_no,
+                    person.watch.name.replace("Watch ", "") if person.watch else "-",
+                    *[assignment_map[person.id].get(day, "") for day in days],
+                ]
+            )
+        writer.writerow([])
+        writer.writerow(
+            ["Totals (M/D/A/N)", "", ""]
+            + [
+                f"M:{counters[day]['M']}/{requirements[day]['M']}-{rag[day]['M']} | "
+                f"D:{counters[day]['D']}/{requirements[day]['D']}-{rag[day]['D']} | "
+                f"A:{counters[day]['A']}/{requirements[day]['A']}-{rag[day]['A']} | "
+                f"N:{counters[day]['N']}/{requirements[day]['N']}-{rag[day]['N']}"
+                for day in days
+            ]
+        )
+        return Response(
+            output.getvalue().encode("utf-8"),
+            mimetype="text/csv; charset=utf-8",
+            headers={
+                "Content-Disposition": (
+                    f"attachment; filename=roster_{year:04d}-{month:02d}.csv"
+                )
+            },
+        )
+
+    @login_required
+    def roster_print_view(ym):
+        return redirect(url_for("roster_month", ym=ym))
 
     @blueprint.record_once
     def register_routes(state):
@@ -31,41 +336,28 @@ def create_roster_blueprint(views: RosterViews) -> Blueprint:
             (
                 "/roster/<ym>/publish",
                 "roster_month_publish",
-                views.roster_month_publish,
+                roster_month_publish,
                 ["POST"],
             ),
             (
                 "/roster/<ym>/unpublish",
                 "roster_month_unpublish",
-                views.roster_month_unpublish,
+                roster_month_unpublish,
                 ["POST"],
             ),
-            ("/roster/<ym>", "roster_month", views.roster_month, ["GET"]),
+            ("/roster/<ym>", "roster_month", dependencies.roster_month, ["GET"]),
             (
                 "/assign/<int:staff_id>/<ym>/<day>",
                 "assign_cell",
-                views.assign_cell,
+                dependencies.assign_cell,
                 ["POST"],
             ),
-            (
-                "/roster/<ym>/export",
-                "roster_export_csv",
-                views.roster_export_csv,
-                ["GET"],
-            ),
-            (
-                "/roster/<ym>/print",
-                "roster_print_view",
-                views.roster_print_view,
-                ["GET"],
-            ),
+            ("/roster/<ym>/export", "roster_export_csv", roster_export_csv, ["GET"]),
+            ("/roster/<ym>/print", "roster_print_view", roster_print_view, ["GET"]),
         )
         for rule, endpoint, view_func, methods in routes:
             state.app.add_url_rule(
-                rule,
-                endpoint=endpoint,
-                view_func=view_func,
-                methods=methods,
+                rule, endpoint=endpoint, view_func=view_func, methods=methods
             )
 
     return blueprint

--- a/tests/test_roster_blueprint.py
+++ b/tests/test_roster_blueprint.py
@@ -24,3 +24,16 @@ def test_roster_routes_are_no_longer_declared_in_legacy_module():
     source = (Path(__file__).parents[1] / "app.py").read_text()
     for path, _methods in ROSTER_ENDPOINTS.values():
         assert f'@app.route("{path}"' not in source
+
+
+def test_completed_roster_handlers_are_no_longer_in_legacy_module():
+    from pathlib import Path
+
+    source = (Path(__file__).parents[1] / "app.py").read_text()
+    for handler in (
+        "roster_month_publish",
+        "roster_month_unpublish",
+        "roster_export_csv",
+        "roster_print_view",
+    ):
+        assert f"def {handler}(" not in source


### PR DESCRIPTION
## What changed

- moved roster publication and withdrawal handlers fully into `roster_blueprint.py`
- moved roster CSV export and print handlers fully into the blueprint
- retained the existing publication versioning, notifications, email delivery, audit logging, rate limiting, credential-aware counters and RAG footer behaviour
- reduced the injected legacy surface to the main roster renderer and cell editor
- added architecture checks preventing the completed handlers from returning to `app.py`

## Why

This continues the roster extraction behind the blueprint boundary created in PR #131, using a focused release rather than moving the renderer, editor and publication workflows simultaneously.

## Impact

No user-facing URL or workflow changes are intended. `app.py` is another 229 lines smaller.

## Validation

- Ruff formatting and lint checks pass
- Bandit security scan passes
- focused roster tests: 9 passed
- full suite: 205 passed, 2 skipped