### PR TITLE
Move training and competency route ownership

### DIFF
--- a/app.py
+++ b/app.py
@@ -5886,7 +5886,6 @@ def _training_profile_allowed(person):
     )
 
 
-@app.get("/training/")
 @login_required
 def training_home():
     unit_id = _current_unit_id()
@@ -5916,7 +5915,6 @@ def training_home():
     )
 
 
-@app.route("/training/<int:sid>", methods=["GET", "POST"])
 @login_required
 def training_profile(sid):
     unit_id = _current_unit_id()
@@ -5994,7 +5992,6 @@ def training_profile(sid):
     )
 
 
-@app.get("/competency/")
 @login_required
 def competency_home():
     unit_id = _current_unit_id()
@@ -6015,7 +6012,6 @@ def competency_home():
     )
 
 
-@app.route("/competency/<int:sid>", methods=["GET", "POST"])
 @login_required
 def competency_profile(sid):
     unit_id = _current_unit_id()
@@ -6076,7 +6072,6 @@ def competency_profile(sid):
     )
 
 
-@app.route("/training/admin", methods=["GET", "POST"])
 @login_required
 def training_admin():
     if not training_enabled(_current_unit_id()):
@@ -6117,7 +6112,6 @@ def training_admin():
     return render_template("training_admin.html", levels=levels)
 
 
-@app.get("/training/analytics")
 @login_required
 def training_analytics():
     if not training_enabled(_current_unit_id()):
@@ -10060,6 +10054,7 @@ from absence_requests_blueprint import (
 )
 from reports_blueprint import ReportsDependencies, create_reports_blueprint
 from roster_blueprint import RosterDependencies, create_roster_blueprint
+from training_blueprint import TrainingDependencies, create_training_blueprint
 
 app.register_blueprint(create_auth_blueprint(AuthDependencies(
     db=db,
@@ -10181,6 +10176,14 @@ app.register_blueprint(create_absence_requests_blueprint(
         notify_requester=_notify_requester,
     )
 ))
+app.register_blueprint(create_training_blueprint(TrainingDependencies(
+    training_home=training_home,
+    training_profile=training_profile,
+    competency_home=competency_home,
+    competency_profile=competency_profile,
+    training_admin=training_admin,
+    training_analytics=training_analytics,
+)))
 app.register_blueprint(briefing_blueprint)
 
 # -------------------- WSGI entry point --------------------

--- a/tests/test_training_blueprint.py
+++ b/tests/test_training_blueprint.py
@@ -1,0 +1,27 @@
+ENDPOINTS = {
+    "training_home": ("/training/", {"GET"}),
+    "training_profile": ("/training/<int:sid>", {"GET", "POST"}),
+    "competency_home": ("/competency/", {"GET"}),
+    "competency_profile": ("/competency/<int:sid>", {"GET", "POST"}),
+    "training_admin": ("/training/admin", {"GET", "POST"}),
+    "training_analytics": ("/training/analytics", {"GET"}),
+}
+
+
+def test_training_blueprint_preserves_global_endpoint_contract():
+    import app
+
+    rules = {rule.endpoint: rule for rule in app.app.url_map.iter_rules()}
+    for endpoint, (path, methods) in ENDPOINTS.items():
+        assert endpoint in rules
+        assert rules[endpoint].rule == path
+        assert methods <= rules[endpoint].methods
+
+
+def test_training_routes_are_owned_outside_legacy_module():
+    from pathlib import Path
+
+    source = (Path(__file__).parents[1] / "app.py").read_text()
+    for path, _methods in ENDPOINTS.values():
+        assert f'@app.route("{path}"' not in source
+        assert f'@app.get("{path}"' not in source

--- a/training_blueprint.py
+++ b/training_blueprint.py
@@ -1,0 +1,59 @@
+"""Route ownership for training and competency workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from flask import Blueprint
+
+
+@dataclass(frozen=True)
+class TrainingDependencies:
+    training_home: Callable
+    training_profile: Callable
+    competency_home: Callable
+    competency_profile: Callable
+    training_admin: Callable
+    training_analytics: Callable
+
+
+def create_training_blueprint(dependencies: TrainingDependencies) -> Blueprint:
+    blueprint = Blueprint("training", __name__)
+
+    @blueprint.record_once
+    def register_routes(state):
+        routes = (
+            ("/training/", "training_home", dependencies.training_home, ["GET"]),
+            (
+                "/training/<int:sid>",
+                "training_profile",
+                dependencies.training_profile,
+                ["GET", "POST"],
+            ),
+            ("/competency/", "competency_home", dependencies.competency_home, ["GET"]),
+            (
+                "/competency/<int:sid>",
+                "competency_profile",
+                dependencies.competency_profile,
+                ["GET", "POST"],
+            ),
+            (
+                "/training/admin",
+                "training_admin",
+                dependencies.training_admin,
+                ["GET", "POST"],
+            ),
+            (
+                "/training/analytics",
+                "training_analytics",
+                dependencies.training_analytics,
+                ["GET"],
+            ),
+        )
+        for rule, endpoint, view_func, methods in routes:
+            state.app.add_url_rule(
+                rule, endpoint=endpoint, view_func=view_func, methods=methods
+            )
+
+    return blueprint


### PR DESCRIPTION
## What changed

- added a dedicated training blueprint
- moved ownership of six training and competency URLs out of `app.py`
- preserved global endpoint names, URL paths, HTTP methods, login decorators and existing handlers
- added endpoint-contract and architecture tests

## Why

This establishes a tested boundary before moving the training and competency implementations in focused stages.

## Impact

No user-facing URL, permission or workflow changes are intended.

## Validation

- focused training/blueprint tests: 3 passed
- full suite: 212 passed, 2 skipped
- Ruff lint and formatting passed
- Bandit security scan passed
- Python compilation passed