### PR TITLE
Move absence and request route ownership

### DIFF
--- a/absence_requests_blueprint.py
+++ b/absence_requests_blueprint.py
@@ -1,0 +1,40 @@
+"""Route ownership for absence and shift-request workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from flask import Blueprint
+
+
+@dataclass(frozen=True)
+class AbsenceRequestDependencies:
+    leave: Callable
+    requests_page: Callable
+    admin_request_respond: Callable
+
+
+def create_absence_requests_blueprint(
+    dependencies: AbsenceRequestDependencies,
+) -> Blueprint:
+    blueprint = Blueprint("absence_requests", __name__)
+
+    @blueprint.record_once
+    def register_routes(state):
+        routes = (
+            ("/leave", "leave", dependencies.leave, ["GET", "POST"]),
+            ("/requests", "requests_page", dependencies.requests_page, ["GET", "POST"]),
+            (
+                "/admin/requests/<int:rid>/respond",
+                "admin_request_respond",
+                dependencies.admin_request_respond,
+                ["POST"],
+            ),
+        )
+        for rule, endpoint, view_func, methods in routes:
+            state.app.add_url_rule(
+                rule, endpoint=endpoint, view_func=view_func, methods=methods
+            )
+
+    return blueprint

--- a/app.py
+++ b/app.py
@@ -5874,7 +5874,6 @@ def _group_sickness_instances(assignments, month_start=None, month_end=None):
     return group_sickness_instances(assignments, month_start, month_end)
 
 
-@app.route("/leave", methods=["GET", "POST"])
 @login_required
 def leave():
     # Page visibility: editors & admins only
@@ -7470,7 +7469,6 @@ def _staff_has_shift_qualification(
     )
 
 
-@app.route("/requests", methods=["GET", "POST"])
 @login_required
 def requests_page():
     today = date.today()
@@ -7667,7 +7665,6 @@ def requests_page():
 # >>> Admin can respond to a specific request
 
 
-@app.route("/admin/requests/<int:rid>/respond", methods=["POST"])
 @login_required
 def admin_request_respond(rid):
     if not is_admin_user(current_user):
@@ -10689,6 +10686,10 @@ app.jinja_env.globals['ShiftType'] = ShiftType
 # -------------------- Run --------------------
 
 from auth_blueprint import AuthDependencies, create_auth_blueprint
+from absence_requests_blueprint import (
+    AbsenceRequestDependencies,
+    create_absence_requests_blueprint,
+)
 from reports_blueprint import ReportsDependencies, create_reports_blueprint
 from roster_blueprint import RosterDependencies, create_roster_blueprint
 
@@ -10779,6 +10780,13 @@ app.register_blueprint(create_roster_blueprint(RosterDependencies(
     roster_fatigue_flags=roster_fatigue_flags_for_range,
     get_annotation_groups=get_annotation_groups,
 )))
+app.register_blueprint(create_absence_requests_blueprint(
+    AbsenceRequestDependencies(
+        leave=leave,
+        requests_page=requests_page,
+        admin_request_respond=admin_request_respond,
+    )
+))
 app.register_blueprint(briefing_blueprint)
 
 # -------------------- WSGI entry point --------------------

--- a/tests/test_absence_requests_blueprint.py
+++ b/tests/test_absence_requests_blueprint.py
@@ -1,0 +1,23 @@
+ENDPOINTS = {
+    "leave": ("/leave", {"GET", "POST"}),
+    "requests_page": ("/requests", {"GET", "POST"}),
+    "admin_request_respond": ("/admin/requests/<int:rid>/respond", {"POST"}),
+}
+
+
+def test_absence_request_blueprint_preserves_global_endpoint_contract():
+    import app
+
+    rules = {rule.endpoint: rule for rule in app.app.url_map.iter_rules()}
+    for endpoint, (path, methods) in ENDPOINTS.items():
+        assert endpoint in rules
+        assert rules[endpoint].rule == path
+        assert methods <= rules[endpoint].methods
+
+
+def test_absence_request_routes_are_owned_outside_legacy_module():
+    from pathlib import Path
+
+    source = (Path(__file__).parents[1] / "app.py").read_text()
+    for path, _methods in ENDPOINTS.values():
+        assert f'@app.route("{path}"' not in source


### PR DESCRIPTION
## What changed

- added a dedicated absence/request blueprint
- moved ownership of `/leave`, `/requests`, and the manager response endpoint out of `app.py`
- preserved the existing global endpoint names, URLs, HTTP methods, login protection, CSRF handling, tenant filtering, and request business logic
- added endpoint-contract and architecture tests

## Why

This establishes a tested route boundary before moving the security-sensitive absence and request handler implementations in smaller follow-up steps.

## Impact

No user-facing workflow or URL changes are intended. Existing templates and redirects continue to use the same endpoint names.

## Validation

- focused absence/request and security tests: 39 passed
- final focused blueprint/security tests: 34 passed
- full suite: 207 passed, 2 skipped
- Ruff lint passed
- Bandit security scan passed
- Python compilation passed