### PR TITLE
Move operations and planning route ownership

### DIFF
--- a/app.py
+++ b/app.py
@@ -8589,7 +8589,6 @@ def _position_assurance(year: int, month: int) -> list[dict]:
     return rows
 
 
-@app.route("/operations/<ym>", methods=["GET", "POST"])
 @login_required
 def operations_assurance(ym):
     if not is_admin_user(current_user):
@@ -8791,7 +8790,6 @@ def operations_assurance(ym):
     )
 
 
-@app.route("/planning/coverage/<ym>")
 @login_required
 def coverage_heatmap(ym):
     if not can_edit_roster(current_user):
@@ -8830,7 +8828,6 @@ def coverage_heatmap(ym):
     )
 
 
-@app.route("/planning/scenarios", methods=["GET", "POST"])
 @login_required
 def scenarios_page():
     if not can_edit_roster(current_user):
@@ -9802,6 +9799,7 @@ from absence_requests_blueprint import (
 from reports_blueprint import ReportsDependencies, create_reports_blueprint
 from roster_blueprint import RosterDependencies, create_roster_blueprint
 from training_blueprint import TrainingDependencies, create_training_blueprint
+from operations_blueprint import OperationsDependencies, create_operations_blueprint
 
 app.register_blueprint(create_auth_blueprint(AuthDependencies(
     db=db,
@@ -9945,6 +9943,11 @@ app.register_blueprint(create_training_blueprint(TrainingDependencies(
     record_qualification_history=_record_qualification_history,
     sync_qualification_to_roster_profile=_sync_qualification_to_roster_profile,
     TrainingObjective=TrainingObjective,
+)))
+app.register_blueprint(create_operations_blueprint(OperationsDependencies(
+    operations_assurance=operations_assurance,
+    coverage_heatmap=coverage_heatmap,
+    scenarios_page=scenarios_page,
 )))
 app.register_blueprint(briefing_blueprint)
 

--- a/operations_blueprint.py
+++ b/operations_blueprint.py
@@ -1,0 +1,48 @@
+"""Route ownership for operations assurance and planning workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from flask import Blueprint
+
+
+@dataclass(frozen=True)
+class OperationsDependencies:
+    operations_assurance: Callable
+    coverage_heatmap: Callable
+    scenarios_page: Callable
+
+
+def create_operations_blueprint(dependencies: OperationsDependencies) -> Blueprint:
+    blueprint = Blueprint("operations", __name__)
+
+    @blueprint.record_once
+    def register_routes(state):
+        routes = (
+            (
+                "/operations/<ym>",
+                "operations_assurance",
+                dependencies.operations_assurance,
+                ["GET", "POST"],
+            ),
+            (
+                "/planning/coverage/<ym>",
+                "coverage_heatmap",
+                dependencies.coverage_heatmap,
+                ["GET"],
+            ),
+            (
+                "/planning/scenarios",
+                "scenarios_page",
+                dependencies.scenarios_page,
+                ["GET", "POST"],
+            ),
+        )
+        for rule, endpoint, view_func, methods in routes:
+            state.app.add_url_rule(
+                rule, endpoint=endpoint, view_func=view_func, methods=methods
+            )
+
+    return blueprint

--- a/tests/test_operations_blueprint.py
+++ b/tests/test_operations_blueprint.py
@@ -1,0 +1,23 @@
+ENDPOINTS = {
+    "operations_assurance": ("/operations/<ym>", {"GET", "POST"}),
+    "coverage_heatmap": ("/planning/coverage/<ym>", {"GET"}),
+    "scenarios_page": ("/planning/scenarios", {"GET", "POST"}),
+}
+
+
+def test_operations_blueprint_preserves_global_endpoint_contract():
+    import app
+
+    rules = {rule.endpoint: rule for rule in app.app.url_map.iter_rules()}
+    for endpoint, (path, methods) in ENDPOINTS.items():
+        assert endpoint in rules
+        assert rules[endpoint].rule == path
+        assert methods <= rules[endpoint].methods
+
+
+def test_operations_routes_are_owned_outside_legacy_module():
+    from pathlib import Path
+
+    source = (Path(__file__).parents[1] / "app.py").read_text()
+    for path, _methods in ENDPOINTS.values():
+        assert f'@app.route("{path}"' not in source


### PR DESCRIPTION
## What changed

- added a dedicated operations blueprint
- moved ownership of the monthly operations, coverage planning and planning scenarios URLs out of `app.py`
- preserved global endpoint names, URL paths, HTTP methods, login decorators and existing handlers
- added endpoint-contract and architecture tests

## Why

This establishes a tested boundary before moving the operations and planning implementations in focused stages.

## Impact

No user-facing URL, permission or workflow changes are intended.

## Validation

- focused operations/route tests: 4 passed
- full suite: 217 passed, 2 skipped
- Ruff lint and formatting passed
- Bandit security scan passed
- Python compilation passed