### PR TITLE
Fix live position role migration

### DIFF
--- a/live_position_blueprint.py
+++ b/live_position_blueprint.py
@@ -193,11 +193,44 @@ def create_live_position_blueprint(
         status = 409 if isinstance(error, LivePositionConflict) else 422
         return jsonify({"ok": False, "error": str(error)}), status
 
+    def _ensure_participant_roles() -> None:
+        defaults = (
+            ("primary", "Primary controller", True, True),
+            ("ojti", "OJTI", False, False),
+            ("assessor", "Assessor", False, False),
+            ("secondary", "Secondary controller", False, False),
+            ("examiner", "Examiner", False, False),
+            ("safety_controller", "Safety controller", False, False),
+            ("observer", "Observer", False, False),
+        )
+        existing = {
+            row.code
+            for row in dependencies.PositionParticipantRole.query.filter_by(
+                unit_id=_unit_id()
+            ).all()
+        }
+        missing = [
+            dependencies.PositionParticipantRole(
+                unit_id=_unit_id(),
+                code=code,
+                label=label,
+                is_primary=is_primary,
+                counts_for_currency=counts,
+                is_active=True,
+            )
+            for code, label, is_primary, counts in defaults
+            if code not in existing
+        ]
+        if missing:
+            dependencies.db.session.add_all(missing)
+            dependencies.db.session.commit()
+
     @blueprint.get("/")
     @login_required
     def admin_home():
         if not dependencies.is_admin_user(current_user):
             abort(403)
+        _ensure_participant_roles()
         return render_template("live_position/admin_home.html")
 
     @blueprint.route("/admin/controller-pins", methods=["GET", "POST"])
@@ -267,6 +300,7 @@ def create_live_position_blueprint(
     @login_required
     def controllers():
         _require_kiosk_or_admin()
+        _ensure_participant_roles()
         configured_ids = {
             row.person_id
             for row in dependencies.ControllerKioskCredential.query.filter_by(

--- a/migrations/versions/20260731_30_live_position_roles.py
+++ b/migrations/versions/20260731_30_live_position_roles.py
@@ -3,6 +3,7 @@
 Revision ID: 20260731_30
 Revises: 20260731_29
 """
+
 import os
 
 from alembic import op
@@ -20,29 +21,51 @@ def upgrade():
         return
     connection = op.get_bind()
     unit_ids = [
-        row[0] for row in connection.execute(
-            sa.text("SELECT DISTINCT unit_id FROM staff")
-        )
+        row[0]
+        for row in connection.execute(sa.text("SELECT DISTINCT unit_id FROM staff"))
     ]
+    roles = sa.table(
+        "position_participant_role",
+        sa.column("unit_id", sa.Integer()),
+        sa.column("code", sa.String(30)),
+        sa.column("label", sa.String(80)),
+        sa.column("is_primary", sa.Boolean()),
+        sa.column("counts_for_currency", sa.Boolean()),
+        sa.column("is_active", sa.Boolean()),
+    )
     for unit_id in unit_ids:
-        for code, label in (
-            ("examiner", "Examiner"),
-            ("safety_controller", "Safety controller"),
-            ("observer", "Observer"),
-        ):
-            connection.execute(sa.text(
-                "INSERT INTO position_participant_role "
-                "(unit_id, code, label, is_primary, counts_for_currency, is_active) "
-                "SELECT :unit_id, :code, :label, false, false, true "
-                "WHERE NOT EXISTS (SELECT 1 FROM position_participant_role "
-                "WHERE unit_id = :unit_id AND code = :code)"
-            ), {"unit_id": unit_id, "code": code, "label": label})
+        existing = {
+            row[0]
+            for row in connection.execute(
+                sa.select(roles.c.code).where(roles.c.unit_id == unit_id)
+            )
+        }
+        rows = [
+            {
+                "unit_id": unit_id,
+                "code": code,
+                "label": label,
+                "is_primary": False,
+                "counts_for_currency": False,
+                "is_active": True,
+            }
+            for code, label in (
+                ("examiner", "Examiner"),
+                ("safety_controller", "Safety controller"),
+                ("observer", "Observer"),
+            )
+            if code not in existing
+        ]
+        if rows:
+            connection.execute(roles.insert(), rows)
 
 
 def downgrade():
     if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
         return
-    op.execute(sa.text(
-        "DELETE FROM position_participant_role "
-        "WHERE code IN ('examiner', 'safety_controller', 'observer')"
-    ))
+    op.execute(
+        sa.text(
+            "DELETE FROM position_participant_role "
+            "WHERE code IN ('examiner', 'safety_controller', 'observer')"
+        )
+    )


### PR DESCRIPTION
## What changed

- replaces ambiguous raw PostgreSQL seed SQL with typed SQLAlchemy inserts
- assures standard participant roles on demand for newly provisioned airport databases

## Why

Production PostgreSQL rejected a repeated untyped bind parameter as both text and varchar during the airport migration. The transaction rolled back cleanly, but the new release could not start.

## Validation

- targeted live-position and legacy migration tests: 9 passed
- formatting, lint and whitespace checks pass
- the fix uses explicitly typed columns for PostgreSQL parameter binding