### PR TITLE
Add secure live position actions

### DIFF
--- a/app.py
+++ b/app.py
@@ -611,6 +611,12 @@ def _bind_tenant_context():
     ):
         allowed_kiosk_endpoints = {
             "live_position.kiosk_hmi", "live_position.live_state",
+            "live_position.controllers", "live_position.open_position",
+            "live_position.live_events",
+            "live_position.close_position",
+            "live_position.logon", "live_position.logoff",
+            "live_position.handover", "live_position.add_participant",
+            "live_position.remove_participant",
             "logout", "static", "favicon", "health_live", "health_ready",
         }
         if request.endpoint not in allowed_kiosk_endpoints:
@@ -746,6 +752,8 @@ def _airport_login_endpoint(user) -> str:
     """Land multi-module airport users on the module launcher."""
     if getattr(user, "role", "") == "position_monitor":
         return "live_position.kiosk_hmi"
+    if is_admin_user(user):
+        return "module_home"
     enabled = FeatureFlag.query.filter(
         FeatureFlag.unit_id == user.unit_id,
         FeatureFlag.key.in_((
@@ -4805,6 +4813,8 @@ def module_home():
     if current_user.role == "superadmin":
         return redirect(url_for("platform_admin"))
     if not (
+        is_admin_user(current_user)
+        or
         briefing_enabled(current_user.unit_id)
         or training_enabled(current_user.unit_id)
         or competency_enabled(current_user.unit_id)
@@ -4815,6 +4825,7 @@ def module_home():
         show_briefing=briefing_enabled(current_user.unit_id),
         show_training=training_enabled(current_user.unit_id),
         show_competency=competency_enabled(current_user.unit_id),
+        show_live_position=is_admin_user(current_user),
     )
 
 
@@ -9521,8 +9532,14 @@ from live_position_blueprint import (
 app.register_blueprint(create_live_position_blueprint(LivePositionDependencies(
     db=db, Unit=Unit, OperationalPosition=OperationalPosition,
     PositionStatusEvent=PositionStatusEvent, PositionSession=PositionSession,
-    PositionSessionParticipant=PositionSessionParticipant, Staff=Staff,
+    PositionSessionParticipant=PositionSessionParticipant,
+    PositionParticipantRole=PositionParticipantRole,
+    PositionSessionAudit=PositionSessionAudit,
+    ControllerKioskCredential=ControllerKioskCredential,
+    PositionEndorsement=PositionEndorsement, Staff=Staff,
     utcnow=utcnow, is_admin_user=is_admin_user,
+    consume_rate_limit=_consume_rate_limit, reset_rate_limit=_reset_rate_limit,
+    security_event=_security_event,
 )))
 
 app.register_blueprint(create_auth_blueprint(AuthDependencies(

--- a/live_position_blueprint.py
+++ b/live_position_blueprint.py
@@ -1,11 +1,34 @@
 """HTTP boundary for the Live Position Monitoring module."""
+
 from __future__ import annotations
 
+import json
+import time
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Any, Callable
 
-from flask import Blueprint, abort, jsonify, render_template
+from flask import (
+    Blueprint,
+    Response,
+    abort,
+    flash,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    stream_with_context,
+    url_for,
+)
 from flask_login import current_user, login_required
+from werkzeug.security import check_password_hash, generate_password_hash
+
+from live_position_service import (
+    LivePositionConflict,
+    LivePositionModels,
+    LivePositionService,
+    LivePositionValidationError,
+)
 
 
 @dataclass(frozen=True)
@@ -16,9 +39,16 @@ class LivePositionDependencies:
     PositionStatusEvent: Any
     PositionSession: Any
     PositionSessionParticipant: Any
+    PositionParticipantRole: Any
+    PositionSessionAudit: Any
+    ControllerKioskCredential: Any
+    PositionEndorsement: Any
     Staff: Any
     utcnow: Callable[[], Any]
     is_admin_user: Callable[[Any], bool]
+    consume_rate_limit: Callable[..., bool]
+    reset_rate_limit: Callable[..., None]
+    security_event: Callable[..., None]
 
 
 def create_live_position_blueprint(
@@ -36,12 +66,195 @@ def create_live_position_blueprint(
         ):
             abort(403)
 
+    def _service() -> LivePositionService:
+        return LivePositionService(
+            dependencies.db,
+            LivePositionModels(
+                dependencies.OperationalPosition,
+                dependencies.PositionStatusEvent,
+                dependencies.PositionSession,
+                dependencies.PositionSessionParticipant,
+                dependencies.PositionSessionAudit,
+            ),
+            dependencies.utcnow,
+        )
+
+    def _payload() -> dict[str, Any]:
+        return request.get_json(silent=True) or request.form.to_dict()
+
+    def _request_key(data: dict[str, Any]) -> str:
+        return str(
+            data.get("request_key") or request.headers.get("Idempotency-Key", "")
+        )
+
+    def _audit_identity(
+        action: str,
+        actor_id: int,
+        requested_person_id: int,
+    ) -> None:
+        dependencies.db.session.add(
+            dependencies.PositionSessionAudit(
+                unit_id=_unit_id(),
+                actor_id=actor_id,
+                action=action,
+                occurred_at=dependencies.utcnow(),
+                new_value_json=(
+                    '{"requested_person_id":' + str(requested_person_id) + "}"
+                ),
+                transaction_key=LivePositionService.transaction_key(),
+            )
+        )
+
+    def _verify_pin(person_id: int, pin: str) -> Any:
+        unit_id = _unit_id()
+        now = dependencies.utcnow()
+        if not dependencies.consume_rate_limit(
+            "controller-kiosk-pin",
+            f"{unit_id}:{person_id}",
+            limit=5,
+            window=timedelta(minutes=15),
+            fail_closed=True,
+        ):
+            dependencies.security_event(
+                "controller_kiosk_pin_rate_limited", unit_id=unit_id
+            )
+            abort(429, "Too many PIN attempts. Try again later.")
+        person = dependencies.Staff.query.filter_by(
+            id=person_id, unit_id=unit_id, membership_status="active"
+        ).first()
+        credential = dependencies.ControllerKioskCredential.query.filter_by(
+            unit_id=unit_id, person_id=person_id, enabled=True
+        ).first()
+        valid = bool(
+            person
+            and credential
+            and (not credential.locked_until or credential.locked_until <= now)
+            and check_password_hash(credential.pin_hash, pin)
+        )
+        if not valid:
+            if credential:
+                credential.failed_attempts = int(credential.failed_attempts or 0) + 1
+                if credential.failed_attempts >= 5:
+                    credential.locked_until = now + timedelta(minutes=15)
+            _audit_identity("identity_verification_failed", current_user.id, person_id)
+            dependencies.db.session.commit()
+            dependencies.security_event("controller_kiosk_pin_failed", unit_id=unit_id)
+            abort(403, "Identity verification failed.")
+        credential.failed_attempts = 0
+        credential.locked_until = None
+        _audit_identity("identity_verified", person.id, person_id)
+        dependencies.db.session.commit()
+        dependencies.reset_rate_limit("controller-kiosk-pin", f"{unit_id}:{person_id}")
+        return person
+
+    def _validate_primary(person: Any) -> None:
+        today = dependencies.utcnow().date()
+        if not person.is_operational:
+            raise LivePositionValidationError(
+                "This person is not currently operational."
+            )
+        if not person.medical_expiry or person.medical_expiry < today:
+            raise LivePositionValidationError(
+                "A current medical is required to log on."
+            )
+        legacy_ue = any(
+            expiry and expiry >= today
+            for expiry in (
+                person.tower_ue_expiry,
+                person.radar_ue_expiry,
+                person.met_ue_expiry,
+            )
+        )
+        endorsement = dependencies.PositionEndorsement.query.filter(
+            dependencies.PositionEndorsement.unit_id == _unit_id(),
+            dependencies.PositionEndorsement.person_id == person.id,
+            dependencies.PositionEndorsement.status == "valid",
+            dependencies.PositionEndorsement.valid_from <= today,
+            dependencies.db.or_(
+                dependencies.PositionEndorsement.valid_until.is_(None),
+                dependencies.PositionEndorsement.valid_until >= today,
+            ),
+        ).first()
+        if not legacy_ue and not endorsement:
+            raise LivePositionValidationError(
+                "A current unit endorsement is required to log on."
+            )
+
+    def _validate_support(person: Any, role: Any) -> None:
+        _validate_primary(person)
+        if role.code == "ojti" and not person.has_ojti:
+            raise LivePositionValidationError("A current OJTI is required.")
+        if role.code in {"assessor", "examiner"} and not person.has_assessor:
+            raise LivePositionValidationError(
+                "A current assessor authority is required."
+            )
+
+    def _mutation_error(error: Exception):
+        status = 409 if isinstance(error, LivePositionConflict) else 422
+        return jsonify({"ok": False, "error": str(error)}), status
+
     @blueprint.get("/")
     @login_required
     def admin_home():
         if not dependencies.is_admin_user(current_user):
             abort(403)
         return render_template("live_position/admin_home.html")
+
+    @blueprint.route("/admin/controller-pins", methods=["GET", "POST"])
+    @login_required
+    def controller_pins():
+        if not dependencies.is_admin_user(current_user):
+            abort(403)
+        if request.method == "POST":
+            data = _payload()
+            person_id = int(data.get("person_id") or 0)
+            pin = str(data.get("pin") or "")
+            person = dependencies.Staff.query.filter_by(
+                id=person_id, unit_id=_unit_id(), membership_status="active"
+            ).first_or_404()
+            if not pin.isdigit() or not 4 <= len(pin) <= 8:
+                flash("PINs must contain 4 to 8 digits.", "error")
+            else:
+                credential = dependencies.ControllerKioskCredential.query.filter_by(
+                    unit_id=_unit_id(), person_id=person.id
+                ).first()
+                if not credential:
+                    credential = dependencies.ControllerKioskCredential(
+                        unit_id=_unit_id(),
+                        person_id=person.id,
+                        pin_hash="",
+                        changed_at=dependencies.utcnow(),
+                    )
+                    dependencies.db.session.add(credential)
+                credential.pin_hash = generate_password_hash(pin)
+                credential.enabled = True
+                credential.failed_attempts = 0
+                credential.locked_until = None
+                credential.changed_at = dependencies.utcnow()
+                _audit_identity("controller_pin_changed", current_user.id, person.id)
+                dependencies.db.session.commit()
+                flash(f"Kiosk PIN updated for {person.name}.", "ok")
+                return redirect(url_for("live_position.controller_pins"))
+        people = (
+            dependencies.Staff.query.filter_by(
+                unit_id=_unit_id(),
+                membership_status="active",
+                is_operational=True,
+            )
+            .order_by(dependencies.Staff.name)
+            .all()
+        )
+        configured = {
+            row.person_id
+            for row in dependencies.ControllerKioskCredential.query.filter_by(
+                unit_id=_unit_id(), enabled=True
+            ).all()
+        }
+        return render_template(
+            "live_position/controller_pins.html",
+            people=people,
+            configured=configured,
+        )
 
     @blueprint.get("/kiosk")
     @login_required
@@ -50,41 +263,257 @@ def create_live_position_blueprint(
         unit = dependencies.db.session.get(dependencies.Unit, _unit_id())
         return render_template("live_position/kiosk.html", unit=unit)
 
-    @blueprint.get("/api/state")
+    @blueprint.get("/api/controllers")
     @login_required
-    def live_state():
+    def controllers():
         _require_kiosk_or_admin()
+        configured_ids = {
+            row.person_id
+            for row in dependencies.ControllerKioskCredential.query.filter_by(
+                unit_id=_unit_id(), enabled=True
+            ).all()
+        }
+        people = (
+            dependencies.Staff.query.filter_by(
+                unit_id=_unit_id(),
+                membership_status="active",
+                is_operational=True,
+            )
+            .order_by(dependencies.Staff.name)
+            .all()
+        )
+        roles = (
+            dependencies.PositionParticipantRole.query.filter_by(
+                unit_id=_unit_id(), is_active=True, is_primary=False
+            )
+            .order_by(dependencies.PositionParticipantRole.label)
+            .all()
+        )
+        return jsonify(
+            {
+                "controllers": [
+                    {"id": person.id, "name": person.name}
+                    for person in people
+                    if person.id in configured_ids
+                ],
+                "roles": [
+                    {"id": role.id, "code": role.code, "label": role.label}
+                    for role in roles
+                ],
+            }
+        )
+
+    @blueprint.post("/api/positions/<int:position_id>/open")
+    @login_required
+    def open_position(position_id: int):
+        _require_kiosk_or_admin()
+        data = _payload()
+        actor = _verify_pin(int(data.get("person_id") or 0), str(data.get("pin") or ""))
+        try:
+            _service().set_position_open(
+                unit_id=_unit_id(),
+                position_id=position_id,
+                actor_id=actor.id,
+                open_position=True,
+                reason=str(data.get("reason") or ""),
+                request_key=_request_key(data),
+            )
+            return jsonify({"ok": True})
+        except (LivePositionConflict, LivePositionValidationError) as error:
+            return _mutation_error(error)
+
+    @blueprint.post("/api/positions/<int:position_id>/close")
+    @login_required
+    def close_position(position_id: int):
+        _require_kiosk_or_admin()
+        data = _payload()
+        actor = _verify_pin(int(data.get("person_id") or 0), str(data.get("pin") or ""))
+        try:
+            _service().set_position_open(
+                unit_id=_unit_id(),
+                position_id=position_id,
+                actor_id=actor.id,
+                open_position=False,
+                reason=str(data.get("reason") or ""),
+                request_key=_request_key(data),
+            )
+            return jsonify({"ok": True})
+        except (LivePositionConflict, LivePositionValidationError) as error:
+            return _mutation_error(error)
+
+    @blueprint.post("/api/positions/<int:position_id>/logon")
+    @login_required
+    def logon(position_id: int):
+        _require_kiosk_or_admin()
+        data = _payload()
+        person = _verify_pin(
+            int(data.get("person_id") or 0), str(data.get("pin") or "")
+        )
+        try:
+            _validate_primary(person)
+            _service().start_session(
+                unit_id=_unit_id(),
+                position_id=position_id,
+                person_id=person.id,
+                actor_id=person.id,
+                session_type=str(data.get("session_type") or "operational"),
+                request_key=_request_key(data),
+            )
+            return jsonify({"ok": True})
+        except (LivePositionConflict, LivePositionValidationError) as error:
+            return _mutation_error(error)
+
+    @blueprint.post("/api/positions/<int:position_id>/logoff")
+    @login_required
+    def logoff(position_id: int):
+        _require_kiosk_or_admin()
+        data = _payload()
+        person = _verify_pin(
+            int(data.get("person_id") or 0), str(data.get("pin") or "")
+        )
+        active = dependencies.PositionSession.query.filter_by(
+            unit_id=_unit_id(),
+            position_id=position_id,
+            ended_at=None,
+            is_void=False,
+        ).first()
+        if not active or active.primary_person_id != person.id:
+            abort(403, "Only the active primary controller may log off.")
+        try:
+            if str(data.get("close_position") or "").lower() in {"1", "true", "yes"}:
+                _service().set_position_open(
+                    unit_id=_unit_id(),
+                    position_id=position_id,
+                    actor_id=person.id,
+                    open_position=False,
+                    reason=str(data.get("reason") or ""),
+                    request_key=_request_key(data),
+                )
+            else:
+                _service().end_session(
+                    unit_id=_unit_id(),
+                    position_id=position_id,
+                    actor_id=person.id,
+                    request_key=_request_key(data),
+                )
+            return jsonify({"ok": True})
+        except (LivePositionConflict, LivePositionValidationError) as error:
+            return _mutation_error(error)
+
+    @blueprint.post("/api/positions/<int:position_id>/handover")
+    @login_required
+    def handover(position_id: int):
+        _require_kiosk_or_admin()
+        data = _payload()
+        incoming = _verify_pin(
+            int(data.get("person_id") or 0), str(data.get("pin") or "")
+        )
+        try:
+            _validate_primary(incoming)
+            _service().handover(
+                unit_id=_unit_id(),
+                position_id=position_id,
+                incoming_person_id=incoming.id,
+                actor_id=incoming.id,
+                session_type=str(data.get("session_type") or "operational"),
+                request_key=_request_key(data),
+            )
+            return jsonify({"ok": True})
+        except (LivePositionConflict, LivePositionValidationError) as error:
+            return _mutation_error(error)
+
+    @blueprint.post("/api/positions/<int:position_id>/participants")
+    @login_required
+    def add_participant(position_id: int):
+        _require_kiosk_or_admin()
+        data = _payload()
+        person = _verify_pin(
+            int(data.get("person_id") or 0), str(data.get("pin") or "")
+        )
+        role = dependencies.PositionParticipantRole.query.filter_by(
+            id=int(data.get("role_id") or 0),
+            unit_id=_unit_id(),
+            is_active=True,
+            is_primary=False,
+        ).first_or_404()
+        try:
+            _validate_support(person, role)
+            row = _service().add_participant(
+                unit_id=_unit_id(),
+                position_id=position_id,
+                person_id=person.id,
+                role_id=role.id,
+                actor_id=person.id,
+                request_key=_request_key(data),
+            )
+            return jsonify({"ok": True, "participant_id": row.id})
+        except (LivePositionConflict, LivePositionValidationError) as error:
+            return _mutation_error(error)
+
+    @blueprint.post(
+        "/api/positions/<int:position_id>/participants/<int:participant_id>/logoff"
+    )
+    @login_required
+    def remove_participant(position_id: int, participant_id: int):
+        _require_kiosk_or_admin()
+        data = _payload()
+        person = _verify_pin(
+            int(data.get("person_id") or 0), str(data.get("pin") or "")
+        )
+        participant = dependencies.PositionSessionParticipant.query.filter_by(
+            id=participant_id, unit_id=_unit_id(), ended_at=None
+        ).first()
+        if not participant or participant.person_id != person.id:
+            abort(403, "Only the active participant may log off.")
+        try:
+            _service().end_participant(
+                unit_id=_unit_id(),
+                position_id=position_id,
+                participant_id=participant_id,
+                actor_id=person.id,
+                request_key=_request_key(data),
+            )
+            return jsonify({"ok": True})
+        except (LivePositionConflict, LivePositionValidationError) as error:
+            return _mutation_error(error)
+
+    def _state_payload() -> dict[str, Any]:
         unit_id = _unit_id()
         now = dependencies.utcnow()
         positions = (
-            dependencies.OperationalPosition.query
-            .filter_by(unit_id=unit_id, is_active=True)
+            dependencies.OperationalPosition.query.filter_by(
+                unit_id=unit_id, is_active=True
+            )
             .order_by(
                 dependencies.OperationalPosition.display_order,
                 dependencies.OperationalPosition.code,
-            ).all()
+            )
+            .all()
         )
         state = []
         for position in positions:
             status_event = (
-                dependencies.PositionStatusEvent.query
-                .filter_by(unit_id=unit_id, position_id=position.id)
+                dependencies.PositionStatusEvent.query.filter_by(
+                    unit_id=unit_id, position_id=position.id
+                )
                 .order_by(
                     dependencies.PositionStatusEvent.occurred_at.desc(),
                     dependencies.PositionStatusEvent.id.desc(),
-                ).first()
+                )
+                .first()
             )
-            session = (
-                dependencies.PositionSession.query
-                .filter_by(
-                    unit_id=unit_id, position_id=position.id,
-                    ended_at=None, is_void=False,
-                ).first()
-            )
+            session = dependencies.PositionSession.query.filter_by(
+                unit_id=unit_id,
+                position_id=position.id,
+                ended_at=None,
+                is_void=False,
+            ).first()
             primary = (
                 dependencies.db.session.get(
                     dependencies.Staff, session.primary_person_id
-                ) if session else None
+                )
+                if session
+                else None
             )
             participants = []
             if session:
@@ -94,33 +523,76 @@ def create_live_position_blueprint(
                     person = dependencies.db.session.get(
                         dependencies.Staff, row.person_id
                     )
-                    participants.append({
-                        "id": row.id,
-                        "person_name": person.name if person else "Unknown",
-                        "role_id": row.role_id,
-                        "started_at": row.started_at.isoformat() + "Z",
-                    })
+                    role = dependencies.db.session.get(
+                        dependencies.PositionParticipantRole, row.role_id
+                    )
+                    participants.append(
+                        {
+                            "id": row.id,
+                            "person_name": person.name if person else "Unknown",
+                            "role_id": row.role_id,
+                            "role_label": role.label if role else "Supporting",
+                            "started_at": row.started_at.isoformat() + "Z",
+                        }
+                    )
             physical_status = status_event.status if status_event else "closed"
             display_status = (
-                "closed" if physical_status == "closed" else
-                session.session_type if session else "vacant"
+                "closed"
+                if physical_status == "closed"
+                else session.session_type
+                if session
+                else "vacant"
             )
-            state.append({
-                "id": position.id, "code": position.code,
-                "label": position.label, "physical_status": physical_status,
-                "display_status": display_status,
-                "primary": ({
-                    "id": primary.id, "name": primary.name,
-                    "started_at": session.started_at.isoformat() + "Z",
-                    "due_off_at": (
-                        session.due_off_at.isoformat() + "Z"
-                        if session.due_off_at else None
+            state.append(
+                {
+                    "id": position.id,
+                    "code": position.code,
+                    "label": position.label,
+                    "physical_status": physical_status,
+                    "display_status": display_status,
+                    "primary": (
+                        {
+                            "id": primary.id,
+                            "name": primary.name,
+                            "started_at": session.started_at.isoformat() + "Z",
+                            "due_off_at": (
+                                session.due_off_at.isoformat() + "Z"
+                                if session.due_off_at
+                                else None
+                            ),
+                        }
+                        if primary and session
+                        else None
                     ),
-                } if primary and session else None),
-                "participants": participants,
-            })
-        return jsonify({
-            "server_time": now.isoformat() + "Z", "positions": state,
-        })
+                    "participants": participants,
+                }
+            )
+        return {"server_time": now.isoformat() + "Z", "positions": state}
+
+    @blueprint.get("/api/state")
+    @login_required
+    def live_state():
+        _require_kiosk_or_admin()
+        return jsonify(_state_payload())
+
+    @blueprint.get("/api/events")
+    @login_required
+    def live_events():
+        _require_kiosk_or_admin()
+
+        @stream_with_context
+        def events():
+            # Database state is authoritative. A short heartbeat makes this
+            # work consistently across multiple web processes; the browser's
+            # normal polling remains the fallback when SSE is unavailable.
+            for _index in range(120):
+                yield f"event: state\ndata: {json.dumps(_state_payload())}\n\n"
+                time.sleep(5)
+
+        return Response(
+            events(),
+            content_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
 
     return blueprint

--- a/live_position_service.py
+++ b/live_position_service.py
@@ -3,9 +3,11 @@
 Routes deliberately stay thin: all linked position/session/audit mutations are
 performed here using one authoritative timestamp and one transaction key.
 """
+
 from __future__ import annotations
 
 import json
+import hashlib
 import secrets
 from dataclasses import dataclass
 from datetime import datetime
@@ -33,7 +35,9 @@ class LivePositionModels:
 
 class LivePositionService:
     def __init__(
-        self, db: Any, models: LivePositionModels,
+        self,
+        db: Any,
+        models: LivePositionModels,
         now: Callable[[], datetime],
     ) -> None:
         self.db = db
@@ -45,10 +49,15 @@ class LivePositionService:
         value = (value or "").strip()
         return value[:64] if value else secrets.token_hex(24)
 
+    @staticmethod
+    def related_key(key: str, suffix: str) -> str:
+        return hashlib.sha256(f"{key}:{suffix}".encode()).hexdigest()
+
     def _position_for_update(self, unit_id: int, position_id: int) -> Any:
         position = (
-            self.models.OperationalPosition.query
-            .filter_by(id=position_id, unit_id=unit_id, is_active=True)
+            self.models.OperationalPosition.query.filter_by(
+                id=position_id, unit_id=unit_id, is_active=True
+            )
             .with_for_update()
             .first()
         )
@@ -58,10 +67,11 @@ class LivePositionService:
 
     def _open_session(self, unit_id: int, position_id: int) -> Any | None:
         return (
-            self.models.PositionSession.query
-            .filter_by(
-                unit_id=unit_id, position_id=position_id,
-                ended_at=None, is_void=False,
+            self.models.PositionSession.query.filter_by(
+                unit_id=unit_id,
+                position_id=position_id,
+                ended_at=None,
+                is_void=False,
             )
             .with_for_update()
             .first()
@@ -69,33 +79,55 @@ class LivePositionService:
 
     def _latest_status(self, unit_id: int, position_id: int) -> str:
         event = (
-            self.models.PositionStatusEvent.query
-            .filter_by(unit_id=unit_id, position_id=position_id)
+            self.models.PositionStatusEvent.query.filter_by(
+                unit_id=unit_id, position_id=position_id
+            )
             .order_by(
                 self.models.PositionStatusEvent.occurred_at.desc(),
                 self.models.PositionStatusEvent.id.desc(),
-            ).first()
+            )
+            .first()
         )
         return event.status if event else "closed"
 
     def _audit(
-        self, *, unit_id: int, actor_id: int, action: str,
-        occurred_at: datetime, transaction_key: str,
-        session_id: int | None = None, position_id: int | None = None,
-        old: dict[str, Any] | None = None, new: dict[str, Any] | None = None,
+        self,
+        *,
+        unit_id: int,
+        actor_id: int,
+        action: str,
+        occurred_at: datetime,
+        transaction_key: str,
+        session_id: int | None = None,
+        position_id: int | None = None,
+        old: dict[str, Any] | None = None,
+        new: dict[str, Any] | None = None,
         reason: str = "",
     ) -> None:
-        self.db.session.add(self.models.PositionSessionAudit(
-            unit_id=unit_id, session_id=session_id, position_id=position_id,
-            actor_id=actor_id, action=action, occurred_at=occurred_at,
-            old_value_json=json.dumps(old or {}, sort_keys=True, default=str),
-            new_value_json=json.dumps(new or {}, sort_keys=True, default=str),
-            reason=reason, transaction_key=transaction_key,
-        ))
+        self.db.session.add(
+            self.models.PositionSessionAudit(
+                unit_id=unit_id,
+                session_id=session_id,
+                position_id=position_id,
+                actor_id=actor_id,
+                action=action,
+                occurred_at=occurred_at,
+                old_value_json=json.dumps(old or {}, sort_keys=True, default=str),
+                new_value_json=json.dumps(new or {}, sort_keys=True, default=str),
+                reason=reason,
+                transaction_key=transaction_key,
+            )
+        )
 
     def set_position_open(
-        self, *, unit_id: int, position_id: int, actor_id: int,
-        open_position: bool, reason: str = "", request_key: str | None = None,
+        self,
+        *,
+        unit_id: int,
+        position_id: int,
+        actor_id: int,
+        open_position: bool,
+        reason: str = "",
+        request_key: str | None = None,
     ) -> Any:
         key = self.transaction_key(request_key)
         existing = self.models.PositionStatusEvent.query.filter_by(
@@ -111,43 +143,61 @@ class LivePositionService:
             if target == "closed":
                 active = self._open_session(unit_id, position_id)
                 if active:
-                    self._end_session_records(
-                        active, timestamp, "position_closed", key
-                    )
+                    self._end_session_records(active, timestamp, "position_closed", key)
                     self._audit(
-                        unit_id=unit_id, actor_id=actor_id,
-                        action="session_ended", occurred_at=timestamp,
-                        transaction_key=key, session_id=active.id,
+                        unit_id=unit_id,
+                        actor_id=actor_id,
+                        action="session_ended",
+                        occurred_at=timestamp,
+                        transaction_key=key,
+                        session_id=active.id,
                         position_id=position_id,
                         new={"ended_at": timestamp, "reason": "position_closed"},
                         reason=reason,
                     )
             event = self.models.PositionStatusEvent(
-                unit_id=unit_id, position_id=position_id, status=target,
-                occurred_at=timestamp, actor_id=actor_id, reason=reason,
+                unit_id=unit_id,
+                position_id=position_id,
+                status=target,
+                occurred_at=timestamp,
+                actor_id=actor_id,
+                reason=reason,
                 transaction_key=key,
             )
             self.db.session.add(event)
             self._audit(
-                unit_id=unit_id, actor_id=actor_id,
+                unit_id=unit_id,
+                actor_id=actor_id,
                 action="position_opened" if open_position else "position_closed",
-                occurred_at=timestamp, transaction_key=key,
-                position_id=position_id, old={"status": current},
-                new={"status": target}, reason=reason,
+                occurred_at=timestamp,
+                transaction_key=key,
+                position_id=position_id,
+                old={"status": current},
+                new={"status": target},
+                reason=reason,
             )
             self.db.session.commit()
             return event
         except IntegrityError as error:
             self.db.session.rollback()
-            raise LivePositionConflict("Position state changed concurrently.") from error
+            raise LivePositionConflict(
+                "Position state changed concurrently."
+            ) from error
 
     def start_session(
-        self, *, unit_id: int, position_id: int, person_id: int,
-        actor_id: int, session_type: str = "operational",
+        self,
+        *,
+        unit_id: int,
+        position_id: int,
+        person_id: int,
+        actor_id: int,
+        session_type: str = "operational",
         currency_category_id: int | None = None,
         maximum_duration_seconds: int | None = None,
         warning_threshold_seconds: int | None = None,
-        due_off_at: datetime | None = None, request_key: str | None = None,
+        due_off_at: datetime | None = None,
+        request_key: str | None = None,
+        participants: list[dict[str, int]] | None = None,
     ) -> Any:
         if session_type not in {"operational", "training", "assessment", "supervised"}:
             raise LivePositionValidationError("Unsupported session type.")
@@ -169,23 +219,48 @@ class LivePositionService:
             if session_type == "assessment" and not position.assessment_supported:
                 raise LivePositionValidationError("Assessment is not supported here.")
             session = self.models.PositionSession(
-                unit_id=unit_id, position_id=position_id,
-                primary_person_id=person_id, session_type=session_type,
-                started_at=timestamp, currency_category_id=(
+                unit_id=unit_id,
+                position_id=position_id,
+                primary_person_id=person_id,
+                session_type=session_type,
+                started_at=timestamp,
+                currency_category_id=(
                     currency_category_id or position.currency_category_id
-                ), maximum_duration_seconds=maximum_duration_seconds,
+                ),
+                maximum_duration_seconds=maximum_duration_seconds,
                 warning_threshold_seconds=warning_threshold_seconds,
-                due_off_at=due_off_at, created_by_id=actor_id,
+                due_off_at=due_off_at,
+                created_by_id=actor_id,
                 transaction_key=key,
             )
             self.db.session.add(session)
             self.db.session.flush()
+            for participant in participants or []:
+                self.db.session.add(
+                    self.models.PositionSessionParticipant(
+                        unit_id=unit_id,
+                        session_id=session.id,
+                        person_id=participant["person_id"],
+                        role_id=participant["role_id"],
+                        started_at=timestamp,
+                        transaction_key=self.related_key(
+                            key, f"participant:{participant['person_id']}"
+                        ),
+                    )
+                )
             self._audit(
-                unit_id=unit_id, actor_id=actor_id, action="session_started",
-                occurred_at=timestamp, transaction_key=key,
-                session_id=session.id, position_id=position_id,
-                new={"person_id": person_id, "session_type": session_type,
-                     "started_at": timestamp},
+                unit_id=unit_id,
+                actor_id=actor_id,
+                action="session_started",
+                occurred_at=timestamp,
+                transaction_key=key,
+                session_id=session.id,
+                position_id=position_id,
+                new={
+                    "person_id": person_id,
+                    "session_type": session_type,
+                    "started_at": timestamp,
+                },
             )
             self.db.session.commit()
             return session
@@ -199,9 +274,11 @@ class LivePositionService:
         self, session: Any, timestamp: datetime, reason: str, key: str
     ) -> None:
         participants = (
-            self.models.PositionSessionParticipant.query
-            .filter_by(session_id=session.id, unit_id=session.unit_id, ended_at=None)
-            .with_for_update().all()
+            self.models.PositionSessionParticipant.query.filter_by(
+                session_id=session.id, unit_id=session.unit_id, ended_at=None
+            )
+            .with_for_update()
+            .all()
         )
         for participant in participants:
             participant.ended_at = timestamp
@@ -211,8 +288,13 @@ class LivePositionService:
         session.version += 1
 
     def end_session(
-        self, *, unit_id: int, position_id: int, actor_id: int,
-        reason: str = "logoff", request_key: str | None = None,
+        self,
+        *,
+        unit_id: int,
+        position_id: int,
+        actor_id: int,
+        reason: str = "logoff",
+        request_key: str | None = None,
     ) -> Any:
         key = self.transaction_key(request_key)
         audit = self.models.PositionSessionAudit.query.filter_by(
@@ -227,10 +309,189 @@ class LivePositionService:
             raise LivePositionConflict("The position is not occupied.")
         self._end_session_records(session, timestamp, reason, key)
         self._audit(
-            unit_id=unit_id, actor_id=actor_id, action="session_ended",
-            occurred_at=timestamp, transaction_key=key,
-            session_id=session.id, position_id=position_id,
+            unit_id=unit_id,
+            actor_id=actor_id,
+            action="session_ended",
+            occurred_at=timestamp,
+            transaction_key=key,
+            session_id=session.id,
+            position_id=position_id,
             new={"ended_at": timestamp, "reason": reason},
         )
         self.db.session.commit()
         return session
+
+    def add_participant(
+        self,
+        *,
+        unit_id: int,
+        position_id: int,
+        person_id: int,
+        role_id: int,
+        actor_id: int,
+        request_key: str | None = None,
+    ) -> Any:
+        key = self.transaction_key(request_key)
+        existing = self.models.PositionSessionParticipant.query.filter_by(
+            transaction_key=key
+        ).first()
+        if existing:
+            return existing
+        timestamp = self.now()
+        position = self._position_for_update(unit_id, position_id)
+        if not position.supporting_participants_allowed:
+            raise LivePositionValidationError(
+                "Supporting participants are not permitted on this position."
+            )
+        session = self._open_session(unit_id, position_id)
+        if not session:
+            raise LivePositionConflict("The position is not occupied.")
+        active = (
+            self.models.PositionSessionParticipant.query.filter_by(
+                unit_id=unit_id, session_id=session.id, ended_at=None
+            )
+            .with_for_update()
+            .all()
+        )
+        if active and not position.multiple_supporting_participants_allowed:
+            raise LivePositionConflict(
+                "This position permits only one supporting participant."
+            )
+        if any(row.person_id == person_id for row in active):
+            raise LivePositionConflict("This participant is already logged on.")
+        participant = self.models.PositionSessionParticipant(
+            unit_id=unit_id,
+            session_id=session.id,
+            person_id=person_id,
+            role_id=role_id,
+            started_at=timestamp,
+            transaction_key=key,
+        )
+        self.db.session.add(participant)
+        self.db.session.flush()
+        self._audit(
+            unit_id=unit_id,
+            actor_id=actor_id,
+            action="participant_added",
+            occurred_at=timestamp,
+            transaction_key=key,
+            session_id=session.id,
+            position_id=position_id,
+            new={
+                "participant_id": participant.id,
+                "person_id": person_id,
+                "role_id": role_id,
+                "started_at": timestamp,
+            },
+        )
+        try:
+            self.db.session.commit()
+            return participant
+        except IntegrityError as error:
+            self.db.session.rollback()
+            raise LivePositionConflict(
+                "The participant became active elsewhere concurrently."
+            ) from error
+
+    def end_participant(
+        self,
+        *,
+        unit_id: int,
+        position_id: int,
+        participant_id: int,
+        actor_id: int,
+        request_key: str | None = None,
+    ) -> Any:
+        key = self.transaction_key(request_key)
+        prior = self.models.PositionSessionAudit.query.filter_by(
+            transaction_key=key, action="participant_removed"
+        ).first()
+        if prior:
+            return self.db.session.get(
+                self.models.PositionSessionParticipant, participant_id
+            )
+        timestamp = self.now()
+        session = self._open_session(unit_id, position_id)
+        if not session:
+            raise LivePositionConflict("The position is not occupied.")
+        participant = (
+            self.models.PositionSessionParticipant.query.filter_by(
+                id=participant_id,
+                unit_id=unit_id,
+                session_id=session.id,
+                ended_at=None,
+            )
+            .with_for_update()
+            .first()
+        )
+        if not participant:
+            raise LivePositionConflict("The participant is no longer active.")
+        participant.ended_at = timestamp
+        participant.ended_reason = "logoff"
+        self._audit(
+            unit_id=unit_id,
+            actor_id=actor_id,
+            action="participant_removed",
+            occurred_at=timestamp,
+            transaction_key=key,
+            session_id=session.id,
+            position_id=position_id,
+            old={"participant_id": participant.id, "ended_at": None},
+            new={"ended_at": timestamp},
+        )
+        self.db.session.commit()
+        return participant
+
+    def handover(
+        self,
+        *,
+        unit_id: int,
+        position_id: int,
+        incoming_person_id: int,
+        actor_id: int,
+        session_type: str = "operational",
+        request_key: str | None = None,
+    ) -> Any:
+        key = self.transaction_key(request_key)
+        existing = self.models.PositionSession.query.filter_by(
+            transaction_key=self.related_key(key, "incoming")
+        ).first()
+        if existing:
+            return existing
+        timestamp = self.now()
+        position = self._position_for_update(unit_id, position_id)
+        outgoing = self._open_session(unit_id, position_id)
+        if not outgoing:
+            raise LivePositionConflict("The position is not occupied.")
+        self._end_session_records(outgoing, timestamp, "handover", key)
+        incoming = self.models.PositionSession(
+            unit_id=unit_id,
+            position_id=position_id,
+            primary_person_id=incoming_person_id,
+            session_type=session_type,
+            started_at=timestamp,
+            currency_category_id=position.currency_category_id,
+            created_by_id=actor_id,
+            transaction_key=self.related_key(key, "incoming"),
+        )
+        self.db.session.add(incoming)
+        self.db.session.flush()
+        self._audit(
+            unit_id=unit_id,
+            actor_id=actor_id,
+            action="handover",
+            occurred_at=timestamp,
+            transaction_key=key,
+            session_id=incoming.id,
+            position_id=position_id,
+            old={"session_id": outgoing.id, "person_id": outgoing.primary_person_id},
+            new={"session_id": incoming.id, "person_id": incoming_person_id},
+        )
+        try:
+            self.db.session.commit()
+            return incoming
+        except IntegrityError as error:
+            self.db.session.rollback()
+            raise LivePositionConflict(
+                "The handover conflicted with another live action."
+            ) from error

--- a/migrations/versions/20260731_30_live_position_roles.py
+++ b/migrations/versions/20260731_30_live_position_roles.py
@@ -1,0 +1,48 @@
+"""add standard live-position supporting roles
+
+Revision ID: 20260731_30
+Revises: 20260731_29
+"""
+import os
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260731_30"
+down_revision = "20260731_29"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
+    connection = op.get_bind()
+    unit_ids = [
+        row[0] for row in connection.execute(
+            sa.text("SELECT DISTINCT unit_id FROM staff")
+        )
+    ]
+    for unit_id in unit_ids:
+        for code, label in (
+            ("examiner", "Examiner"),
+            ("safety_controller", "Safety controller"),
+            ("observer", "Observer"),
+        ):
+            connection.execute(sa.text(
+                "INSERT INTO position_participant_role "
+                "(unit_id, code, label, is_primary, counts_for_currency, is_active) "
+                "SELECT :unit_id, :code, :label, false, false, true "
+                "WHERE NOT EXISTS (SELECT 1 FROM position_participant_role "
+                "WHERE unit_id = :unit_id AND code = :code)"
+            ), {"unit_id": unit_id, "code": code, "label": label})
+
+
+def downgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
+    op.execute(sa.text(
+        "DELETE FROM position_participant_role "
+        "WHERE code IN ('examiner', 'safety_controller', 'observer')"
+    ))

--- a/static/styles.css
+++ b/static/styles.css
@@ -61,6 +61,18 @@
 .live-position-tile__primary { display: flex; align-items: baseline; justify-content: space-between; gap: 1rem; }
 .live-position-tile__primary strong { font-size: 1.5rem; }
 .live-position-tile__primary span { font-size: 1.4rem; font-variant-numeric: tabular-nums; }
+.live-position-tile__participants { display: grid; gap: .4rem; margin-top: .75rem; }
+.live-position-tile__participants small { display: flex; align-items: center; gap: .4rem; }
+.live-position-tile__participants button { margin-left: auto; border: 1px solid #94a3b8; border-radius: 6px; background: transparent; color: inherit; }
+.live-position-tile > footer { display: flex; flex-wrap: wrap; gap: .5rem; margin-top: 1.25rem; }
+.live-position-dialog { width: min(520px, calc(100vw - 2rem)); padding: 1.5rem; border: 2px solid #475569; border-radius: 16px; background: #111c2e; color: #f8fafc; }
+.live-position-dialog::backdrop { background: rgb(0 0 0 / 70%); }
+.live-position-dialog form { display: grid; gap: 1rem; }
+.live-position-dialog header { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+.live-position-dialog h2, .live-position-dialog p { margin: 0; }
+.live-position-dialog label { display: grid; gap: .35rem; font-weight: 700; }
+.live-position-dialog input, .live-position-dialog select { min-height: 48px; border: 1px solid #64748b; border-radius: 8px; padding: .65rem; background: #f8fafc; color: #0f172a; font-size: 1rem; }
+.live-position-dialog__error { padding: .75rem; border: 2px solid #f87171; border-radius: 8px; background: #450a0a; }
 .live-position-kiosk__footer { position: fixed; inset: auto 0 0; display: flex; align-items: center; justify-content: space-between; padding: .75rem 2rem; background: rgb(7 17 31 / 95%); border-top: 1px solid #334155; color: #94a3b8; }
 @media (max-width: 700px) {
   .live-position-kiosk__header { grid-template-columns: 1fr auto; padding: 1rem; }

--- a/templates/live_position/admin_home.html
+++ b/templates/live_position/admin_home.html
@@ -18,9 +18,15 @@
     ('Session history and corrections', 'Review, correct and audit achieved activity.'),
     ('Reports and exports', 'Analyse hours, currency and operational exceptions.')
   ] %}
+  {% if title == 'Kiosk and controller PINs' %}
+  <a class="module-card live-position-admin-card" href="{{ url_for('live_position.controller_pins') }}">
+    <span><strong>{{ title }}</strong><small>{{ description }}</small></span>
+  </a>
+  {% else %}
   <div class="module-card live-position-admin-card">
     <span><strong>{{ title }}</strong><small>{{ description }}</small></span>
   </div>
+  {% endif %}
   {% endfor %}
 </section>
 {% endblock %}

--- a/templates/live_position/controller_pins.html
+++ b/templates/live_position/controller_pins.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% block title %}Controller kiosk PINs{% endblock %}
+{% block content %}
+<section class="page-header">
+  <div>
+    <p class="eyebrow">Live Position Monitoring</p>
+    <h1>Controller kiosk PINs</h1>
+    <p>PINs identify controllers on the shared live-position display. They are separate from application passwords and are never displayed after saving.</p>
+  </div>
+  <a class="btn btn-secondary" href="{{ url_for('live_position.admin_home') }}">Back to module</a>
+</section>
+<section class="card">
+  <form method="post" class="form-grid">
+    <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+    <label>Controller
+      <select name="person_id" required>
+        <option value="">Select controller</option>
+        {% for person in people %}
+        <option value="{{ person.id }}">{{ person.name }}{% if person.id in configured %} — PIN configured{% endif %}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label>New PIN
+      <input name="pin" type="password" inputmode="numeric" pattern="[0-9]{4,8}" minlength="4" maxlength="8" autocomplete="new-password" required>
+      <small>Enter 4 to 8 digits. The PIN is stored as a one-way secure hash.</small>
+    </label>
+    <button class="btn" type="submit">Save kiosk PIN</button>
+  </form>
+</section>
+{% endblock %}

--- a/templates/live_position/kiosk.html
+++ b/templates/live_position/kiosk.html
@@ -21,6 +21,40 @@
     <div id="live-position-warning" class="live-position-kiosk__warning" hidden></div>
     <section id="live-position-grid" class="live-position-grid" aria-live="polite"></section>
   </main>
+  <dialog id="live-position-dialog" class="live-position-dialog">
+    <form id="live-position-action-form">
+      <input type="hidden" id="live-position-id">
+      <input type="hidden" id="live-position-operation">
+      <input type="hidden" id="live-position-participant-id">
+      <header>
+        <h2 id="live-position-dialog-title">Position action</h2>
+        <button type="button" class="btn btn-secondary" data-dialog-close>Cancel</button>
+      </header>
+      <p id="live-position-dialog-help">Identify yourself to continue.</p>
+      <label>Controller
+        <select id="live-position-person" required></select>
+      </label>
+      <label>Controller PIN
+        <input id="live-position-pin" type="password" inputmode="numeric" pattern="[0-9]{4,8}" minlength="4" maxlength="8" autocomplete="off" required>
+      </label>
+      <label id="live-position-mode-wrap">Operating mode
+        <select id="live-position-mode">
+          <option value="operational">Solo</option>
+          <option value="training">Training</option>
+          <option value="assessment">Assessment</option>
+          <option value="supervised">Supervised</option>
+        </select>
+      </label>
+      <label id="live-position-role-wrap">Supporting role
+        <select id="live-position-role"></select>
+      </label>
+      <label id="live-position-reason-wrap">Reason or note
+        <input id="live-position-reason" maxlength="250">
+      </label>
+      <p id="live-position-action-error" class="live-position-dialog__error" role="alert" hidden></p>
+      <button class="btn" type="submit" id="live-position-confirm">Confirm</button>
+    </form>
+  </dialog>
   <footer class="live-position-kiosk__footer">
     <span id="live-position-refresh">Awaiting server data</span>
     <form method="post" action="{{ url_for('logout') }}">
@@ -34,6 +68,11 @@
     const connection = document.getElementById('live-position-connection');
     const refreshed = document.getElementById('live-position-refresh');
     const clock = document.getElementById('live-position-clock');
+    const dialog = document.getElementById('live-position-dialog');
+    const form = document.getElementById('live-position-action-form');
+    const csrf = {{ csrf_token()|tojson }};
+    let people = [];
+    let roles = [];
     let serverOffset = 0;
     const escapeText = (value) => String(value ?? '').replace(/[&<>"']/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
     const render = (payload) => {
@@ -41,17 +80,91 @@
       grid.innerHTML = payload.positions.map((position) => {
         const occupied = position.primary;
         const label = position.display_status.replace('_', ' ').toUpperCase();
-        return `<article class="live-position-tile live-position-tile--${escapeText(position.display_status)}">
+        const buttons = position.display_status === 'closed'
+          ? '<button class="btn" data-operation="open">Open position</button>'
+          : position.display_status === 'vacant'
+            ? '<button class="btn" data-operation="logon">Log on</button><button class="btn btn-secondary" data-operation="close">Close</button>'
+            : '<button class="btn" data-operation="handover">Hand over</button><button class="btn btn-secondary" data-operation="logoff">Log off</button><button class="btn btn-secondary" data-operation="logoff_close">Log off & close</button><button class="btn btn-secondary" data-operation="participant">Add support</button>';
+        return `<article class="live-position-tile live-position-tile--${escapeText(position.display_status)}" data-position-id="${position.id}" data-position-label="${escapeText(position.code)}">
           <header><strong>${escapeText(position.code)}</strong><span>${escapeText(label)}</span></header>
           <h2>${escapeText(position.label)}</h2>
           ${occupied ? `<div class="live-position-tile__primary"><strong>${escapeText(occupied.name)}</strong><span data-start="${escapeText(occupied.started_at)}">00:00</span></div>` : '<p>No controller logged on</p>'}
-          ${position.participants.map((p) => `<small>${escapeText(p.person_name)}</small>`).join('')}
+          <div class="live-position-tile__participants">${position.participants.map((p) => `<small><strong>${escapeText(p.role_label)}</strong> ${escapeText(p.person_name)} <button data-operation="participant_remove" data-participant-id="${p.id}">Log off</button></small>`).join('')}</div>
+          <footer>${buttons}</footer>
         </article>`;
       }).join('') || '<p class="empty-state">No active operational positions are configured.</p>';
       connection.innerHTML = '<span aria-hidden="true">●</span> Connected';
       connection.classList.add('is-connected');
       refreshed.textContent = `Last refreshed ${new Date().toLocaleTimeString('en-GB')}`;
     };
+    const loadPeople = async () => {
+      const response = await fetch('{{ url_for("live_position.controllers") }}', {headers: {'Accept': 'application/json'}});
+      if (!response.ok) return;
+      const payload = await response.json();
+      people = payload.controllers;
+      roles = payload.roles;
+    };
+    const openAction = (button) => {
+      const tile = button.closest('[data-position-id]');
+      const operation = button.dataset.operation;
+      document.getElementById('live-position-id').value = tile.dataset.positionId;
+      document.getElementById('live-position-operation').value = operation;
+      document.getElementById('live-position-participant-id').value = button.dataset.participantId || '';
+      document.getElementById('live-position-dialog-title').textContent = `${button.textContent.trim()} · ${tile.dataset.positionLabel}`;
+      document.getElementById('live-position-person').innerHTML = '<option value="">Select your name</option>' + people.map((person) => `<option value="${person.id}">${escapeText(person.name)}</option>`).join('');
+      document.getElementById('live-position-role').innerHTML = roles.map((role) => `<option value="${role.id}">${escapeText(role.label)}</option>`).join('');
+      document.getElementById('live-position-mode-wrap').hidden = !['logon', 'handover'].includes(operation);
+      document.getElementById('live-position-role-wrap').hidden = operation !== 'participant';
+      document.getElementById('live-position-reason-wrap').hidden = !['open', 'close', 'logoff_close'].includes(operation);
+      document.getElementById('live-position-action-error').hidden = true;
+      document.getElementById('live-position-pin').value = '';
+      dialog.showModal();
+    };
+    grid.addEventListener('click', (event) => {
+      const button = event.target.closest('[data-operation]');
+      if (button) openAction(button);
+    });
+    document.querySelector('[data-dialog-close]').addEventListener('click', () => dialog.close());
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const operation = document.getElementById('live-position-operation').value;
+      const positionId = document.getElementById('live-position-id').value;
+      const participantId = document.getElementById('live-position-participant-id').value;
+      const routes = {
+        open: `/live-positions/api/positions/${positionId}/open`,
+        close: `/live-positions/api/positions/${positionId}/close`,
+        logon: `/live-positions/api/positions/${positionId}/logon`,
+        logoff: `/live-positions/api/positions/${positionId}/logoff`,
+        logoff_close: `/live-positions/api/positions/${positionId}/logoff`,
+        handover: `/live-positions/api/positions/${positionId}/handover`,
+        participant: `/live-positions/api/positions/${positionId}/participants`,
+        participant_remove: `/live-positions/api/positions/${positionId}/participants/${participantId}/logoff`,
+      };
+      const payload = {
+        person_id: Number(document.getElementById('live-position-person').value),
+        pin: document.getElementById('live-position-pin').value,
+        session_type: document.getElementById('live-position-mode').value,
+        role_id: Number(document.getElementById('live-position-role').value),
+        reason: document.getElementById('live-position-reason').value,
+        close_position: operation === 'logoff_close',
+        request_key: crypto.randomUUID(),
+      };
+      const error = document.getElementById('live-position-action-error');
+      try {
+        const response = await fetch(routes[operation], {
+          method: 'POST', headers: {'Content-Type': 'application/json', 'X-CSRF-Token': csrf},
+          body: JSON.stringify(payload),
+        });
+        const result = await response.json().catch(() => ({}));
+        if (!response.ok) throw new Error(result.error || 'The action could not be completed.');
+        dialog.close();
+        form.reset();
+        await refresh();
+      } catch (failure) {
+        error.textContent = failure.message;
+        error.hidden = false;
+      }
+    });
     const refresh = async () => {
       try {
         const response = await fetch('{{ url_for("live_position.live_state") }}', {headers: {'Accept': 'application/json'}});
@@ -71,7 +184,18 @@
       });
     }, 1000);
     setInterval(refresh, 15000);
-    refresh();
+    const connectEvents = () => {
+      if (!window.EventSource) return;
+      const source = new EventSource('{{ url_for("live_position.live_events") }}');
+      source.addEventListener('state', (event) => {
+        try { render(JSON.parse(event.data)); } catch (_) { /* polling remains active */ }
+      });
+      source.onerror = () => {
+        connection.innerHTML = '<span aria-hidden="true">●</span> Reconnecting';
+        connection.classList.remove('is-connected');
+      };
+    };
+    loadPeople().then(() => { refresh(); connectEvents(); });
     if ('wakeLock' in navigator) navigator.wakeLock.request('screen').catch(() => {});
   })();
   </script>

--- a/templates/module_home.html
+++ b/templates/module_home.html
@@ -54,6 +54,19 @@
       <i class="fa-solid fa-arrow-right" aria-hidden="true"></i>
     </a>
     {% endif %}
+    {% if show_live_position %}
+    <a class="module-card" href="{{ url_for('live_position.admin_home') }}">
+      <span class="module-card__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false">
+          <rect x="3" y="4" width="18" height="16" rx="2"></rect>
+          <circle cx="8" cy="10" r="2"></circle>
+          <path d="M5.5 16c.5-2 1.3-3 2.5-3s2 .9 2.5 3M14 8h4M14 12h4M14 16h4"></path>
+        </svg>
+      </span>
+      <span><strong>Live Position Monitoring</strong></span>
+      <i class="fa-solid fa-arrow-right" aria-hidden="true"></i>
+    </a>
+    {% endif %}
   </div>
 </section>
 {% endblock %}

--- a/tests/test_legacy_migration_fixtures.py
+++ b/tests/test_legacy_migration_fixtures.py
@@ -119,7 +119,7 @@ def test_legacy_fixture_upgrades_to_head_without_data_loss(
         inspector = inspect(connection)
         assert connection.execute(
             text("SELECT version_num FROM alembic_version")
-        ).scalar_one() == "20260731_29"
+        ).scalar_one() == "20260731_30"
         for table, count in before.items():
             assert connection.execute(
                 text(f'SELECT COUNT(*) FROM "{table}"')

--- a/tests/test_live_position_monitoring.py
+++ b/tests/test_live_position_monitoring.py
@@ -1,9 +1,10 @@
-from datetime import datetime
+from datetime import date, datetime
 
 import pytest
 
 import app
 from live_position_service import LivePositionModels, LivePositionService
+from werkzeug.security import generate_password_hash
 
 
 @pytest.fixture()
@@ -13,34 +14,89 @@ def live_position_data():
         app.db.create_all()
         unit = app.Unit(id=1, code="LIVE", name="Live Test Airport")
         kiosk = app.Staff(
-            unit_id=1, username="position-screen", name="Position screen",
-            staff_no="KIOSK-1", role="position_monitor", is_operational=False,
+            unit_id=1,
+            username="position-screen",
+            name="Position screen",
+            staff_no="KIOSK-1",
+            role="position_monitor",
+            is_operational=False,
         )
         controller = app.Staff(
-            unit_id=1, username="controller", name="Alex Controller",
-            staff_no="ATCO-1", role="user", is_operational=True,
+            unit_id=1,
+            username="controller",
+            name="Alex Controller",
+            staff_no="ATCO-1",
+            role="user",
+            is_operational=True,
+            medical_expiry=date(2027, 7, 31),
+            tower_ue_expiry=date(2027, 7, 31),
+        )
+        supporter = app.Staff(
+            unit_id=1,
+            username="ojti",
+            name="Sam Instructor",
+            staff_no="ATCO-2",
+            role="user",
+            is_operational=True,
+            medical_expiry=date(2027, 7, 31),
+            tower_ue_expiry=date(2027, 7, 31),
+            has_ojti=True,
         )
         kiosk.set_password("secure-kiosk-password")
         controller.set_password("controller-password")
+        supporter.set_password("supporter-password")
         position = app.OperationalPosition(
-            unit_id=1, code="AIR", label="Aerodrome Control",
+            unit_id=1,
+            code="AIR",
+            label="Aerodrome Control",
         )
-        app.db.session.add_all([unit, kiosk, controller, position])
+        role = app.PositionParticipantRole(
+            unit_id=1,
+            code="ojti",
+            label="OJTI",
+            is_primary=False,
+        )
+        app.db.session.add_all([unit, kiosk, controller, supporter, position, role])
         app.db.session.flush()
         identity = app.PlatformIdentity(
-            public_id="test-position-screen", username=kiosk.username,
+            public_id="test-position-screen",
+            username=kiosk.username,
             password_hash=kiosk.password_hash,
         )
         app.db.session.add(identity)
         app.db.session.flush()
-        app.db.session.add(app.UnitMembership(
-            identity_id=identity.id, unit_id=1, person_id=kiosk.id,
-            role="StaffUser", status="active",
-        ))
+        app.db.session.add(
+            app.UnitMembership(
+                identity_id=identity.id,
+                unit_id=1,
+                person_id=kiosk.id,
+                role="StaffUser",
+                status="active",
+            )
+        )
+        app.db.session.add_all(
+            [
+                app.ControllerKioskCredential(
+                    unit_id=1,
+                    person_id=controller.id,
+                    pin_hash=generate_password_hash("1234"),
+                    changed_at=datetime.now(),
+                ),
+                app.ControllerKioskCredential(
+                    unit_id=1,
+                    person_id=supporter.id,
+                    pin_hash=generate_password_hash("5678"),
+                    changed_at=datetime.now(),
+                ),
+            ]
+        )
         app.db.session.commit()
         yield {
-            "kiosk_id": kiosk.id, "controller_id": controller.id,
+            "kiosk_id": kiosk.id,
+            "controller_id": controller.id,
+            "supporter_id": supporter.id,
             "position_id": position.id,
+            "role_id": role.id,
         }
         app.db.session.remove()
         app.db.drop_all()
@@ -50,8 +106,10 @@ def _service(now):
     return LivePositionService(
         app.db,
         LivePositionModels(
-            app.OperationalPosition, app.PositionStatusEvent,
-            app.PositionSession, app.PositionSessionParticipant,
+            app.OperationalPosition,
+            app.PositionStatusEvent,
+            app.PositionSession,
+            app.PositionSessionParticipant,
             app.PositionSessionAudit,
         ),
         lambda: now,
@@ -63,24 +121,35 @@ def test_atomic_position_lifecycle_is_audited_and_idempotent(live_position_data)
     with app.app.app_context():
         service = _service(moment)
         opened = service.set_position_open(
-            unit_id=1, position_id=live_position_data["position_id"],
-            actor_id=live_position_data["kiosk_id"], open_position=True,
+            unit_id=1,
+            position_id=live_position_data["position_id"],
+            actor_id=live_position_data["kiosk_id"],
+            open_position=True,
             request_key="open-once",
         )
-        assert service.set_position_open(
-            unit_id=1, position_id=live_position_data["position_id"],
-            actor_id=live_position_data["kiosk_id"], open_position=True,
-            request_key="open-once",
-        ).id == opened.id
+        assert (
+            service.set_position_open(
+                unit_id=1,
+                position_id=live_position_data["position_id"],
+                actor_id=live_position_data["kiosk_id"],
+                open_position=True,
+                request_key="open-once",
+            ).id
+            == opened.id
+        )
         session = service.start_session(
-            unit_id=1, position_id=live_position_data["position_id"],
+            unit_id=1,
+            position_id=live_position_data["position_id"],
             person_id=live_position_data["controller_id"],
-            actor_id=live_position_data["kiosk_id"], request_key="logon-once",
+            actor_id=live_position_data["kiosk_id"],
+            request_key="logon-once",
         )
         assert session.started_at == moment
         ended = service.end_session(
-            unit_id=1, position_id=live_position_data["position_id"],
-            actor_id=live_position_data["kiosk_id"], request_key="logoff-once",
+            unit_id=1,
+            position_id=live_position_data["position_id"],
+            actor_id=live_position_data["kiosk_id"],
+            request_key="logoff-once",
         )
         assert ended.ended_at == moment
         assert app.PositionSessionAudit.query.count() == 3
@@ -93,10 +162,14 @@ def test_kiosk_password_login_bypasses_only_mfa_and_is_endpoint_limited(
     client.get("/login")
     with client.session_transaction() as session:
         csrf = session["_csrf_token"]
-    response = client.post("/login", data={
-        "_csrf_token": csrf, "username": "position-screen",
-        "password": "secure-kiosk-password",
-    })
+    response = client.post(
+        "/login",
+        data={
+            "_csrf_token": csrf,
+            "username": "position-screen",
+            "password": "secure-kiosk-password",
+        },
+    )
     assert response.status_code == 302
     assert response.headers["Location"].endswith("/live-positions/kiosk")
     assert client.get("/live-positions/kiosk").status_code == 200
@@ -106,3 +179,143 @@ def test_kiosk_password_login_bypasses_only_mfa_and_is_endpoint_limited(
     blocked = client.get("/roster/2026-07")
     assert blocked.status_code == 302
     assert blocked.headers["Location"].endswith("/live-positions/kiosk")
+
+
+def _login_kiosk(client):
+    client.get("/login")
+    with client.session_transaction() as session:
+        csrf = session["_csrf_token"]
+    response = client.post(
+        "/login",
+        data={
+            "_csrf_token": csrf,
+            "username": "position-screen",
+            "password": "secure-kiosk-password",
+        },
+    )
+    assert response.status_code == 302
+    assert client.get("/live-positions/kiosk").status_code == 200
+    with client.session_transaction() as session:
+        return session["_csrf_token"]
+
+
+def _action(client, csrf, path, payload):
+    return client.post(
+        path,
+        json=payload,
+        headers={"X-CSRF-Token": csrf, "Idempotency-Key": payload["request_key"]},
+    )
+
+
+def test_kiosk_pin_authorises_full_live_position_workflow(live_position_data):
+    client = app.app.test_client()
+    csrf = _login_kiosk(client)
+    position = live_position_data["position_id"]
+    opened = _action(
+        client,
+        csrf,
+        f"/live-positions/api/positions/{position}/open",
+        {
+            "person_id": live_position_data["controller_id"],
+            "pin": "1234",
+            "request_key": "open-workflow",
+        },
+    )
+    assert opened.status_code == 200
+    logged_on = _action(
+        client,
+        csrf,
+        f"/live-positions/api/positions/{position}/logon",
+        {
+            "person_id": live_position_data["controller_id"],
+            "pin": "1234",
+            "session_type": "training",
+            "request_key": "logon-workflow",
+        },
+    )
+    assert logged_on.status_code == 200
+    supported = _action(
+        client,
+        csrf,
+        f"/live-positions/api/positions/{position}/participants",
+        {
+            "person_id": live_position_data["supporter_id"],
+            "pin": "5678",
+            "role_id": live_position_data["role_id"],
+            "request_key": "support-workflow",
+        },
+    )
+    assert supported.status_code == 200
+    state = client.get("/live-positions/api/state").get_json()["positions"][0]
+    assert state["display_status"] == "training"
+    assert state["primary"]["name"] == "Alex Controller"
+    assert state["participants"][0]["role_label"] == "OJTI"
+    participant_id = supported.get_json()["participant_id"]
+    removed = _action(
+        client,
+        csrf,
+        f"/live-positions/api/positions/{position}/participants/{participant_id}/logoff",
+        {
+            "person_id": live_position_data["supporter_id"],
+            "pin": "5678",
+            "request_key": "support-logoff-workflow",
+        },
+    )
+    assert removed.status_code == 200
+    handed_over = _action(
+        client,
+        csrf,
+        f"/live-positions/api/positions/{position}/handover",
+        {
+            "person_id": live_position_data["supporter_id"],
+            "pin": "5678",
+            "session_type": "operational",
+            "request_key": "handover-workflow",
+        },
+    )
+    assert handed_over.status_code == 200
+    assert (
+        client.get("/live-positions/api/state").get_json()["positions"][0]["primary"][
+            "name"
+        ]
+        == "Sam Instructor"
+    )
+    ended = _action(
+        client,
+        csrf,
+        f"/live-positions/api/positions/{position}/logoff",
+        {
+            "person_id": live_position_data["supporter_id"],
+            "pin": "5678",
+            "close_position": True,
+            "request_key": "close-workflow",
+        },
+    )
+    assert ended.status_code == 200
+    assert (
+        client.get("/live-positions/api/state").get_json()["positions"][0][
+            "display_status"
+        ]
+        == "closed"
+    )
+
+
+def test_wrong_pin_is_generic_and_audited(live_position_data):
+    client = app.app.test_client()
+    csrf = _login_kiosk(client)
+    response = _action(
+        client,
+        csrf,
+        f"/live-positions/api/positions/{live_position_data['position_id']}/open",
+        {
+            "person_id": live_position_data["controller_id"],
+            "pin": "9999",
+            "request_key": "wrong-pin",
+        },
+    )
+    assert response.status_code == 403
+    with app.app.app_context():
+        audit = app.PositionSessionAudit.query.filter_by(
+            action="identity_verification_failed"
+        ).one()
+        assert "requested_person_id" in audit.new_value_json

--- a/tests/test_postgresql_multidatabase.py
+++ b/tests/test_postgresql_multidatabase.py
@@ -54,9 +54,9 @@ def test_postgresql_control_and_two_airport_databases_are_isolated(
     dispose_operational_engines()
     for url in (CONTROL_URL, AIRPORT_A_URL, AIRPORT_B_URL):
         _reset_postgres(url)
-    assert upgrade_database(CONTROL_URL, "control") == "20260731_29"
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260731_29"
-    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260731_29"
+    assert upgrade_database(CONTROL_URL, "control") == "20260731_30"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260731_30"
+    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260731_30"
     secret_a = "ATCROSTER_UNIT_1_DATABASE_URL"
     secret_b = "ATCROSTER_UNIT_2_DATABASE_URL"
     monkeypatch.setenv(secret_a, AIRPORT_A_URL)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -941,7 +941,7 @@ def test_login_next_rejects_external_or_unapproved_destinations(
     assert response.status_code == 302
     assert response.headers["Location"].endswith("/login/mfa")
     with client.session_transaction() as session:
-        assert session["_mfa_next"] == "/"
+        assert session["_mfa_next"] == "/modules"
 
 
 def test_untrusted_host_returns_plain_400_instead_of_error_handler_500(client):


### PR DESCRIPTION
## What changed

- adds secure administrator management for controller-specific kiosk PINs
- requires a verified controller identity for every live position mutation
- adds touch workflows for opening, closing, log-on, log-off, log-off-and-close, handover and supporting participants
- validates operational status, medical and unit endorsement before log-on, plus OJTI/assessor authority for supporting roles
- adds shared rate limiting, temporary PIN lockout and audit evidence for successful and failed identity checks
- adds atomic supporting-participant and handover service operations with idempotency and conflict handling
- adds SSE live-state updates with automatic reconnection and polling fallback
- exposes the Live Position Monitoring module to unit administrators through the normal module launcher
- seeds the remaining standard supporting roles through a backwards-compatible operational migration

## Why

The initial foundation intentionally had no operational mutation UI. This slice makes the kiosk usable while ensuring the shared kiosk identity is never mistaken for the controller who authorised an action.

## Impact

Administrators can configure separate 4–8 digit controller PINs. Controllers with an in-date medical and unit endorsement can then perform live position actions from the kiosk. Existing normal-account MFA and all kiosk route restrictions remain in force.

## Validation

- full suite: 224 passed, 2 skipped
- interactive workflow tests cover open, training log-on, OJTI join/leave, handover and log-off-and-close
- wrong-PIN audit and access-boundary tests pass
- legacy migrations, PostgreSQL head assertions, formatting, lint and compilation pass locally
