### PR TITLE
Add kiosk account provisioning

### DIFF
--- a/app.py
+++ b/app.py
@@ -708,6 +708,7 @@ _LOGIN_NEXT_ENDPOINTS = {
     "/competency/": "competency_home",
     "/admin": "admin",
     "/administration": "administration_home",
+    "/administration/kiosk-accounts": "kiosk_accounts",
     "/leave": "leave",
     "/messages": "unit_messages",
     "/overtime": "overtime",
@@ -4850,6 +4851,123 @@ def administration_home():
     )
 
 
+@app.route("/administration/kiosk-accounts", methods=["GET", "POST"])
+@login_required
+@admin_required
+def kiosk_accounts():
+    """Provision dedicated, module-scoped Live Position kiosk identities."""
+    unit_id = _current_unit_id()
+    if not live_position_enabled(unit_id):
+        abort(404)
+    unit = db.session.get(Unit, unit_id)
+    if not unit:
+        abort(404)
+    if request.method == "POST":
+        _validate_csrf()
+        action = (request.form.get("action") or "").strip()
+        if action == "create_invitation":
+            from account_limits import lock_unit_capacity
+
+            try:
+                lock_unit_capacity(db, Unit, UnitMembership, unit_id)
+                raw_token = secrets.token_urlsafe(32)
+                invitation = SecureInvitation(
+                    unit_id=unit_id,
+                    token_digest=hashlib.sha256(raw_token.encode()).hexdigest(),
+                    role="PositionMonitor",
+                    expires_at=utcnow() + timedelta(days=7),
+                )
+                db.session.add(invitation)
+                db.session.commit()
+            except ValueError as exc:
+                db.session.rollback()
+                flash(str(exc), "error")
+                return redirect(url_for("kiosk_accounts"))
+            invite_url = url_for(
+                "accept_invitation", token=raw_token, _external=True
+            )
+            flash(
+                "Kiosk setup link created. Copy it now; it is shown only "
+                f"once: {invite_url}",
+                "ok",
+            )
+            return redirect(url_for("kiosk_accounts"))
+        if action == "disable_invitation":
+            invitation_id = int(request.form.get("invitation_id") or 0)
+            invitation = SecureInvitation.query.filter_by(
+                id=invitation_id,
+                unit_id=unit_id,
+                role="PositionMonitor",
+                accepted_at=None,
+                disabled_at=None,
+            ).first_or_404()
+            invitation.disabled_at = utcnow()
+            db.session.commit()
+            flash("Kiosk setup link disabled.", "ok")
+            return redirect(url_for("kiosk_accounts"))
+        if action in {"deactivate", "restore"}:
+            membership_id = int(request.form.get("membership_id") or 0)
+            expected_status = "active" if action == "deactivate" else "suspended"
+            membership = UnitMembership.query.filter_by(
+                id=membership_id,
+                unit_id=unit_id,
+                role="PositionMonitor",
+                status=expected_status,
+            ).first_or_404()
+            linked = (
+                tenant_get(Staff, membership.person_id)
+                if membership.person_id
+                else None
+            )
+            if action == "deactivate":
+                membership.status = "suspended"
+                membership.suspended_at = utcnow()
+                if linked:
+                    linked.membership_status = "suspended"
+                message = "Kiosk account deactivated."
+            else:
+                from account_limits import activate_membership
+
+                try:
+                    activate_membership(db, Unit, UnitMembership, membership.id)
+                except ValueError as exc:
+                    db.session.rollback()
+                    flash(str(exc), "error")
+                    return redirect(url_for("kiosk_accounts"))
+                membership.suspended_at = None
+                membership.activated_at = membership.activated_at or utcnow()
+                if linked:
+                    linked.membership_status = "active"
+                message = "Kiosk account restored."
+            db.session.commit()
+            flash(message, "ok")
+            return redirect(url_for("kiosk_accounts"))
+        abort(400)
+    invitations = SecureInvitation.query.filter(
+        SecureInvitation.unit_id == unit_id,
+        SecureInvitation.role == "PositionMonitor",
+        SecureInvitation.accepted_at.is_(None),
+        SecureInvitation.disabled_at.is_(None),
+        SecureInvitation.expires_at > utcnow(),
+    ).order_by(SecureInvitation.expires_at).all()
+    memberships = UnitMembership.query.filter_by(
+        unit_id=unit_id, role="PositionMonitor"
+    ).order_by(UnitMembership.id).all()
+    people = {
+        row.id: row
+        for row in Staff.query.filter(
+            Staff.unit_id == unit_id,
+            Staff.id.in_([row.person_id for row in memberships if row.person_id]),
+        ).all()
+    }
+    return render_template(
+        "kiosk_accounts.html",
+        invitations=invitations,
+        memberships=memberships,
+        people=people,
+    )
+
+
 
 @app.route("/__can")
 @login_required
