### PR TITLE
Add live position monitoring foundation

### DIFF
--- a/access_policy.py
+++ b/access_policy.py
@@ -18,7 +18,7 @@ def is_editor(user) -> bool:
 def permissions_for(user) -> dict[str, bool]:
     try:
         raw = json.loads(getattr(user, "permissions_json", "") or "{}")
-    except (TypeError, ValueError, json.JSONDecodeError):
+    except TypeError, ValueError, json.JSONDecodeError:
         return {}
     if not isinstance(raw, dict):
         return {}

--- a/access_policy.py
+++ b/access_policy.py
@@ -18,7 +18,7 @@ def is_editor(user) -> bool:
 def permissions_for(user) -> dict[str, bool]:
     try:
         raw = json.loads(getattr(user, "permissions_json", "") or "{}")
-    except TypeError, ValueError, json.JSONDecodeError:
+    except (TypeError, ValueError, json.JSONDecodeError):
         return {}
     if not isinstance(raw, dict):
         return {}

--- a/app.py
+++ b/app.py
@@ -471,7 +471,10 @@ OPERATIONAL_TABLE_NAMES = frozenset({
     "briefing_item", "briefing_delivery", "briefing_audit",
     "briefing_assurance_run", "briefing_message_type",
     "training_level", "training_objective", "training_session",
-    "training_score",
+    "training_score", "position_currency_category",
+    "position_participant_role", "position_status_event",
+    "position_session", "position_session_participant",
+    "controller_kiosk_credential", "position_session_audit",
 })
 
 
