### PR TITLE
Move coverage planning handler into blueprint

### DIFF
--- a/app.py
+++ b/app.py
@@ -8590,44 +8590,6 @@ def _position_assurance(year: int, month: int) -> list[dict]:
 
 
 @login_required
-def coverage_heatmap(ym):
-    if not can_edit_roster(current_user):
-        abort(403)
-    year, month = parse_ym(ym)
-    start, days = month_range(year, month)
-    end = days[-1]
-    counts = defaultdict(Counter)
-    competence_exclusions = defaultdict(Counter)
-    assignments = Assignment.query.filter(
-        Assignment.unit_id == _current_unit_id(),
-        Assignment.day >= start, Assignment.day <= end,
-    ).all()
-    for assignment in assignments:
-        shift = ShiftType.query.filter_by(
-            unit_id=_current_unit_id(), code=assignment.code
-        ).first()
-        group = shift_counter_group_for_day(
-            assignment.code, assignment.day, _current_unit_id()
-        )
-        if not group:
-            continue
-        if (
-            shift
-            and shift.required_qualification
-            and not _staff_has_shift_qualification(
-                assignment.staff, shift, assignment.day
-            )
-        ):
-            competence_exclusions[assignment.day][group] += 1
-            continue
-        counts[assignment.day][group] += 1
-    return render_template(
-        "coverage_heatmap.html", days=days, counts=counts, ym=ym,
-        competence_exclusions=competence_exclusions,
-    )
-
-
-@login_required
 def scenarios_page():
     if not can_edit_roster(current_user):
         abort(403)
@@ -9763,7 +9725,11 @@ app.register_blueprint(create_operations_blueprint(OperationsDependencies(
     log_change=log_change,
     month_add=_month_add,
     position_assurance=_position_assurance,
-    coverage_heatmap=coverage_heatmap,
+    can_edit_roster=can_edit_roster,
+    parse_year_month=parse_ym,
+    month_range=month_range,
+    shift_counter_group_for_day=shift_counter_group_for_day,
+    staff_has_shift_qualification=_staff_has_shift_qualification,
     scenarios_page=scenarios_page,
 )))
 app.register_blueprint(briefing_blueprint)

--- a/operations_blueprint.py
+++ b/operations_blueprint.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import Counter, defaultdict
 from dataclasses import dataclass
 from datetime import date, datetime, time
 import json
@@ -41,7 +42,11 @@ class OperationsDependencies:
     log_change: Callable
     month_add: Callable
     position_assurance: Callable
-    coverage_heatmap: Callable
+    can_edit_roster: Callable
+    parse_year_month: Callable
+    month_range: Callable
+    shift_counter_group_for_day: Callable
+    staff_has_shift_qualification: Callable
     scenarios_page: Callable
 
 
@@ -340,6 +345,47 @@ def create_operations_blueprint(dependencies: OperationsDependencies) -> Bluepri
             .all(),
         )
 
+    @login_required
+    def coverage_heatmap(ym):
+        if not dependencies.can_edit_roster(current_user):
+            abort(403)
+        year, month = dependencies.parse_year_month(ym)
+        start, days = dependencies.month_range(year, month)
+        end = days[-1]
+        counts = defaultdict(Counter)
+        competence_exclusions = defaultdict(Counter)
+        assignments = dependencies.Assignment.query.filter(
+            dependencies.Assignment.unit_id == dependencies.current_unit_id(),
+            dependencies.Assignment.day >= start,
+            dependencies.Assignment.day <= end,
+        ).all()
+        for assignment in assignments:
+            shift = dependencies.ShiftType.query.filter_by(
+                unit_id=dependencies.current_unit_id(), code=assignment.code
+            ).first()
+            group = dependencies.shift_counter_group_for_day(
+                assignment.code, assignment.day, dependencies.current_unit_id()
+            )
+            if not group:
+                continue
+            if (
+                shift
+                and shift.required_qualification
+                and not dependencies.staff_has_shift_qualification(
+                    assignment.staff, shift, assignment.day
+                )
+            ):
+                competence_exclusions[assignment.day][group] += 1
+                continue
+            counts[assignment.day][group] += 1
+        return render_template(
+            "coverage_heatmap.html",
+            days=days,
+            counts=counts,
+            ym=ym,
+            competence_exclusions=competence_exclusions,
+        )
+
     @blueprint.record_once
     def register_routes(state):
         routes = (
@@ -352,7 +398,7 @@ def create_operations_blueprint(dependencies: OperationsDependencies) -> Bluepri
             (
                 "/planning/coverage/<ym>",
                 "coverage_heatmap",
-                dependencies.coverage_heatmap,
+                coverage_heatmap,
                 ["GET"],
             ),
             (

--- a/tests/test_operations_blueprint.py
+++ b/tests/test_operations_blueprint.py
@@ -28,3 +28,10 @@ def test_operations_handler_is_no_longer_in_legacy_module():
 
     source = (Path(__file__).parents[1] / "app.py").read_text()
     assert "def operations_assurance(" not in source
+
+
+def test_coverage_handler_is_no_longer_in_legacy_module():
+    from pathlib import Path
+
+    source = (Path(__file__).parents[1] / "app.py").read_text()
+    assert "def coverage_heatmap(" not in source


### PR DESCRIPTION
## What changed

- moved the coverage heatmap handler fully into `operations_blueprint.py`
- preserved roster-edit authorization and month parsing
- preserved tenant-scoped assignment and shift lookups
- preserved shift counter grouping and exclusion of staff whose required qualification is missing or expired
- preserved the existing template context and global endpoint
- added architecture coverage preventing the handler from returning to `app.py`

## Why

This continues the staged operations/planning extraction after the monthly operations handler.

## Impact

No user-facing URL or workflow changes are intended. `app.py` is roughly 40 lines smaller.

## Validation

- focused operations/coverage tests: 6 passed
- full suite: 219 passed, 2 skipped
- Ruff lint and formatting passed
- Bandit security scan passed
- Python compilation passed