### PR TITLE
Move training profile handlers into blueprint

### DIFF
--- a/app.py
+++ b/app.py
@@ -5887,112 +5887,6 @@ def _training_profile_allowed(person):
 
 
 @login_required
-def training_home():
-    unit_id = _current_unit_id()
-    if not training_enabled(unit_id):
-        abort(404)
-    own_sessions = TrainingSession.query.filter_by(
-        unit_id=unit_id, trainee_id=current_user.id
-    ).all()
-    own_minutes = sum(row.duration_minutes for row in own_sessions)
-    can_view_people = bool(
-        is_editor_user(current_user)
-        or can_manage_training(current_user)
-        or can_record_training(current_user)
-    )
-    people = []
-    if can_view_people:
-        people = Staff.query.filter_by(
-            unit_id=unit_id, is_operational=True
-        ).order_by(Staff.name).all()
-        people = [person for person in people if is_under_training(person)]
-    trainee_count = sum(1 for person in people if is_under_training(person))
-    return render_template(
-        "training_home.html", people=people,
-        own_minutes=own_minutes, can_view_people=can_view_people,
-        trainee_count=trainee_count,
-        own_under_training=is_under_training(current_user),
-    )
-
-
-@login_required
-def training_profile(sid):
-    unit_id = _current_unit_id()
-    if not training_enabled(unit_id):
-        abort(404)
-    person = Staff.query.filter_by(id=sid, unit_id=unit_id).first_or_404()
-    if not _training_profile_allowed(person):
-        abort(403)
-    if not is_under_training(person):
-        abort(404)
-    if request.method == "POST":
-        _validate_csrf()
-        if not can_record_training(current_user) or not is_under_training(person):
-            abort(403)
-        level = TrainingLevel.query.filter_by(
-            id=int(request.form.get("level_id") or 0), unit_id=unit_id,
-            is_active=True,
-        ).first_or_404()
-        try:
-            training_date = date.fromisoformat(request.form.get("training_date") or "")
-            duration_minutes = int(request.form.get("duration_minutes") or 0)
-        except (TypeError, ValueError):
-            abort(400, "Enter a valid training date and duration.")
-        if not 1 <= duration_minutes <= 1440:
-            abort(400, "Training duration must be between 1 and 1,440 minutes.")
-        session_row = TrainingSession(
-            unit_id=unit_id, trainee_id=person.id, ojti_id=current_user.id,
-            level_id=level.id, training_date=training_date,
-            duration_minutes=duration_minutes,
-            summary=(request.form.get("summary") or "").strip()[:4000],
-        )
-        db.session.add(session_row)
-        db.session.flush()
-        for objective in sorted(level.objectives, key=lambda row: row.position)[:15]:
-            raw_attainment = request.form.get(f"attainment_{objective.id}")
-            raw_assistance = request.form.get(f"assistance_{objective.id}")
-            if not raw_attainment and not raw_assistance:
-                continue
-            try:
-                attainment = int(raw_attainment or 0)
-                assistance = int(raw_assistance or 0)
-            except ValueError:
-                abort(400, "Objective scores must be whole numbers.")
-            if attainment not in {1, 2, 3, 4} or assistance not in {1, 2, 3, 4}:
-                abort(400, "Objective scores must be between 1 and 4.")
-            db.session.add(TrainingScore(
-                unit_id=unit_id, session_id=session_row.id,
-                objective_id=objective.id, attainment=attainment,
-                assistance=assistance,
-                safety_critical=bool(request.form.get(f"safety_{objective.id}")),
-                note=(request.form.get(f"note_{objective.id}") or "").strip()[:4000],
-            ))
-        db.session.commit()
-        flash("Training report saved.", "ok")
-        return redirect(url_for("training_profile", sid=person.id, level=level.id))
-
-    levels = TrainingLevel.query.filter_by(
-        unit_id=unit_id, is_active=True
-    ).order_by(TrainingLevel.sort_order, TrainingLevel.name).all()
-    selected_id = request.args.get("level", type=int)
-    selected = next((row for row in levels if row.id == selected_id), levels[0] if levels else None)
-    sessions = []
-    if selected:
-        sessions = TrainingSession.query.filter_by(
-            unit_id=unit_id, trainee_id=person.id, level_id=selected.id
-        ).order_by(TrainingSession.training_date.desc(), TrainingSession.id.desc()).all()
-    total_minutes = sum(row.duration_minutes for row in TrainingSession.query.filter_by(
-        unit_id=unit_id, trainee_id=person.id
-    ).all())
-    return render_template(
-        "training_profile.html", person=person, levels=levels,
-        selected_level=selected, sessions=sessions, total_minutes=total_minutes,
-        under_training=is_under_training(person),
-        can_record=can_record_training(current_user),
-    )
-
-
-@login_required
 def competency_home():
     unit_id = _current_unit_id()
     if not competency_enabled(unit_id):