@@ -7858,6 +7976,7 @@ def _run_invitation_signup(
                 "UnitAdmin": "admin", "RosterEditor": "editor",
                 "WatchManager": "user", "StaffUser": "user",
                 "ReadOnlyAuditor": "auditor",
+                "PositionMonitor": "position_monitor",
             }
             if invitation.target_person_id:
                 staff = Staff.query.filter_by(
@@ -8100,7 +8219,12 @@ def accept_invitation(token):
                 "invitation_accept.html", invitation=invitation, unit=unit,
                 target_person=target_person,
             ), 409
-        flash("Account created. Sign in and configure MFA.", "ok")
+        flash(
+            "Kiosk account created. Sign in on the dedicated display."
+            if invitation.role == "PositionMonitor"
+            else "Account created. Sign in and configure MFA.",
+            "ok",
+        )
         return redirect(url_for("login"))
     return render_template(
         "invitation_accept.html", invitation=invitation, unit=unit,

--- a/templates/administration_home.html
+++ b/templates/administration_home.html
@@ -14,6 +14,11 @@
       <i class="fa-solid fa-arrow-right" aria-hidden="true"></i>
     </a>
     {% if show_live_position %}
+    <a class="module-card" href="{{ url_for('kiosk_accounts') }}">
+      <span class="module-card__icon" aria-hidden="true"><i class="fa-solid fa-display"></i></span>
+      <span><strong>Kiosk accounts</strong><small>Create and manage dedicated Live Position display accounts.</small></span>
+      <i class="fa-solid fa-arrow-right" aria-hidden="true"></i>
+    </a>
     <a class="module-card" href="{{ url_for('live_position.position_configuration') }}">
       <span class="module-card__icon" aria-hidden="true"><i class="fa-solid fa-tower-broadcast"></i></span>
       <span><strong>Position Monitoring setup</strong><small>Configure positions, currency categories and kiosk identities.</small></span>

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,7 +11,7 @@
   {% set in_training_module = request.endpoint and request.endpoint.startswith('training_') %}
   {% set in_competency_module = request.endpoint and request.endpoint.startswith('competency_') %}
   {% set in_shared_admin = request.endpoint in (
-    'administration_home', 'unit_accounts',
+    'administration_home', 'unit_accounts', 'kiosk_accounts',
     'live_position.position_configuration', 'live_position.controller_pins'
   ) %}
   {% set report_endpoints = (
@@ -96,6 +96,7 @@
               <a href="{{ url_for('administration_home') }}" class="nav-link {% if request.endpoint == 'administration_home' %}active{% endif %}"><i class="fa-solid fa-screwdriver-wrench" aria-hidden="true"></i> Administration</a>
               <a href="{{ url_for('unit_accounts') }}" class="nav-link {% if request.endpoint == 'unit_accounts' %}active{% endif %}"><i class="fa-solid fa-users-gear" aria-hidden="true"></i> People and access</a>
               {% if has_live_position_module %}
+                <a href="{{ url_for('kiosk_accounts') }}" class="nav-link {% if request.endpoint == 'kiosk_accounts' %}active{% endif %}"><i class="fa-solid fa-display" aria-hidden="true"></i> Kiosk accounts</a>
                 <a href="{{ url_for('live_position.position_configuration') }}" class="nav-link {% if request.endpoint == 'live_position.position_configuration' %}active{% endif %}"><i class="fa-solid fa-tower-broadcast" aria-hidden="true"></i> Positions</a>
                 <a href="{{ url_for('live_position.controller_pins') }}" class="nav-link {% if request.endpoint == 'live_position.controller_pins' %}active{% endif %}"><i class="fa-solid fa-key" aria-hidden="true"></i> Kiosk PINs</a>
               {% endif %}

--- a/templates/invitation_accept.html
+++ b/templates/invitation_accept.html
@@ -7,7 +7,7 @@
     {% if target_person %}
       <p>Your roster profile for <strong>{{ target_person.name }}</strong> is already configured. This invitation only adds secure account access.</p>
     {% else %}
-      <p>You have been invited as {{ invitation.role }}. This link is single-use.</p>
+      <p>{% if invitation.role == 'PositionMonitor' %}Create the dedicated Live Position kiosk account. It can only access the shared operational display.{% else %}You have been invited as {{ invitation.role }}. This link is single-use.{% endif %}</p>
     {% endif %}
     <form method="post" class="stack">
       <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
@@ -17,7 +17,7 @@
         <label>Name<input name="name" maxlength="80" required autocomplete="name"></label>
       {% endif %}
       <label>Username<input name="username" minlength="3" maxlength="120" required autocomplete="username"></label>
-      <label>Email address<input type="email" name="email" maxlength="254" required autocomplete="email"></label>
+      <label>{{ 'Recovery email address' if invitation.role == 'PositionMonitor' else 'Email address' }}<input type="email" name="email" maxlength="254" required autocomplete="email"></label>
       <label>Password<input type="password" name="password" minlength="12" required autocomplete="new-password"></label>
       <button class="btn btn-primary" type="submit">Activate account access</button>
     </form>

--- a/templates/kiosk_accounts.html
+++ b/templates/kiosk_accounts.html
@@ -1,0 +1,62 @@
+{% extends "base.html" %}
+{% block title %}Kiosk accounts{% endblock %}
+{% block content %}
+<section class="page-header">
+  <div>
+    <p class="eyebrow">Administration · Live Position Monitoring</p>
+    <h1>Kiosk accounts</h1>
+    <p>Create dedicated accounts for Live Position displays. These accounts cannot access the roster or administration tools.</p>
+  </div>
+  <a class="btn btn-secondary" href="{{ url_for('administration_home') }}">Back to administration</a>
+</section>
+
+<section class="card card-body mb-4">
+  <h2>Create kiosk account</h2>
+  <p>Generate a single-use setup link, then open it on the kiosk device to choose its username and password.</p>
+  <form method="post">
+    <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+    <input type="hidden" name="action" value="create_invitation">
+    <button class="btn btn-primary" type="submit">Create kiosk setup link</button>
+  </form>
+</section>
+
+<section class="card card-body mb-4">
+  <h2>Pending setup links</h2>
+  {% for invitation in invitations %}
+  <form method="post" class="d-flex gap-2 align-items-center mb-2">
+    <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+    <input type="hidden" name="action" value="disable_invitation">
+    <input type="hidden" name="invitation_id" value="{{ invitation.id }}">
+    <span>Expires {{ invitation.expires_at.strftime('%d %b %Y %H:%M') }}</span>
+    <button class="btn btn-sm" type="submit">Disable link</button>
+  </form>
+  {% else %}<p class="muted">No setup links are awaiting use.</p>{% endfor %}
+</section>
+
+<section class="card card-body">
+  <h2>Existing kiosk accounts</h2>
+  <table class="table">
+    <thead><tr><th>Kiosk</th><th>Username</th><th>Status</th><th>Action</th></tr></thead>
+    <tbody>
+    {% for membership in memberships %}
+      {% set kiosk = people.get(membership.person_id) %}
+      <tr>
+        <td>{{ kiosk.name if kiosk else 'Kiosk account' }}</td>
+        <td>{{ kiosk.username if kiosk else '—' }}</td>
+        <td>{{ membership.status|title }}</td>
+        <td>
+          {% if membership.status in ('active', 'suspended') %}
+          <form method="post">
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+            <input type="hidden" name="action" value="{{ 'deactivate' if membership.status == 'active' else 'restore' }}">
+            <input type="hidden" name="membership_id" value="{{ membership.id }}">
+            <button class="btn btn-sm" type="submit">{{ 'Deactivate' if membership.status == 'active' else 'Restore' }}</button>
+          </form>
+          {% else %}—{% endif %}
+        </td>
+      </tr>
+    {% else %}<tr><td colspan="4">No kiosk accounts have been created.</td></tr>{% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endblock %}

--- a/tests/test_live_position_monitoring.py
+++ b/tests/test_live_position_monitoring.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime
+import re
 
 import pytest
 
@@ -434,3 +435,69 @@ def test_live_position_module_must_be_enabled(live_position_data):
         },
     )
     assert client.get("/live-positions/kiosk").status_code == 404
+
+
+def test_unit_admin_can_provision_a_dedicated_kiosk_account(live_position_data):
+    admin_client = app.app.test_client()
+    admin_client.get("/login")
+    with admin_client.session_transaction() as session:
+        csrf = session["_csrf_token"]
+    admin_client.post(
+        "/login",
+        data={
+            "_csrf_token": csrf,
+            "username": "live-admin",
+            "password": "admin-password",
+        },
+    )
+    finish_operational_login(admin_client)
+    page = admin_client.get("/administration/kiosk-accounts")
+    assert page.status_code == 200
+    with admin_client.session_transaction() as session:
+        csrf = session["_csrf_token"]
+    created = admin_client.post(
+        "/administration/kiosk-accounts",
+        data={"_csrf_token": csrf, "action": "create_invitation"},
+        follow_redirects=True,
+    )
+    token_match = re.search(rb"/invite/([A-Za-z0-9_-]+)", created.data)
+    assert token_match
+    invitation_path = f"/invite/{token_match.group(1).decode()}"
+
+    kiosk_client = app.app.test_client()
+    setup = kiosk_client.get(invitation_path)
+    assert setup.status_code == 200
+    with kiosk_client.session_transaction() as session:
+        csrf = session["_csrf_token"]
+    accepted = kiosk_client.post(
+        invitation_path,
+        data={
+            "_csrf_token": csrf,
+            "name": "Tower display",
+            "username": "tower-display",
+            "email": "kiosk@example.test",
+            "password": "secure-kiosk-password",
+        },
+    )
+    assert accepted.status_code == 302
+    with app.app.app_context():
+        kiosk = app.Staff.query.filter_by(username="tower-display").one()
+        membership = app.UnitMembership.query.filter_by(person_id=kiosk.id).one()
+        assert kiosk.role == "position_monitor"
+        assert not kiosk.is_operational
+        assert membership.role == "PositionMonitor"
+        assert membership.status == "active"
+
+    kiosk_client.get("/login")
+    with kiosk_client.session_transaction() as session:
+        csrf = session["_csrf_token"]
+    login = kiosk_client.post(
+        "/login",
+        data={
+            "_csrf_token": csrf,
+            "username": "tower-display",
+            "password": "secure-kiosk-password",
+        },
+    )
+    assert login.status_code == 302
+    assert login.headers["Location"].endswith("/live-positions/kiosk")


### PR DESCRIPTION
## What changed

- adds Administration → Kiosk accounts for units with Live Position Monitoring enabled
- lets Unit Admins create single-use kiosk setup links
- creates dedicated PositionMonitor identities through the existing secure invitation workflow
- gives kiosk setup copy tailored to the locked-down display role
- lists kiosk accounts and supports deactivation and restoration
- keeps the feature hidden and inaccessible when the paid module entitlement is disabled

## Why

The kiosk security role existed, but there was no supported interface for a Unit Admin to provision one. Creating a kiosk account previously required direct database work.

## Security impact

Setup links are random, hashed at rest, expire after seven days, and are single-use. Created accounts receive the restricted PositionMonitor membership and are confined by the existing server-side kiosk endpoint allowlist.

## Validation

- full suite: 227 passed, 2 skipped
- end-to-end Unit Admin invitation, acceptance, role assignment and kiosk login test
- Ruff checks passed for the live-position test/module files
- git diff check passed