@@ -604,7 +607,20 @@ def _bind_tenant_context():
             )
     if (
         current_user.is_authenticated
+        and getattr(current_user, "role", "") == "position_monitor"
+    ):
+        allowed_kiosk_endpoints = {
+            "live_position.kiosk_hmi", "live_position.live_state",
+            "logout", "static", "favicon", "health_live", "health_ready",
+        }
+        if request.endpoint not in allowed_kiosk_endpoints:
+            if request.method == "GET":
+                return redirect(url_for("live_position.kiosk_hmi"))
+            abort(403)
+    if (
+        current_user.is_authenticated
         and getattr(current_user, "role", "") != "superadmin"
+        and getattr(current_user, "role", "") != "position_monitor"
         and (
             DEPLOYMENT_ENV == "production"
             or UnitMembership.query.filter_by(
@@ -728,6 +744,8 @@ def _canonical_login_redirect(
 
 def _airport_login_endpoint(user) -> str:
     """Land multi-module airport users on the module launcher."""
+    if getattr(user, "role", "") == "position_monitor":
+        return "live_position.kiosk_hmi"
     enabled = FeatureFlag.query.filter(
         FeatureFlag.unit_id == user.unit_id,
         FeatureFlag.key.in_((
@@ -1307,7 +1325,7 @@ class Staff(UserMixin, db.Model):
     email = db.Column(db.String(254), nullable=False, default="")
 
     # Roles: 'admin' | 'editor' | 'user'
-    role = db.Column(db.String(10), nullable=False, default="user")
+    role = db.Column(db.String(32), nullable=False, default="user")
     membership_status = db.Column(db.String(20), nullable=False, default="active")
     permissions_json = db.Column(db.Text, nullable=False, default="{}")
 
@@ -1654,6 +1672,13 @@ RosterPublication = SaaS.RosterPublication
 RosterAcknowledgement = SaaS.RosterAcknowledgement
 Scenario = SaaS.Scenario
 OperationalPosition = SaaS.OperationalPosition
+PositionCurrencyCategory = SaaS.PositionCurrencyCategory
+PositionParticipantRole = SaaS.PositionParticipantRole
+PositionStatusEvent = SaaS.PositionStatusEvent
+PositionSession = SaaS.PositionSession
+PositionSessionParticipant = SaaS.PositionSessionParticipant
+ControllerKioskCredential = SaaS.ControllerKioskCredential
+PositionSessionAudit = SaaS.PositionSessionAudit
 PositionEndorsement = SaaS.PositionEndorsement
 PositionRequirement = SaaS.PositionRequirement
 BreakPlan = SaaS.BreakPlan
@@ -1681,7 +1706,10 @@ TENANT_OPERATIONAL_MODELS = (
     ChangeLog, StaffWatchHistory, QualificationType,
     PersonQualification, PersonQualificationHistory,
     RosterPublication, RosterAcknowledgement, Scenario,
-    OperationalPosition, PositionEndorsement, PositionRequirement, BreakPlan,
+    OperationalPosition, PositionCurrencyCategory, PositionParticipantRole,
+    PositionStatusEvent, PositionSession, PositionSessionParticipant,
+    ControllerKioskCredential, PositionSessionAudit,
+    PositionEndorsement, PositionRequirement, BreakPlan,
     AchievedDuty, FatigueReport, RosterRuleVersion,
     MfaCredential, BriefingMessageType, BriefingItem, BriefingDelivery,
     BriefingAudit,
@@ -9486,6 +9514,16 @@ from reports_blueprint import ReportsDependencies, create_reports_blueprint
 from roster_blueprint import RosterDependencies, create_roster_blueprint
 from training_blueprint import TrainingDependencies, create_training_blueprint
 from operations_blueprint import OperationsDependencies, create_operations_blueprint
+from live_position_blueprint import (
+    LivePositionDependencies, create_live_position_blueprint,
+)
+
+app.register_blueprint(create_live_position_blueprint(LivePositionDependencies(
+    db=db, Unit=Unit, OperationalPosition=OperationalPosition,
+    PositionStatusEvent=PositionStatusEvent, PositionSession=PositionSession,
+    PositionSessionParticipant=PositionSessionParticipant, Staff=Staff,
+    utcnow=utcnow, is_admin_user=is_admin_user,
+)))
 
 app.register_blueprint(create_auth_blueprint(AuthDependencies(
     db=db,

--- a/auth_blueprint.py
+++ b/auth_blueprint.py
@@ -195,6 +195,19 @@ def create_auth_blueprint(dependencies: AuthDependencies) -> Blueprint:
                             else "platform_mfa_setup"
                         )
                     )
+                if user.role == "position_monitor":
+                    # Password-only authentication is deliberately confined to
+                    # the locked-down unit kiosk role. Ordinary airport users
+                    # continue through the existing MFA flow below.
+                    login_user(user, remember=True)
+                    session.permanent = True
+                    dependencies.initialize_authenticated_session(user)
+                    dependencies.security_event(
+                        "position_monitor_login_succeeded",
+                        principal=rate_key[-16:], unit_id=user.unit_id,
+                    )
+                    dependencies.record_successful_login(user)
+                    return redirect(url_for(dependencies.airport_login_endpoint(user)))
                 credential = dependencies.MfaCredential.query.filter_by(
                     person_id=user.id, enabled=True
                 ).first()

--- a/auth_blueprint.py
+++ b/auth_blueprint.py
@@ -204,7 +204,8 @@ def create_auth_blueprint(dependencies: AuthDependencies) -> Blueprint:
                     dependencies.initialize_authenticated_session(user)
                     dependencies.security_event(
                         "position_monitor_login_succeeded",
-                        principal=rate_key[-16:], unit_id=user.unit_id,
+                        principal=rate_key[-16:],
+                        unit_id=user.unit_id,
                     )
                     dependencies.record_successful_login(user)
                     return redirect(url_for(dependencies.airport_login_endpoint(user)))

--- a/live_position_blueprint.py
+++ b/live_position_blueprint.py
@@ -1,0 +1,126 @@
+"""HTTP boundary for the Live Position Monitoring module."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from flask import Blueprint, abort, jsonify, render_template
+from flask_login import current_user, login_required
+
+
+@dataclass(frozen=True)
+class LivePositionDependencies:
+    db: Any
+    Unit: Any
+    OperationalPosition: Any
+    PositionStatusEvent: Any
+    PositionSession: Any
+    PositionSessionParticipant: Any
+    Staff: Any
+    utcnow: Callable[[], Any]
+    is_admin_user: Callable[[Any], bool]
+
+
+def create_live_position_blueprint(
+    dependencies: LivePositionDependencies,
+) -> Blueprint:
+    blueprint = Blueprint("live_position", __name__, url_prefix="/live-positions")
+
+    def _unit_id() -> int:
+        return int(getattr(current_user, "unit_id", 0) or 0)
+
+    def _require_kiosk_or_admin() -> None:
+        if not (
+            getattr(current_user, "role", "") == "position_monitor"
+            or dependencies.is_admin_user(current_user)
+        ):
+            abort(403)
+
+    @blueprint.get("/")
+    @login_required
+    def admin_home():
+        if not dependencies.is_admin_user(current_user):
+            abort(403)
+        return render_template("live_position/admin_home.html")
+
+    @blueprint.get("/kiosk")
+    @login_required
+    def kiosk_hmi():
+        _require_kiosk_or_admin()
+        unit = dependencies.db.session.get(dependencies.Unit, _unit_id())
+        return render_template("live_position/kiosk.html", unit=unit)
+
+    @blueprint.get("/api/state")
+    @login_required
+    def live_state():
+        _require_kiosk_or_admin()
+        unit_id = _unit_id()
+        now = dependencies.utcnow()
+        positions = (
+            dependencies.OperationalPosition.query
+            .filter_by(unit_id=unit_id, is_active=True)
+            .order_by(
+                dependencies.OperationalPosition.display_order,
+                dependencies.OperationalPosition.code,
+            ).all()
+        )
+        state = []
+        for position in positions:
+            status_event = (
+                dependencies.PositionStatusEvent.query
+                .filter_by(unit_id=unit_id, position_id=position.id)
+                .order_by(
+                    dependencies.PositionStatusEvent.occurred_at.desc(),
+                    dependencies.PositionStatusEvent.id.desc(),
+                ).first()
+            )
+            session = (
+                dependencies.PositionSession.query
+                .filter_by(
+                    unit_id=unit_id, position_id=position.id,
+                    ended_at=None, is_void=False,
+                ).first()
+            )
+            primary = (
+                dependencies.db.session.get(
+                    dependencies.Staff, session.primary_person_id
+                ) if session else None
+            )
+            participants = []
+            if session:
+                for row in dependencies.PositionSessionParticipant.query.filter_by(
+                    unit_id=unit_id, session_id=session.id, ended_at=None
+                ).all():
+                    person = dependencies.db.session.get(
+                        dependencies.Staff, row.person_id
+                    )
+                    participants.append({
+                        "id": row.id,
+                        "person_name": person.name if person else "Unknown",
+                        "role_id": row.role_id,
+                        "started_at": row.started_at.isoformat() + "Z",
+                    })
+            physical_status = status_event.status if status_event else "closed"
+            display_status = (
+                "closed" if physical_status == "closed" else
+                session.session_type if session else "vacant"
+            )
+            state.append({
+                "id": position.id, "code": position.code,
+                "label": position.label, "physical_status": physical_status,
+                "display_status": display_status,
+                "primary": ({
+                    "id": primary.id, "name": primary.name,
+                    "started_at": session.started_at.isoformat() + "Z",
+                    "due_off_at": (
+                        session.due_off_at.isoformat() + "Z"
+                        if session.due_off_at else None
+                    ),
+                } if primary and session else None),
+                "participants": participants,
+            })
+        return jsonify({
+            "server_time": now.isoformat() + "Z", "positions": state,
+        })
+
+    return blueprint

--- a/live_position_service.py
+++ b/live_position_service.py
@@ -1,0 +1,236 @@
+"""Transactional domain operations for Live Position Monitoring.
+
+Routes deliberately stay thin: all linked position/session/audit mutations are
+performed here using one authoritative timestamp and one transaction key.
+"""
+from __future__ import annotations
+
+import json
+import secrets
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Callable
+
+from sqlalchemy.exc import IntegrityError
+
+
+class LivePositionConflict(RuntimeError):
+    """The requested state transition conflicts with current live state."""
+
+
+class LivePositionValidationError(ValueError):
+    """The requested state transition is not operationally valid."""
+
+
+@dataclass(frozen=True)
+class LivePositionModels:
+    OperationalPosition: Any
+    PositionStatusEvent: Any
+    PositionSession: Any
+    PositionSessionParticipant: Any
+    PositionSessionAudit: Any
+
+
+class LivePositionService:
+    def __init__(
+        self, db: Any, models: LivePositionModels,
+        now: Callable[[], datetime],
+    ) -> None:
+        self.db = db
+        self.models = models
+        self.now = now
+
+    @staticmethod
+    def transaction_key(value: str | None = None) -> str:
+        value = (value or "").strip()
+        return value[:64] if value else secrets.token_hex(24)
+
+    def _position_for_update(self, unit_id: int, position_id: int) -> Any:
+        position = (
+            self.models.OperationalPosition.query
+            .filter_by(id=position_id, unit_id=unit_id, is_active=True)
+            .with_for_update()
+            .first()
+        )
+        if not position:
+            raise LivePositionValidationError("Unknown or inactive position.")
+        return position
+
+    def _open_session(self, unit_id: int, position_id: int) -> Any | None:
+        return (
+            self.models.PositionSession.query
+            .filter_by(
+                unit_id=unit_id, position_id=position_id,
+                ended_at=None, is_void=False,
+            )
+            .with_for_update()
+            .first()
+        )
+
+    def _latest_status(self, unit_id: int, position_id: int) -> str:
+        event = (
+            self.models.PositionStatusEvent.query
+            .filter_by(unit_id=unit_id, position_id=position_id)
+            .order_by(
+                self.models.PositionStatusEvent.occurred_at.desc(),
+                self.models.PositionStatusEvent.id.desc(),
+            ).first()
+        )
+        return event.status if event else "closed"
+
+    def _audit(
+        self, *, unit_id: int, actor_id: int, action: str,
+        occurred_at: datetime, transaction_key: str,
+        session_id: int | None = None, position_id: int | None = None,
+        old: dict[str, Any] | None = None, new: dict[str, Any] | None = None,
+        reason: str = "",
+    ) -> None:
+        self.db.session.add(self.models.PositionSessionAudit(
+            unit_id=unit_id, session_id=session_id, position_id=position_id,
+            actor_id=actor_id, action=action, occurred_at=occurred_at,
+            old_value_json=json.dumps(old or {}, sort_keys=True, default=str),
+            new_value_json=json.dumps(new or {}, sort_keys=True, default=str),
+            reason=reason, transaction_key=transaction_key,
+        ))
+
+    def set_position_open(
+        self, *, unit_id: int, position_id: int, actor_id: int,
+        open_position: bool, reason: str = "", request_key: str | None = None,
+    ) -> Any:
+        key = self.transaction_key(request_key)
+        existing = self.models.PositionStatusEvent.query.filter_by(
+            transaction_key=key
+        ).first()
+        if existing:
+            return existing
+        timestamp = self.now()
+        target = "open" if open_position else "closed"
+        try:
+            self._position_for_update(unit_id, position_id)
+            current = self._latest_status(unit_id, position_id)
+            if target == "closed":
+                active = self._open_session(unit_id, position_id)
+                if active:
+                    self._end_session_records(
+                        active, timestamp, "position_closed", key
+                    )
+                    self._audit(
+                        unit_id=unit_id, actor_id=actor_id,
+                        action="session_ended", occurred_at=timestamp,
+                        transaction_key=key, session_id=active.id,
+                        position_id=position_id,
+                        new={"ended_at": timestamp, "reason": "position_closed"},
+                        reason=reason,
+                    )
+            event = self.models.PositionStatusEvent(
+                unit_id=unit_id, position_id=position_id, status=target,
+                occurred_at=timestamp, actor_id=actor_id, reason=reason,
+                transaction_key=key,
+            )
+            self.db.session.add(event)
+            self._audit(
+                unit_id=unit_id, actor_id=actor_id,
+                action="position_opened" if open_position else "position_closed",
+                occurred_at=timestamp, transaction_key=key,
+                position_id=position_id, old={"status": current},
+                new={"status": target}, reason=reason,
+            )
+            self.db.session.commit()
+            return event
+        except IntegrityError as error:
+            self.db.session.rollback()
+            raise LivePositionConflict("Position state changed concurrently.") from error
+
+    def start_session(
+        self, *, unit_id: int, position_id: int, person_id: int,
+        actor_id: int, session_type: str = "operational",
+        currency_category_id: int | None = None,
+        maximum_duration_seconds: int | None = None,
+        warning_threshold_seconds: int | None = None,
+        due_off_at: datetime | None = None, request_key: str | None = None,
+    ) -> Any:
+        if session_type not in {"operational", "training", "assessment", "supervised"}:
+            raise LivePositionValidationError("Unsupported session type.")
+        key = self.transaction_key(request_key)
+        existing = self.models.PositionSession.query.filter_by(
+            transaction_key=key
+        ).first()
+        if existing:
+            return existing
+        timestamp = self.now()
+        try:
+            position = self._position_for_update(unit_id, position_id)
+            if self._latest_status(unit_id, position_id) != "open":
+                raise LivePositionConflict("The position is closed.")
+            if self._open_session(unit_id, position_id):
+                raise LivePositionConflict("The position is already occupied.")
+            if session_type == "training" and not position.training_supported:
+                raise LivePositionValidationError("Training is not supported here.")
+            if session_type == "assessment" and not position.assessment_supported:
+                raise LivePositionValidationError("Assessment is not supported here.")
+            session = self.models.PositionSession(
+                unit_id=unit_id, position_id=position_id,
+                primary_person_id=person_id, session_type=session_type,
+                started_at=timestamp, currency_category_id=(
+                    currency_category_id or position.currency_category_id
+                ), maximum_duration_seconds=maximum_duration_seconds,
+                warning_threshold_seconds=warning_threshold_seconds,
+                due_off_at=due_off_at, created_by_id=actor_id,
+                transaction_key=key,
+            )
+            self.db.session.add(session)
+            self.db.session.flush()
+            self._audit(
+                unit_id=unit_id, actor_id=actor_id, action="session_started",
+                occurred_at=timestamp, transaction_key=key,
+                session_id=session.id, position_id=position_id,
+                new={"person_id": person_id, "session_type": session_type,
+                     "started_at": timestamp},
+            )
+            self.db.session.commit()
+            return session
+        except IntegrityError as error:
+            self.db.session.rollback()
+            raise LivePositionConflict(
+                "The position or controller became occupied concurrently."
+            ) from error
+
+    def _end_session_records(
+        self, session: Any, timestamp: datetime, reason: str, key: str
+    ) -> None:
+        participants = (
+            self.models.PositionSessionParticipant.query
+            .filter_by(session_id=session.id, unit_id=session.unit_id, ended_at=None)
+            .with_for_update().all()
+        )
+        for participant in participants:
+            participant.ended_at = timestamp
+            participant.ended_reason = reason
+        session.ended_at = timestamp
+        session.ended_reason = reason
+        session.version += 1
+
+    def end_session(
+        self, *, unit_id: int, position_id: int, actor_id: int,
+        reason: str = "logoff", request_key: str | None = None,
+    ) -> Any:
+        key = self.transaction_key(request_key)
+        audit = self.models.PositionSessionAudit.query.filter_by(
+            transaction_key=key, action="session_ended"
+        ).first()
+        if audit and audit.session_id:
+            return self.db.session.get(self.models.PositionSession, audit.session_id)
+        timestamp = self.now()
+        self._position_for_update(unit_id, position_id)
+        session = self._open_session(unit_id, position_id)
+        if not session:
+            raise LivePositionConflict("The position is not occupied.")
+        self._end_session_records(session, timestamp, reason, key)
+        self._audit(
+            unit_id=unit_id, actor_id=actor_id, action="session_ended",
+            occurred_at=timestamp, transaction_key=key,
+            session_id=session.id, position_id=position_id,
+            new={"ended_at": timestamp, "reason": reason},
+        )
+        self.db.session.commit()
+        return session

--- a/migrations/versions/20260731_29_live_position_core.py
+++ b/migrations/versions/20260731_29_live_position_core.py
@@ -1,0 +1,229 @@
+"""live position monitoring core records
+
+Revision ID: 20260731_29
+Revises: 20260730_28
+"""
+import os
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260731_29"
+down_revision = "20260730_28"
+branch_labels = None
+depends_on = None
+
+
+def _tenant_columns():
+    return [
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("unit_id", sa.Integer(), nullable=False, index=True),
+    ]
+
+
+def upgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
+
+    staff_columns = {
+        column["name"] for column in sa.inspect(op.get_bind()).get_columns("staff")
+    }
+    with op.batch_alter_table("staff") as batch:
+        if "role" in staff_columns:
+            batch.alter_column(
+                "role", existing_type=sa.String(10), type_=sa.String(32),
+                existing_nullable=False,
+            )
+        else:
+            batch.add_column(sa.Column(
+                "role", sa.String(32), nullable=False, server_default="user"
+            ))
+
+    op.create_table(
+        "position_currency_category", *_tenant_columns(),
+        sa.Column("code", sa.String(30), nullable=False),
+        sa.Column("label", sa.String(120), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.UniqueConstraint(
+            "unit_id", "code", name="uq_position_currency_category_code"
+        ),
+    )
+    existing_tables = set(sa.inspect(op.get_bind()).get_table_names())
+    if "operational_position" not in existing_tables:
+        op.create_table(
+            "operational_position", *_tenant_columns(),
+            sa.Column("code", sa.String(30), nullable=False),
+            sa.Column("label", sa.String(120), nullable=False),
+            sa.Column("description", sa.Text(), nullable=False, server_default=""),
+            sa.Column("display_order", sa.Integer(), nullable=False, server_default="100"),
+            sa.Column("group_name", sa.String(80), nullable=False, server_default=""),
+            sa.Column("currency_category_id", sa.Integer(), sa.ForeignKey(
+                "position_currency_category.id",
+                name="fk_operational_position_currency_category",
+            )),
+            sa.Column("supporting_participants_allowed", sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.Column("multiple_supporting_participants_allowed", sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.Column("training_supported", sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.Column("assessment_supported", sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.Column("is_safety_critical", sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.UniqueConstraint("unit_id", "code", name="uq_position_unit_code"),
+        )
+    else:
+        with op.batch_alter_table("operational_position") as batch:
+            batch.add_column(sa.Column("display_order", sa.Integer(), nullable=False, server_default="100"))
+            batch.add_column(sa.Column("group_name", sa.String(80), nullable=False, server_default=""))
+            batch.add_column(sa.Column("currency_category_id", sa.Integer()))
+            batch.add_column(sa.Column("supporting_participants_allowed", sa.Boolean(), nullable=False, server_default=sa.true()))
+            batch.add_column(sa.Column("multiple_supporting_participants_allowed", sa.Boolean(), nullable=False, server_default=sa.true()))
+            batch.add_column(sa.Column("training_supported", sa.Boolean(), nullable=False, server_default=sa.true()))
+            batch.add_column(sa.Column("assessment_supported", sa.Boolean(), nullable=False, server_default=sa.true()))
+            batch.create_foreign_key(
+                "fk_operational_position_currency_category",
+                "position_currency_category", ["currency_category_id"], ["id"],
+            )
+
+    op.create_table(
+        "position_participant_role", *_tenant_columns(),
+        sa.Column("code", sa.String(30), nullable=False),
+        sa.Column("label", sa.String(80), nullable=False),
+        sa.Column("is_primary", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("counts_for_currency", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.UniqueConstraint(
+            "unit_id", "code", name="uq_position_participant_role_code"
+        ),
+    )
+    op.create_table(
+        "position_status_event", *_tenant_columns(),
+        sa.Column("position_id", sa.Integer(), sa.ForeignKey("operational_position.id"), nullable=False, index=True),
+        sa.Column("status", sa.String(20), nullable=False),
+        sa.Column("occurred_at", sa.DateTime(), nullable=False, index=True),
+        sa.Column("actor_id", sa.Integer(), sa.ForeignKey("staff.id"), nullable=False),
+        sa.Column("reason", sa.String(250), nullable=False, server_default=""),
+        sa.Column("transaction_key", sa.String(64), nullable=False, unique=True),
+        sa.CheckConstraint("status IN ('closed', 'open')", name="ck_position_status_event_status"),
+    )
+    op.create_table(
+        "position_session", *_tenant_columns(),
+        sa.Column("position_id", sa.Integer(), sa.ForeignKey("operational_position.id"), nullable=False, index=True),
+        sa.Column("primary_person_id", sa.Integer(), sa.ForeignKey("staff.id"), nullable=False, index=True),
+        sa.Column("session_type", sa.String(20), nullable=False, server_default="operational"),
+        sa.Column("started_at", sa.DateTime(), nullable=False, index=True),
+        sa.Column("ended_at", sa.DateTime(), index=True),
+        sa.Column("ended_reason", sa.String(40), nullable=False, server_default=""),
+        sa.Column("maximum_duration_seconds", sa.Integer()),
+        sa.Column("warning_threshold_seconds", sa.Integer()),
+        sa.Column("due_off_at", sa.DateTime()),
+        sa.Column("currency_category_id", sa.Integer(), sa.ForeignKey("position_currency_category.id")),
+        sa.Column("created_by_id", sa.Integer(), sa.ForeignKey("staff.id"), nullable=False),
+        sa.Column("corrected_at", sa.DateTime()),
+        sa.Column("corrected_by_id", sa.Integer(), sa.ForeignKey("staff.id")),
+        sa.Column("correction_reason", sa.String(500), nullable=False, server_default=""),
+        sa.Column("is_void", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("transaction_key", sa.String(64), nullable=False, unique=True),
+        sa.CheckConstraint("ended_at IS NULL OR ended_at >= started_at", name="ck_position_session_time_order"),
+    )
+    op.create_index(
+        "uq_position_session_open_position", "position_session", ["unit_id", "position_id"],
+        unique=True, postgresql_where=sa.text("ended_at IS NULL AND is_void = false"),
+        sqlite_where=sa.text("ended_at IS NULL AND is_void = 0"),
+    )
+    op.create_index(
+        "uq_position_session_open_controller", "position_session", ["unit_id", "primary_person_id"],
+        unique=True, postgresql_where=sa.text("ended_at IS NULL AND is_void = false"),
+        sqlite_where=sa.text("ended_at IS NULL AND is_void = 0"),
+    )
+    op.create_table(
+        "position_session_participant", *_tenant_columns(),
+        sa.Column("session_id", sa.Integer(), sa.ForeignKey("position_session.id"), nullable=False, index=True),
+        sa.Column("person_id", sa.Integer(), sa.ForeignKey("staff.id"), nullable=False, index=True),
+        sa.Column("role_id", sa.Integer(), sa.ForeignKey("position_participant_role.id"), nullable=False, index=True),
+        sa.Column("started_at", sa.DateTime(), nullable=False, index=True),
+        sa.Column("ended_at", sa.DateTime(), index=True),
+        sa.Column("ended_reason", sa.String(40), nullable=False, server_default=""),
+        sa.Column("transaction_key", sa.String(64), nullable=False, unique=True),
+        sa.CheckConstraint("ended_at IS NULL OR ended_at >= started_at", name="ck_position_participant_time_order"),
+    )
+    op.create_index(
+        "uq_position_participant_open_person", "position_session_participant",
+        ["unit_id", "person_id"], unique=True,
+        postgresql_where=sa.text("ended_at IS NULL"),
+        sqlite_where=sa.text("ended_at IS NULL"),
+    )
+    op.create_table(
+        "controller_kiosk_credential", *_tenant_columns(),
+        sa.Column("person_id", sa.Integer(), sa.ForeignKey("staff.id"), nullable=False, unique=True),
+        sa.Column("pin_hash", sa.String(255), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("failed_attempts", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("locked_until", sa.DateTime()),
+        sa.Column("changed_at", sa.DateTime(), nullable=False),
+    )
+    op.create_table(
+        "position_session_audit", *_tenant_columns(),
+        sa.Column("session_id", sa.Integer(), sa.ForeignKey("position_session.id"), index=True),
+        sa.Column("position_id", sa.Integer(), sa.ForeignKey("operational_position.id"), index=True),
+        sa.Column("actor_id", sa.Integer(), sa.ForeignKey("staff.id"), nullable=False),
+        sa.Column("action", sa.String(40), nullable=False, index=True),
+        sa.Column("occurred_at", sa.DateTime(), nullable=False, index=True),
+        sa.Column("old_value_json", sa.Text(), nullable=False, server_default="{}"),
+        sa.Column("new_value_json", sa.Text(), nullable=False, server_default="{}"),
+        sa.Column("reason", sa.String(500), nullable=False, server_default=""),
+        sa.Column("transaction_key", sa.String(64), nullable=False, index=True),
+    )
+
+    roles = sa.table(
+        "position_participant_role",
+        sa.column("unit_id", sa.Integer), sa.column("code", sa.String),
+        sa.column("label", sa.String), sa.column("is_primary", sa.Boolean),
+        sa.column("counts_for_currency", sa.Boolean), sa.column("is_active", sa.Boolean),
+    )
+    # Airport databases intentionally do not contain the control-plane Unit
+    # table. Staff is authoritative for the tenant identifier on this physical
+    # database.
+    unit_ids = [
+        row[0] for row in op.get_bind().execute(
+            sa.text("SELECT DISTINCT unit_id FROM staff")
+        )
+    ]
+    op.bulk_insert(roles, [
+        {"unit_id": unit_id, "code": code, "label": label, "is_primary": primary,
+         "counts_for_currency": counts, "is_active": True}
+        for unit_id in unit_ids
+        for code, label, primary, counts in (
+            ("primary", "Primary controller", True, True),
+            ("ojti", "OJTI", False, False),
+            ("assessor", "Assessor", False, False),
+            ("secondary", "Secondary controller", False, False),
+        )
+    ])
+
+
+def downgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
+    for table in (
+        "position_session_audit", "controller_kiosk_credential",
+        "position_session_participant", "position_session",
+        "position_status_event", "position_participant_role",
+    ):
+        op.drop_table(table)
+    with op.batch_alter_table("operational_position") as batch:
+        batch.drop_constraint("fk_operational_position_currency_category", type_="foreignkey")
+        for column in (
+            "assessment_supported", "training_supported",
+            "multiple_supporting_participants_allowed",
+            "supporting_participants_allowed", "currency_category_id",
+            "group_name", "display_order",
+        ):
+            batch.drop_column(column)
+    op.drop_table("position_currency_category")
+    with op.batch_alter_table("staff") as batch:
+        batch.alter_column(
+            "role", existing_type=sa.String(32), type_=sa.String(10),
+            existing_nullable=False,
+        )

--- a/saas_models.py
+++ b/saas_models.py
@@ -333,11 +333,170 @@ def register_saas_models(db, utcnow):
         code = db.Column(db.String(30), nullable=False)
         label = db.Column(db.String(120), nullable=False)
         description = db.Column(db.Text, nullable=False, default="")
+        display_order = db.Column(db.Integer, nullable=False, default=100)
+        group_name = db.Column(db.String(80), nullable=False, default="")
+        currency_category_id = db.Column(
+            db.Integer, db.ForeignKey("position_currency_category.id")
+        )
+        supporting_participants_allowed = db.Column(
+            db.Boolean, nullable=False, default=True
+        )
+        multiple_supporting_participants_allowed = db.Column(
+            db.Boolean, nullable=False, default=True
+        )
+        training_supported = db.Column(db.Boolean, nullable=False, default=True)
+        assessment_supported = db.Column(db.Boolean, nullable=False, default=True)
         is_safety_critical = db.Column(db.Boolean, nullable=False, default=True)
         is_active = db.Column(db.Boolean, nullable=False, default=True)
         __table_args__ = (
             db.UniqueConstraint("unit_id", "code", name="uq_position_unit_code"),
         )
+
+    class PositionCurrencyCategory(db.Model):
+        __tablename__ = "position_currency_category"
+        id = db.Column(db.Integer, primary_key=True)
+        unit_id = db.Column(
+            db.Integer, db.ForeignKey("unit.id"), nullable=False, index=True
+        )
+        code = db.Column(db.String(30), nullable=False)
+        label = db.Column(db.String(120), nullable=False)
+        description = db.Column(db.Text, nullable=False, default="")
+        is_active = db.Column(db.Boolean, nullable=False, default=True)
+        __table_args__ = (
+            db.UniqueConstraint(
+                "unit_id", "code", name="uq_position_currency_category_code"
+            ),
+        )
+
+    class PositionParticipantRole(db.Model):
+        __tablename__ = "position_participant_role"
+        id = db.Column(db.Integer, primary_key=True)
+        unit_id = db.Column(
+            db.Integer, db.ForeignKey("unit.id"), nullable=False, index=True
+        )
+        code = db.Column(db.String(30), nullable=False)
+        label = db.Column(db.String(80), nullable=False)
+        is_primary = db.Column(db.Boolean, nullable=False, default=False)
+        counts_for_currency = db.Column(db.Boolean, nullable=False, default=False)
+        is_active = db.Column(db.Boolean, nullable=False, default=True)
+        __table_args__ = (
+            db.UniqueConstraint(
+                "unit_id", "code", name="uq_position_participant_role_code"
+            ),
+        )
+
+    class PositionStatusEvent(db.Model):
+        __tablename__ = "position_status_event"
+        id = db.Column(db.Integer, primary_key=True)
+        unit_id = db.Column(
+            db.Integer, db.ForeignKey("unit.id"), nullable=False, index=True
+        )
+        position_id = db.Column(
+            db.Integer, db.ForeignKey("operational_position.id"),
+            nullable=False, index=True,
+        )
+        status = db.Column(db.String(20), nullable=False)
+        occurred_at = db.Column(db.DateTime, nullable=False, default=utcnow, index=True)
+        actor_id = db.Column(db.Integer, db.ForeignKey("staff.id"), nullable=False)
+        reason = db.Column(db.String(250), nullable=False, default="")
+        transaction_key = db.Column(db.String(64), nullable=False, unique=True)
+
+    class PositionSession(db.Model):
+        __tablename__ = "position_session"
+        id = db.Column(db.Integer, primary_key=True)
+        unit_id = db.Column(
+            db.Integer, db.ForeignKey("unit.id"), nullable=False, index=True
+        )
+        position_id = db.Column(
+            db.Integer, db.ForeignKey("operational_position.id"),
+            nullable=False, index=True,
+        )
+        primary_person_id = db.Column(
+            db.Integer, db.ForeignKey("staff.id"), nullable=False, index=True
+        )
+        session_type = db.Column(db.String(20), nullable=False, default="operational")
+        started_at = db.Column(db.DateTime, nullable=False, default=utcnow, index=True)
+        ended_at = db.Column(db.DateTime, index=True)
+        ended_reason = db.Column(db.String(40), nullable=False, default="")
+        maximum_duration_seconds = db.Column(db.Integer)
+        warning_threshold_seconds = db.Column(db.Integer)
+        due_off_at = db.Column(db.DateTime)
+        currency_category_id = db.Column(
+            db.Integer, db.ForeignKey("position_currency_category.id")
+        )
+        created_by_id = db.Column(db.Integer, db.ForeignKey("staff.id"), nullable=False)
+        corrected_at = db.Column(db.DateTime)
+        corrected_by_id = db.Column(db.Integer, db.ForeignKey("staff.id"))
+        correction_reason = db.Column(db.String(500), nullable=False, default="")
+        is_void = db.Column(db.Boolean, nullable=False, default=False)
+        version = db.Column(db.Integer, nullable=False, default=1)
+        transaction_key = db.Column(db.String(64), nullable=False, unique=True)
+        __table_args__ = (
+            db.CheckConstraint(
+                "ended_at IS NULL OR ended_at >= started_at",
+                name="ck_position_session_time_order",
+            ),
+        )
+
+    class PositionSessionParticipant(db.Model):
+        __tablename__ = "position_session_participant"
+        id = db.Column(db.Integer, primary_key=True)
+        unit_id = db.Column(
+            db.Integer, db.ForeignKey("unit.id"), nullable=False, index=True
+        )
+        session_id = db.Column(
+            db.Integer, db.ForeignKey("position_session.id"), nullable=False, index=True
+        )
+        person_id = db.Column(
+            db.Integer, db.ForeignKey("staff.id"), nullable=False, index=True
+        )
+        role_id = db.Column(
+            db.Integer, db.ForeignKey("position_participant_role.id"),
+            nullable=False, index=True,
+        )
+        started_at = db.Column(db.DateTime, nullable=False, default=utcnow, index=True)
+        ended_at = db.Column(db.DateTime, index=True)
+        ended_reason = db.Column(db.String(40), nullable=False, default="")
+        transaction_key = db.Column(db.String(64), nullable=False, unique=True)
+        __table_args__ = (
+            db.CheckConstraint(
+                "ended_at IS NULL OR ended_at >= started_at",
+                name="ck_position_participant_time_order",
+            ),
+        )
+
+    class ControllerKioskCredential(db.Model):
+        __tablename__ = "controller_kiosk_credential"
+        id = db.Column(db.Integer, primary_key=True)
+        unit_id = db.Column(
+            db.Integer, db.ForeignKey("unit.id"), nullable=False, index=True
+        )
+        person_id = db.Column(
+            db.Integer, db.ForeignKey("staff.id"), nullable=False, unique=True
+        )
+        pin_hash = db.Column(db.String(255), nullable=False)
+        enabled = db.Column(db.Boolean, nullable=False, default=True)
+        failed_attempts = db.Column(db.Integer, nullable=False, default=0)
+        locked_until = db.Column(db.DateTime)
+        changed_at = db.Column(db.DateTime, nullable=False, default=utcnow)
+
+    class PositionSessionAudit(db.Model):
+        __tablename__ = "position_session_audit"
+        id = db.Column(db.Integer, primary_key=True)
+        unit_id = db.Column(
+            db.Integer, db.ForeignKey("unit.id"), nullable=False, index=True
+        )
+        session_id = db.Column(db.Integer, db.ForeignKey("position_session.id"), index=True)
+        position_id = db.Column(
+            db.Integer, db.ForeignKey("operational_position.id"), index=True
+        )
+        actor_id = db.Column(db.Integer, db.ForeignKey("staff.id"), nullable=False)
+        action = db.Column(db.String(40), nullable=False, index=True)
+        occurred_at = db.Column(db.DateTime, nullable=False, default=utcnow, index=True)
+        old_value_json = db.Column(db.Text, nullable=False, default="{}")
+        new_value_json = db.Column(db.Text, nullable=False, default="{}")
+        reason = db.Column(db.String(500), nullable=False, default="")
+        transaction_key = db.Column(db.String(64), nullable=False, index=True)
 
     class PositionEndorsement(db.Model):
         __tablename__ = "position_endorsement"

--- a/static/styles.css
+++ b/static/styles.css
@@ -35,6 +35,40 @@
   --ui-scale: 1;     /* dynamic scaling for roster */
 }
 
+/* Live Position Monitoring uses a dedicated, navigation-free kiosk shell. */
+.live-position-admin-card small { display: block; margin-top: .5rem; color: var(--muted); }
+.live-position-kiosk { margin: 0; min-height: 100vh; background: #07111f; color: #f8fafc; font-family: system-ui, sans-serif; }
+.live-position-kiosk__header { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 2rem; padding: 1.25rem 2rem; border-bottom: 2px solid #334155; }
+.live-position-kiosk__header p, .live-position-kiosk__header h1 { margin: 0; }
+.live-position-kiosk__header p { color: #94a3b8; font-size: .9rem; text-transform: uppercase; letter-spacing: .08em; }
+.live-position-kiosk__clock { text-align: center; }
+.live-position-kiosk__clock strong { display: block; font-variant-numeric: tabular-nums; font-size: clamp(2rem, 4vw, 4rem); }
+.live-position-kiosk__clock span { color: #94a3b8; }
+.live-position-kiosk__connection { justify-self: end; color: #fbbf24; }
+.live-position-kiosk__connection.is-connected { color: #86efac; }
+.live-position-kiosk main { padding: 1.5rem 2rem 6rem; }
+.live-position-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.25rem; }
+.live-position-tile { min-height: 210px; padding: 1.25rem; border: 3px solid #64748b; border-radius: 16px; background: #111c2e; box-shadow: 0 12px 35px rgb(0 0 0 / 22%); }
+.live-position-tile > header { display: flex; justify-content: space-between; gap: 1rem; }
+.live-position-tile > header strong { font-size: 1.35rem; }
+.live-position-tile > header span { padding: .3rem .65rem; border: 1px solid currentColor; border-radius: 999px; font-weight: 700; }
+.live-position-tile h2 { margin: 1.5rem 0 .75rem; font-size: clamp(1.5rem, 3vw, 2.4rem); }
+.live-position-tile--closed { border-style: dashed; color: #cbd5e1; background: #172033; }
+.live-position-tile--vacant { border-color: #fbbf24; }
+.live-position-tile--operational { border-color: #4ade80; }
+.live-position-tile--training, .live-position-tile--supervised { border-color: #60a5fa; }
+.live-position-tile--assessment { border-color: #c084fc; }
+.live-position-tile__primary { display: flex; align-items: baseline; justify-content: space-between; gap: 1rem; }
+.live-position-tile__primary strong { font-size: 1.5rem; }
+.live-position-tile__primary span { font-size: 1.4rem; font-variant-numeric: tabular-nums; }
+.live-position-kiosk__footer { position: fixed; inset: auto 0 0; display: flex; align-items: center; justify-content: space-between; padding: .75rem 2rem; background: rgb(7 17 31 / 95%); border-top: 1px solid #334155; color: #94a3b8; }
+@media (max-width: 700px) {
+  .live-position-kiosk__header { grid-template-columns: 1fr auto; padding: 1rem; }
+  .live-position-kiosk__connection { grid-column: 1 / -1; justify-self: start; }
+  .live-position-kiosk main { padding: 1rem 1rem 6rem; }
+  .live-position-kiosk__footer { padding-inline: 1rem; }
+}
+
 *{box-sizing:border-box;}
 
 ::selection{background:var(--accent-strong); color:#fff;}

--- a/templates/live_position/admin_home.html
+++ b/templates/live_position/admin_home.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% block title %}Live Position Monitoring{% endblock %}
+{% block content %}
+<section class="page-header">
+  <div>
+    <p class="eyebrow">Operations</p>
+    <h1>Live Position Monitoring</h1>
+    <p>Configure positions, monitor live occupancy and review achieved operational activity.</p>
+  </div>
+  <a class="btn" href="{{ url_for('live_position.kiosk_hmi') }}">Open live display</a>
+</section>
+<section class="module-launcher__grid" aria-label="Live Position Monitoring administration">
+  {% for title, description in [
+    ('Live status overview', 'View current position state and occupancy.'),
+    ('Position configuration', 'Manage physical positions, groups and currency categories.'),
+    ('Rules and alerts', 'Configure supervision, validity and position-time rules.'),
+    ('Kiosk and controller PINs', 'Manage the restricted display account and identity PINs.'),
+    ('Session history and corrections', 'Review, correct and audit achieved activity.'),
+    ('Reports and exports', 'Analyse hours, currency and operational exceptions.')
+  ] %}
+  <div class="module-card live-position-admin-card">
+    <span><strong>{{ title }}</strong><small>{{ description }}</small></span>
+  </div>
+  {% endfor %}
+</section>
+{% endblock %}

--- a/templates/live_position/kiosk.html
+++ b/templates/live_position/kiosk.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Live positions · {{ unit.name }}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body class="live-position-kiosk">
+  <header class="live-position-kiosk__header">
+    <div><p>Live Position Monitoring</p><h1>{{ unit.name }}</h1></div>
+    <div class="live-position-kiosk__clock">
+      <strong id="live-position-clock">--:--:--</strong>
+      <span>UTC</span>
+    </div>
+    <div class="live-position-kiosk__connection" id="live-position-connection">
+      <span aria-hidden="true">●</span> Connecting
+    </div>
+  </header>
+  <main>
+    <div id="live-position-warning" class="live-position-kiosk__warning" hidden></div>
+    <section id="live-position-grid" class="live-position-grid" aria-live="polite"></section>
+  </main>
+  <footer class="live-position-kiosk__footer">
+    <span id="live-position-refresh">Awaiting server data</span>
+    <form method="post" action="{{ url_for('logout') }}">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+      <button class="btn btn-secondary" type="submit">Log out</button>
+    </form>
+  </footer>
+  <script nonce="{{ csp_nonce() }}">
+  (() => {
+    const grid = document.getElementById('live-position-grid');
+    const connection = document.getElementById('live-position-connection');
+    const refreshed = document.getElementById('live-position-refresh');
+    const clock = document.getElementById('live-position-clock');
+    let serverOffset = 0;
+    const escapeText = (value) => String(value ?? '').replace(/[&<>"']/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+    const render = (payload) => {
+      serverOffset = Date.parse(payload.server_time) - Date.now();
+      grid.innerHTML = payload.positions.map((position) => {
+        const occupied = position.primary;
+        const label = position.display_status.replace('_', ' ').toUpperCase();
+        return `<article class="live-position-tile live-position-tile--${escapeText(position.display_status)}">
+          <header><strong>${escapeText(position.code)}</strong><span>${escapeText(label)}</span></header>
+          <h2>${escapeText(position.label)}</h2>
+          ${occupied ? `<div class="live-position-tile__primary"><strong>${escapeText(occupied.name)}</strong><span data-start="${escapeText(occupied.started_at)}">00:00</span></div>` : '<p>No controller logged on</p>'}
+          ${position.participants.map((p) => `<small>${escapeText(p.person_name)}</small>`).join('')}
+        </article>`;
+      }).join('') || '<p class="empty-state">No active operational positions are configured.</p>';
+      connection.innerHTML = '<span aria-hidden="true">●</span> Connected';
+      connection.classList.add('is-connected');
+      refreshed.textContent = `Last refreshed ${new Date().toLocaleTimeString('en-GB')}`;
+    };
+    const refresh = async () => {
+      try {
+        const response = await fetch('{{ url_for("live_position.live_state") }}', {headers: {'Accept': 'application/json'}});
+        if (!response.ok) throw new Error('refresh failed');
+        render(await response.json());
+      } catch (_) {
+        connection.innerHTML = '<span aria-hidden="true">●</span> Reconnecting';
+        connection.classList.remove('is-connected');
+      }
+    };
+    setInterval(() => {
+      const now = new Date(Date.now() + serverOffset);
+      clock.textContent = now.toISOString().slice(11, 19);
+      document.querySelectorAll('[data-start]').forEach((node) => {
+        const seconds = Math.max(0, Math.floor((now - new Date(node.dataset.start)) / 1000));
+        node.textContent = `${String(Math.floor(seconds / 3600)).padStart(2, '0')}:${String(Math.floor((seconds % 3600) / 60)).padStart(2, '0')}`;
+      });
+    }, 1000);
+    setInterval(refresh, 15000);
+    refresh();
+    if ('wakeLock' in navigator) navigator.wakeLock.request('screen').catch(() => {});
+  })();
+  </script>
+</body>
+</html>

--- a/tests/test_legacy_migration_fixtures.py
+++ b/tests/test_legacy_migration_fixtures.py
@@ -119,7 +119,7 @@ def test_legacy_fixture_upgrades_to_head_without_data_loss(
         inspector = inspect(connection)
         assert connection.execute(
             text("SELECT version_num FROM alembic_version")
-        ).scalar_one() == "20260730_28"
+        ).scalar_one() == "20260731_29"
         for table, count in before.items():
             assert connection.execute(
                 text(f'SELECT COUNT(*) FROM "{table}"')

--- a/tests/test_live_position_monitoring.py
+++ b/tests/test_live_position_monitoring.py
@@ -1,0 +1,108 @@
+from datetime import datetime
+
+import pytest
+
+import app
+from live_position_service import LivePositionModels, LivePositionService
+
+
+@pytest.fixture()
+def live_position_data():
+    with app.app.app_context():
+        app.db.drop_all()
+        app.db.create_all()
+        unit = app.Unit(id=1, code="LIVE", name="Live Test Airport")
+        kiosk = app.Staff(
+            unit_id=1, username="position-screen", name="Position screen",
+            staff_no="KIOSK-1", role="position_monitor", is_operational=False,
+        )
+        controller = app.Staff(
+            unit_id=1, username="controller", name="Alex Controller",
+            staff_no="ATCO-1", role="user", is_operational=True,
+        )
+        kiosk.set_password("secure-kiosk-password")
+        controller.set_password("controller-password")
+        position = app.OperationalPosition(
+            unit_id=1, code="AIR", label="Aerodrome Control",
+        )
+        app.db.session.add_all([unit, kiosk, controller, position])
+        app.db.session.flush()
+        identity = app.PlatformIdentity(
+            public_id="test-position-screen", username=kiosk.username,
+            password_hash=kiosk.password_hash,
+        )
+        app.db.session.add(identity)
+        app.db.session.flush()
+        app.db.session.add(app.UnitMembership(
+            identity_id=identity.id, unit_id=1, person_id=kiosk.id,
+            role="StaffUser", status="active",
+        ))
+        app.db.session.commit()
+        yield {
+            "kiosk_id": kiosk.id, "controller_id": controller.id,
+            "position_id": position.id,
+        }
+        app.db.session.remove()
+        app.db.drop_all()
+
+
+def _service(now):
+    return LivePositionService(
+        app.db,
+        LivePositionModels(
+            app.OperationalPosition, app.PositionStatusEvent,
+            app.PositionSession, app.PositionSessionParticipant,
+            app.PositionSessionAudit,
+        ),
+        lambda: now,
+    )
+
+
+def test_atomic_position_lifecycle_is_audited_and_idempotent(live_position_data):
+    moment = datetime(2026, 7, 31, 8, 30)
+    with app.app.app_context():
+        service = _service(moment)
+        opened = service.set_position_open(
+            unit_id=1, position_id=live_position_data["position_id"],
+            actor_id=live_position_data["kiosk_id"], open_position=True,
+            request_key="open-once",
+        )
+        assert service.set_position_open(
+            unit_id=1, position_id=live_position_data["position_id"],
+            actor_id=live_position_data["kiosk_id"], open_position=True,
+            request_key="open-once",
+        ).id == opened.id
+        session = service.start_session(
+            unit_id=1, position_id=live_position_data["position_id"],
+            person_id=live_position_data["controller_id"],
+            actor_id=live_position_data["kiosk_id"], request_key="logon-once",
+        )
+        assert session.started_at == moment
+        ended = service.end_session(
+            unit_id=1, position_id=live_position_data["position_id"],
+            actor_id=live_position_data["kiosk_id"], request_key="logoff-once",
+        )
+        assert ended.ended_at == moment
+        assert app.PositionSessionAudit.query.count() == 3
+
+
+def test_kiosk_password_login_bypasses_only_mfa_and_is_endpoint_limited(
+    live_position_data,
+):
+    client = app.app.test_client()
+    client.get("/login")
+    with client.session_transaction() as session:
+        csrf = session["_csrf_token"]
+    response = client.post("/login", data={
+        "_csrf_token": csrf, "username": "position-screen",
+        "password": "secure-kiosk-password",
+    })
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/live-positions/kiosk")
+    assert client.get("/live-positions/kiosk").status_code == 200
+    state = client.get("/live-positions/api/state")
+    assert state.status_code == 200
+    assert state.get_json()["positions"][0]["display_status"] == "closed"
+    blocked = client.get("/roster/2026-07")
+    assert blocked.status_code == 302
+    assert blocked.headers["Location"].endswith("/live-positions/kiosk")

--- a/tests/test_postgresql_multidatabase.py
+++ b/tests/test_postgresql_multidatabase.py
@@ -54,9 +54,9 @@ def test_postgresql_control_and_two_airport_databases_are_isolated(
     dispose_operational_engines()
     for url in (CONTROL_URL, AIRPORT_A_URL, AIRPORT_B_URL):
         _reset_postgres(url)
-    assert upgrade_database(CONTROL_URL, "control") == "20260730_28"
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260730_28"
-    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260730_28"
+    assert upgrade_database(CONTROL_URL, "control") == "20260731_29"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260731_29"
+    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260731_29"
     secret_a = "ATCROSTER_UNIT_1_DATABASE_URL"
     secret_b = "ATCROSTER_UNIT_2_DATABASE_URL"
     monkeypatch.setenv(secret_a, AIRPORT_A_URL)


### PR DESCRIPTION
## What changed

- adds the airport-scoped Live Position Monitoring core schema and migration
- extends physical positions while keeping currency categories separate
- adds auditable primary sessions, independently timed supporting participants, status events, controller PIN credentials and immutable audit evidence
- adds atomic, idempotent open/start/end/close service operations with concurrency protection
- introduces the restricted `position_monitor` kiosk login path and server-side endpoint allowlist without weakening MFA for ordinary accounts
- adds the initial full-screen live HMI, polling state endpoint and admin module landing page
- repairs a malformed exception clause in the existing permission parser

## Why

This establishes the secure transactional foundation required before adding controller PIN workflows, handovers, SSE broadcasting, operational rules, currency calculations and reports.

## Impact

The migration applies only to airport operational databases. It widens the existing staff role field and extends the existing operational-position model rather than creating parallel concepts. No kiosk account is created automatically and the new module does not alter existing normal-user navigation.

## Validation

- full test suite: 222 passed, 2 skipped
- legacy migration fixtures: 5 passed
- migration upgraded a clean SQLite schema to `20260731_29`
- Python compilation and whitespace checks passed
