### PR TITLE
Enable live position configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -9531,6 +9531,7 @@ from live_position_blueprint import (
 
 app.register_blueprint(create_live_position_blueprint(LivePositionDependencies(
     db=db, Unit=Unit, OperationalPosition=OperationalPosition,
+    PositionCurrencyCategory=PositionCurrencyCategory,
     PositionStatusEvent=PositionStatusEvent, PositionSession=PositionSession,
     PositionSessionParticipant=PositionSessionParticipant,
     PositionParticipantRole=PositionParticipantRole,

--- a/live_position_blueprint.py
+++ b/live_position_blueprint.py
@@ -36,6 +36,7 @@ class LivePositionDependencies:
     db: Any
     Unit: Any
     OperationalPosition: Any
+    PositionCurrencyCategory: Any
     PositionStatusEvent: Any
     PositionSession: Any
     PositionSessionParticipant: Any
@@ -86,6 +87,12 @@ def create_live_position_blueprint(
         return str(
             data.get("request_key") or request.headers.get("Idempotency-Key", "")
         )
+
+    def _int_field(data: dict[str, Any], name: str, default: int = 0) -> int:
+        try:
+            return int(data.get(name) or default)
+        except TypeError, ValueError:
+            return default
 
     def _audit_identity(
         action: str,
@@ -287,6 +294,158 @@ def create_live_position_blueprint(
             "live_position/controller_pins.html",
             people=people,
             configured=configured,
+        )
+
+    @blueprint.route("/admin/positions", methods=["GET", "POST"])
+    @login_required
+    def position_configuration():
+        if not dependencies.is_admin_user(current_user):
+            abort(403)
+        unit_id = _unit_id()
+        if request.method == "POST":
+            data = _payload()
+            action = str(data.get("action") or "")
+            if action == "create_category":
+                code = str(data.get("category_code") or "").strip().upper()
+                label = str(data.get("category_label") or "").strip()
+                if not code or not label:
+                    flash("Enter a category code and display name.", "error")
+                elif dependencies.PositionCurrencyCategory.query.filter_by(
+                    unit_id=unit_id, code=code
+                ).first():
+                    flash("That currency-category code is already in use.", "error")
+                else:
+                    dependencies.db.session.add(
+                        dependencies.PositionCurrencyCategory(
+                            unit_id=unit_id,
+                            code=code[:30],
+                            label=label[:120],
+                            description=str(
+                                data.get("category_description") or ""
+                            ).strip(),
+                            is_active=True,
+                        )
+                    )
+                    dependencies.db.session.commit()
+                    flash("Currency category added.", "ok")
+                    return redirect(url_for("live_position.position_configuration"))
+            elif action in {"create_position", "update_position"}:
+                position_id = _int_field(data, "position_id")
+                position = (
+                    dependencies.OperationalPosition.query.filter_by(
+                        id=position_id, unit_id=unit_id
+                    ).first_or_404()
+                    if action == "update_position"
+                    else dependencies.OperationalPosition(unit_id=unit_id)
+                )
+                code = str(data.get("code") or "").strip().upper()
+                label = str(data.get("label") or "").strip()
+                duplicate = dependencies.OperationalPosition.query.filter(
+                    dependencies.OperationalPosition.unit_id == unit_id,
+                    dependencies.OperationalPosition.code == code,
+                    dependencies.OperationalPosition.id != (position.id or 0),
+                ).first()
+                category_id = _int_field(data, "currency_category_id")
+                category = (
+                    dependencies.PositionCurrencyCategory.query.filter_by(
+                        id=category_id, unit_id=unit_id, is_active=True
+                    ).first()
+                    if category_id
+                    else None
+                )
+                requested_active = str(data.get("is_active") or "") == "on"
+                occupied = bool(
+                    position.id
+                    and dependencies.PositionSession.query.filter_by(
+                        unit_id=unit_id,
+                        position_id=position.id,
+                        ended_at=None,
+                        is_void=False,
+                    ).first()
+                )
+                if not code or not label:
+                    flash("Enter a position code and display name.", "error")
+                elif duplicate:
+                    flash("That position code is already in use.", "error")
+                elif category_id and not category:
+                    flash("Select a valid currency category.", "error")
+                elif occupied and not requested_active:
+                    flash(
+                        "Log off and close this position before making it inactive.",
+                        "error",
+                    )
+                else:
+                    if action == "create_position":
+                        dependencies.db.session.add(position)
+                    position.code = code[:30]
+                    position.label = label[:120]
+                    position.description = str(data.get("description") or "").strip()
+                    position.display_order = max(
+                        0, _int_field(data, "display_order", 100)
+                    )
+                    position.group_name = str(data.get("group_name") or "").strip()[:80]
+                    position.currency_category_id = category.id if category else None
+                    position.supporting_participants_allowed = (
+                        str(data.get("supporting_participants_allowed") or "") == "on"
+                    )
+                    position.multiple_supporting_participants_allowed = (
+                        str(data.get("multiple_supporting_participants_allowed") or "")
+                        == "on"
+                    )
+                    position.training_supported = (
+                        str(data.get("training_supported") or "") == "on"
+                    )
+                    position.assessment_supported = (
+                        str(data.get("assessment_supported") or "") == "on"
+                    )
+                    position.is_safety_critical = (
+                        str(data.get("is_safety_critical") or "") == "on"
+                    )
+                    position.is_active = requested_active
+                    dependencies.db.session.flush()
+                    dependencies.db.session.add(
+                        dependencies.PositionSessionAudit(
+                            unit_id=unit_id,
+                            position_id=position.id,
+                            actor_id=current_user.id,
+                            action="position_configured",
+                            occurred_at=dependencies.utcnow(),
+                            new_value_json=json.dumps(
+                                {
+                                    "code": position.code,
+                                    "label": position.label,
+                                    "is_active": position.is_active,
+                                },
+                                sort_keys=True,
+                            ),
+                            transaction_key=LivePositionService.transaction_key(),
+                        )
+                    )
+                    dependencies.db.session.commit()
+                    flash(
+                        "Position updated."
+                        if action == "update_position"
+                        else "Position added.",
+                        "ok",
+                    )
+                    return redirect(url_for("live_position.position_configuration"))
+        categories = (
+            dependencies.PositionCurrencyCategory.query.filter_by(unit_id=unit_id)
+            .order_by(dependencies.PositionCurrencyCategory.label)
+            .all()
+        )
+        positions = (
+            dependencies.OperationalPosition.query.filter_by(unit_id=unit_id)
+            .order_by(
+                dependencies.OperationalPosition.display_order,
+                dependencies.OperationalPosition.code,
+            )
+            .all()
+        )
+        return render_template(
+            "live_position/position_configuration.html",
+            positions=positions,
+            categories=categories,
         )
 
     @blueprint.get("/kiosk")

--- a/static/styles.css
+++ b/static/styles.css
@@ -37,6 +37,13 @@
 
 /* Live Position Monitoring uses a dedicated, navigation-free kiosk shell. */
 .live-position-admin-card small { display: block; margin-top: .5rem; color: var(--muted); }
+.live-position-admin-card--pending { opacity: .7; cursor: default; }
+.live-position-admin-card--pending em { display: block; margin-top: .75rem; color: var(--text-muted); font-size: .8rem; font-style: normal; text-transform: uppercase; letter-spacing: .04em; }
+.live-position-config-form { margin-top: 1.25rem; }
+.live-position-config-options { grid-column: 1 / -1; display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: .65rem 1rem; }
+.live-position-config-list details[data-inactive] { opacity: .75; }
+.live-position-config-list summary, details.card > summary { display: flex; justify-content: space-between; gap: 1rem; cursor: pointer; }
+.live-position-category-list { margin: 1rem 0 0; padding-left: 1.25rem; }
 .live-position-kiosk { margin: 0; min-height: 100vh; background: #07111f; color: #f8fafc; font-family: system-ui, sans-serif; }
 .live-position-kiosk__header { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 2rem; padding: 1.25rem 2rem; border-bottom: 2px solid #334155; }
 .live-position-kiosk__header p, .live-position-kiosk__header h1 { margin: 0; }

--- a/templates/live_position/admin_home.html
+++ b/templates/live_position/admin_home.html
@@ -10,21 +10,21 @@
   <a class="btn" href="{{ url_for('live_position.kiosk_hmi') }}">Open live display</a>
 </section>
 <section class="module-launcher__grid" aria-label="Live Position Monitoring administration">
-  {% for title, description in [
-    ('Live status overview', 'View current position state and occupancy.'),
-    ('Position configuration', 'Manage physical positions, groups and currency categories.'),
-    ('Rules and alerts', 'Configure supervision, validity and position-time rules.'),
-    ('Kiosk and controller PINs', 'Manage the restricted display account and identity PINs.'),
-    ('Session history and corrections', 'Review, correct and audit achieved activity.'),
-    ('Reports and exports', 'Analyse hours, currency and operational exceptions.')
+  {% for title, description, endpoint in [
+    ('Live status overview', 'View current position state and occupancy.', 'live_position.kiosk_hmi'),
+    ('Position configuration', 'Manage physical positions, groups and currency categories.', 'live_position.position_configuration'),
+    ('Rules and alerts', 'Configure supervision, validity and position-time rules.', none),
+    ('Kiosk and controller PINs', 'Manage the restricted display account and identity PINs.', 'live_position.controller_pins'),
+    ('Session history and corrections', 'Review, correct and audit achieved activity.', none),
+    ('Reports and exports', 'Analyse hours, currency and operational exceptions.', none)
   ] %}
-  {% if title == 'Kiosk and controller PINs' %}
-  <a class="module-card live-position-admin-card" href="{{ url_for('live_position.controller_pins') }}">
+  {% if endpoint %}
+  <a class="module-card live-position-admin-card" href="{{ url_for(endpoint) }}">
     <span><strong>{{ title }}</strong><small>{{ description }}</small></span>
   </a>
   {% else %}
-  <div class="module-card live-position-admin-card">
-    <span><strong>{{ title }}</strong><small>{{ description }}</small></span>
+  <div class="module-card live-position-admin-card live-position-admin-card--pending" aria-disabled="true">
+    <span><strong>{{ title }}</strong><small>{{ description }}</small><em>Coming in the next build stage</em></span>
   </div>
   {% endif %}
   {% endfor %}

--- a/templates/live_position/position_configuration.html
+++ b/templates/live_position/position_configuration.html
@@ -1,0 +1,83 @@
+{% extends "base.html" %}
+{% block title %}Position configuration{% endblock %}
+{% block content %}
+<section class="page-header">
+  <div>
+    <p class="eyebrow">Live Position Monitoring</p>
+    <h1>Position configuration</h1>
+    <p>Set up the physical positions shown on the live display. Currency categories group positions for later currency calculations without changing their physical identity.</p>
+  </div>
+  <a class="btn btn-secondary" href="{{ url_for('live_position.admin_home') }}">Back to module</a>
+</section>
+
+<details class="card" open>
+  <summary><strong>Add a physical position</strong></summary>
+  <form method="post" class="admin-form-grid live-position-config-form">
+    <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+    <input type="hidden" name="action" value="create_position">
+    <label>Short code<input name="code" maxlength="30" placeholder="AIR" required></label>
+    <label>Display name<input name="label" maxlength="120" placeholder="Aerodrome Control" required></label>
+    <label>Display order<input name="display_order" type="number" min="0" value="100"></label>
+    <label>Position group<input name="group_name" maxlength="80" placeholder="Tower"></label>
+    <label>Currency category
+      <select name="currency_category_id"><option value="">No category yet</option>{% for category in categories if category.is_active %}<option value="{{ category.id }}">{{ category.label }}</option>{% endfor %}</select>
+    </label>
+    <label>Description<textarea name="description" rows="2"></textarea></label>
+    <div class="live-position-config-options">
+      <label class="checkbox"><input type="checkbox" name="supporting_participants_allowed" checked> Supporting participants allowed</label>
+      <label class="checkbox"><input type="checkbox" name="multiple_supporting_participants_allowed" checked> Multiple supporting participants allowed</label>
+      <label class="checkbox"><input type="checkbox" name="training_supported" checked> Training mode</label>
+      <label class="checkbox"><input type="checkbox" name="assessment_supported" checked> Assessment mode</label>
+      <label class="checkbox"><input type="checkbox" name="is_safety_critical" checked> Safety-critical position</label>
+      <label class="checkbox"><input type="checkbox" name="is_active" checked> Show on live display</label>
+    </div>
+    <div class="form-actions"><button class="btn" type="submit">Add position</button></div>
+  </form>
+</details>
+
+<section class="live-position-config-list" aria-label="Configured positions">
+  {% for position in positions %}
+  <details class="card" {% if not position.is_active %}data-inactive{% endif %}>
+    <summary><strong>{{ position.code }} · {{ position.label }}</strong><span>{{ 'Active' if position.is_active else 'Inactive' }}</span></summary>
+    <form method="post" class="admin-form-grid live-position-config-form">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+      <input type="hidden" name="action" value="update_position">
+      <input type="hidden" name="position_id" value="{{ position.id }}">
+      <label>Short code<input name="code" maxlength="30" value="{{ position.code }}" required></label>
+      <label>Display name<input name="label" maxlength="120" value="{{ position.label }}" required></label>
+      <label>Display order<input name="display_order" type="number" min="0" value="{{ position.display_order }}"></label>
+      <label>Position group<input name="group_name" maxlength="80" value="{{ position.group_name or '' }}"></label>
+      <label>Currency category
+        <select name="currency_category_id"><option value="">No category yet</option>{% for category in categories if category.is_active %}<option value="{{ category.id }}" {% if position.currency_category_id == category.id %}selected{% endif %}>{{ category.label }}</option>{% endfor %}</select>
+      </label>
+      <label>Description<textarea name="description" rows="2">{{ position.description or '' }}</textarea></label>
+      <div class="live-position-config-options">
+        <label class="checkbox"><input type="checkbox" name="supporting_participants_allowed" {% if position.supporting_participants_allowed %}checked{% endif %}> Supporting participants allowed</label>
+        <label class="checkbox"><input type="checkbox" name="multiple_supporting_participants_allowed" {% if position.multiple_supporting_participants_allowed %}checked{% endif %}> Multiple supporting participants allowed</label>
+        <label class="checkbox"><input type="checkbox" name="training_supported" {% if position.training_supported %}checked{% endif %}> Training mode</label>
+        <label class="checkbox"><input type="checkbox" name="assessment_supported" {% if position.assessment_supported %}checked{% endif %}> Assessment mode</label>
+        <label class="checkbox"><input type="checkbox" name="is_safety_critical" {% if position.is_safety_critical %}checked{% endif %}> Safety-critical position</label>
+        <label class="checkbox"><input type="checkbox" name="is_active" {% if position.is_active %}checked{% endif %}> Show on live display</label>
+      </div>
+      <div class="form-actions"><button class="btn" type="submit">Save changes</button></div>
+    </form>
+  </details>
+  {% else %}
+  <div class="card empty-state"><p>No physical positions have been configured yet.</p></div>
+  {% endfor %}
+</section>
+
+<details class="card">
+  <summary><strong>Currency categories</strong><span>{{ categories|length }} configured</span></summary>
+  <p>For example, physical positions “Radar 1” and “Radar 2” could both contribute to a single “Radar” currency category.</p>
+  <form method="post" class="admin-form-grid">
+    <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+    <input type="hidden" name="action" value="create_category">
+    <label>Category code<input name="category_code" maxlength="30" placeholder="RADAR" required></label>
+    <label>Display name<input name="category_label" maxlength="120" placeholder="Radar" required></label>
+    <label>Description<textarea name="category_description" rows="2"></textarea></label>
+    <div class="form-actions"><button class="btn" type="submit">Add currency category</button></div>
+  </form>
+  {% if categories %}<ul class="live-position-category-list">{% for category in categories %}<li><strong>{{ category.code }}</strong> — {{ category.label }}</li>{% endfor %}</ul>{% endif %}
+</details>
+{% endblock %}

--- a/tests/test_live_position_monitoring.py
+++ b/tests/test_live_position_monitoring.py
@@ -3,6 +3,7 @@ from datetime import date, datetime
 import pytest
 
 import app
+from conftest import finish_operational_login
 from live_position_service import LivePositionModels, LivePositionService
 from werkzeug.security import generate_password_hash
 
@@ -42,9 +43,18 @@ def live_position_data():
             tower_ue_expiry=date(2027, 7, 31),
             has_ojti=True,
         )
+        admin = app.Staff(
+            unit_id=1,
+            username="live-admin",
+            name="Live Administrator",
+            staff_no="ADMIN-1",
+            role="admin",
+            is_operational=False,
+        )
         kiosk.set_password("secure-kiosk-password")
         controller.set_password("controller-password")
         supporter.set_password("supporter-password")
+        admin.set_password("admin-password")
         position = app.OperationalPosition(
             unit_id=1,
             code="AIR",
@@ -56,7 +66,9 @@ def live_position_data():
             label="OJTI",
             is_primary=False,
         )
-        app.db.session.add_all([unit, kiosk, controller, supporter, position, role])
+        app.db.session.add_all(
+            [unit, kiosk, controller, supporter, admin, position, role]
+        )
         app.db.session.flush()
         identity = app.PlatformIdentity(
             public_id="test-position-screen",
@@ -65,12 +77,28 @@ def live_position_data():
         )
         app.db.session.add(identity)
         app.db.session.flush()
+        admin_identity = app.PlatformIdentity(
+            public_id="test-live-admin",
+            username=admin.username,
+            password_hash=admin.password_hash,
+        )
+        app.db.session.add(admin_identity)
+        app.db.session.flush()
         app.db.session.add(
             app.UnitMembership(
                 identity_id=identity.id,
                 unit_id=1,
                 person_id=kiosk.id,
                 role="StaffUser",
+                status="active",
+            )
+        )
+        app.db.session.add(
+            app.UnitMembership(
+                identity_id=admin_identity.id,
+                unit_id=1,
+                person_id=admin.id,
+                role="UnitAdmin",
                 status="active",
             )
         )
@@ -319,3 +347,63 @@ def test_wrong_pin_is_generic_and_audited(live_position_data):
             action="identity_verification_failed"
         ).one()
         assert "requested_person_id" in audit.new_value_json
+
+
+def test_admin_can_configure_currency_category_and_position(live_position_data):
+    client = app.app.test_client()
+    client.get("/login")
+    with client.session_transaction() as session:
+        csrf = session["_csrf_token"]
+    response = client.post(
+        "/login",
+        data={
+            "_csrf_token": csrf,
+            "username": "live-admin",
+            "password": "admin-password",
+        },
+    )
+    assert response.status_code == 302
+    finish_operational_login(client)
+    module = client.get("/live-positions/")
+    assert module.status_code == 200
+    assert b"/live-positions/admin/positions" in module.data
+    assert b"Coming in the next build stage" in module.data
+    page = client.get("/live-positions/admin/positions")
+    assert page.status_code == 200
+    with client.session_transaction() as session:
+        csrf = session["_csrf_token"]
+    category = client.post(
+        "/live-positions/admin/positions",
+        data={
+            "_csrf_token": csrf,
+            "action": "create_category",
+            "category_code": "TWR",
+            "category_label": "Tower",
+        },
+    )
+    assert category.status_code == 302
+    with app.app.app_context():
+        category_id = app.PositionCurrencyCategory.query.filter_by(code="TWR").one().id
+    position = client.post(
+        "/live-positions/admin/positions",
+        data={
+            "_csrf_token": csrf,
+            "action": "create_position",
+            "code": "GMC",
+            "label": "Ground Movement Control",
+            "display_order": "10",
+            "group_name": "Tower",
+            "currency_category_id": str(category_id),
+            "supporting_participants_allowed": "on",
+            "multiple_supporting_participants_allowed": "on",
+            "training_supported": "on",
+            "assessment_supported": "on",
+            "is_safety_critical": "on",
+            "is_active": "on",
+        },
+    )
+    assert position.status_code == 302
+    with app.app.app_context():
+        configured = app.OperationalPosition.query.filter_by(code="GMC").one()
+        assert configured.label == "Ground Movement Control"
+        assert configured.currency_category_id == category_id


### PR DESCRIPTION
## What changed

- makes the Position Configuration admin card clickable
- adds admin-only creation and editing of physical positions
- adds currency-category setup for future currency calculations
- prevents an occupied position being made inactive
- records configuration changes in the position audit trail
- marks genuinely unfinished admin features as coming soon

## Why

The Live Position Monitoring admin landing page presented placeholder cards as if they were selectable features. Position Configuration now provides the expected working screen, while unfinished areas are clearly identified.

## Validation

- full test suite: 225 passed, 2 skipped
- live-position tests: 5 passed
- Ruff checks passed for the extracted module and tests
- git diff check passed