@@ -10177,8 +10071,19 @@ app.register_blueprint(create_absence_requests_blueprint(
     )
 ))
 app.register_blueprint(create_training_blueprint(TrainingDependencies(
-    training_home=training_home,
-    training_profile=training_profile,
+    db=db,
+    Staff=Staff,
+    TrainingLevel=TrainingLevel,
+    TrainingSession=TrainingSession,
+    TrainingScore=TrainingScore,
+    current_unit_id=_current_unit_id,
+    training_enabled=training_enabled,
+    is_editor_user=is_editor_user,
+    can_manage_training=can_manage_training,
+    can_record_training=can_record_training,
+    is_under_training=is_under_training,
+    training_profile_allowed=_training_profile_allowed,
+    validate_csrf=_validate_csrf,
     competency_home=competency_home,
     competency_profile=competency_profile,
     training_admin=training_admin,

--- a/tests/test_training_blueprint.py
+++ b/tests/test_training_blueprint.py
@@ -25,3 +25,11 @@ def test_training_routes_are_owned_outside_legacy_module():
     for path, _methods in ENDPOINTS.values():
         assert f'@app.route("{path}"' not in source
         assert f'@app.get("{path}"' not in source
+
+
+def test_training_dashboard_handlers_are_no_longer_in_legacy_module():
+    from pathlib import Path
+
+    source = (Path(__file__).parents[1] / "app.py").read_text()
+    assert "def training_home():" not in source
+    assert "def training_profile(" not in source

--- a/training_blueprint.py
+++ b/training_blueprint.py
@@ -3,15 +3,36 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable
+from datetime import date
+from typing import Any, Callable
 
-from flask import Blueprint
+from flask import (
+    Blueprint,
+    abort,
+    flash,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+from flask_login import current_user, login_required
 
 
 @dataclass(frozen=True)
 class TrainingDependencies:
-    training_home: Callable
-    training_profile: Callable
+    db: Any
+    Staff: Any
+    TrainingLevel: Any
+    TrainingSession: Any
+    TrainingScore: Any
+    current_unit_id: Callable
+    training_enabled: Callable
+    is_editor_user: Callable
+    can_manage_training: Callable
+    can_record_training: Callable
+    is_under_training: Callable
+    training_profile_allowed: Callable
+    validate_csrf: Callable
     competency_home: Callable
     competency_profile: Callable
     training_admin: Callable
@@ -21,14 +42,167 @@ class TrainingDependencies:
 def create_training_blueprint(dependencies: TrainingDependencies) -> Blueprint:
     blueprint = Blueprint("training", __name__)
 
+    @login_required
+    def training_home():
+        unit_id = dependencies.current_unit_id()
+        if not dependencies.training_enabled(unit_id):
+            abort(404)
+        own_sessions = dependencies.TrainingSession.query.filter_by(
+            unit_id=unit_id, trainee_id=current_user.id
+        ).all()
+        own_minutes = sum(row.duration_minutes for row in own_sessions)
+        can_view_people = bool(
+            dependencies.is_editor_user(current_user)
+            or dependencies.can_manage_training(current_user)
+            or dependencies.can_record_training(current_user)
+        )
+        people = []
+        if can_view_people:
+            people = (
+                dependencies.Staff.query.filter_by(unit_id=unit_id, is_operational=True)
+                .order_by(dependencies.Staff.name)
+                .all()
+            )
+            people = [
+                person for person in people if dependencies.is_under_training(person)
+            ]
+        trainee_count = sum(
+            1 for person in people if dependencies.is_under_training(person)
+        )
+        return render_template(
+            "training_home.html",
+            people=people,
+            own_minutes=own_minutes,
+            can_view_people=can_view_people,
+            trainee_count=trainee_count,
+            own_under_training=dependencies.is_under_training(current_user),
+        )
+
+    @login_required
+    def training_profile(sid):
+        unit_id = dependencies.current_unit_id()
+        if not dependencies.training_enabled(unit_id):
+            abort(404)
+        person = dependencies.Staff.query.filter_by(
+            id=sid, unit_id=unit_id
+        ).first_or_404()
+        if not dependencies.training_profile_allowed(person):
+            abort(403)
+        if not dependencies.is_under_training(person):
+            abort(404)
+        if request.method == "POST":
+            dependencies.validate_csrf()
+            if not dependencies.can_record_training(
+                current_user
+            ) or not dependencies.is_under_training(person):
+                abort(403)
+            level = dependencies.TrainingLevel.query.filter_by(
+                id=int(request.form.get("level_id") or 0),
+                unit_id=unit_id,
+                is_active=True,
+            ).first_or_404()
+            try:
+                training_date = date.fromisoformat(
+                    request.form.get("training_date") or ""
+                )
+                duration_minutes = int(request.form.get("duration_minutes") or 0)
+            except TypeError, ValueError:
+                abort(400, "Enter a valid training date and duration.")
+            if not 1 <= duration_minutes <= 1440:
+                abort(400, "Training duration must be between 1 and 1,440 minutes.")
+            session_row = dependencies.TrainingSession(
+                unit_id=unit_id,
+                trainee_id=person.id,
+                ojti_id=current_user.id,
+                level_id=level.id,
+                training_date=training_date,
+                duration_minutes=duration_minutes,
+                summary=(request.form.get("summary") or "").strip()[:4000],
+            )
+            dependencies.db.session.add(session_row)
+            dependencies.db.session.flush()
+            for objective in sorted(level.objectives, key=lambda row: row.position)[
+                :15
+            ]:
+                raw_attainment = request.form.get(f"attainment_{objective.id}")
+                raw_assistance = request.form.get(f"assistance_{objective.id}")
+                if not raw_attainment and not raw_assistance:
+                    continue
+                try:
+                    attainment = int(raw_attainment or 0)
+                    assistance = int(raw_assistance or 0)
+                except ValueError:
+                    abort(400, "Objective scores must be whole numbers.")
+                if attainment not in {1, 2, 3, 4} or assistance not in {1, 2, 3, 4}:
+                    abort(400, "Objective scores must be between 1 and 4.")
+                dependencies.db.session.add(
+                    dependencies.TrainingScore(
+                        unit_id=unit_id,
+                        session_id=session_row.id,
+                        objective_id=objective.id,
+                        attainment=attainment,
+                        assistance=assistance,
+                        safety_critical=bool(
+                            request.form.get(f"safety_{objective.id}")
+                        ),
+                        note=(request.form.get(f"note_{objective.id}") or "").strip()[
+                            :4000
+                        ],
+                    )
+                )
+            dependencies.db.session.commit()
+            flash("Training report saved.", "ok")
+            return redirect(url_for("training_profile", sid=person.id, level=level.id))
+
+        levels = (
+            dependencies.TrainingLevel.query.filter_by(unit_id=unit_id, is_active=True)
+            .order_by(
+                dependencies.TrainingLevel.sort_order, dependencies.TrainingLevel.name
+            )
+            .all()
+        )
+        selected_id = request.args.get("level", type=int)
+        selected = next(
+            (row for row in levels if row.id == selected_id),
+            levels[0] if levels else None,
+        )
+        sessions = []
+        if selected:
+            sessions = (
+                dependencies.TrainingSession.query.filter_by(
+                    unit_id=unit_id, trainee_id=person.id, level_id=selected.id
+                )
+                .order_by(
+                    dependencies.TrainingSession.training_date.desc(),
+                    dependencies.TrainingSession.id.desc(),
+                )
+                .all()
+            )
+        total_minutes = sum(
+            row.duration_minutes
+            for row in dependencies.TrainingSession.query.filter_by(
+                unit_id=unit_id, trainee_id=person.id
+            ).all()
+        )
+        return render_template(
+            "training_profile.html",
+            person=person,
+            levels=levels,
+            selected_level=selected,
+            sessions=sessions,
+            total_minutes=total_minutes,
+            under_training=dependencies.is_under_training(person),
+            can_record=dependencies.can_record_training(current_user),
+        )
+
     @blueprint.record_once
     def register_routes(state):
         routes = (
-            ("/training/", "training_home", dependencies.training_home, ["GET"]),
+            ("/training/", "training_home", training_home, ["GET"]),
             (
                 "/training/<int:sid>",
                 "training_profile",
-                dependencies.training_profile,
+                training_profile,
                 ["GET", "POST"],
             ),
             ("/competency/", "competency_home", dependencies.competency_home, ["GET"]),


### PR DESCRIPTION
## What changed

- moved the training dashboard and individual training profile handlers fully into `training_blueprint.py`
- preserved feature enablement, trainee visibility, self/editor/OJTI access and report-recording permissions
- preserved tenant-scoped staff, level and session queries
- preserved CSRF checks, training duration limits, objective score validation, safety-critical flags and report history
- replaced legacy global access with explicit dependencies
- added architecture coverage preventing both handlers from returning to `app.py`

## Why

This is the first implementation stage after establishing training route ownership.

## Impact

No user-facing URL or workflow changes are intended. `app.py` is roughly 110 lines smaller.

## Validation

- focused training and route tests: 5 passed
- full suite: 213 passed, 2 skipped
- Ruff lint and formatting passed
- Bandit security scan passed
- Python compilation passed