### PR TITLE
Group the live position display

### DIFF
--- a/app.py
+++ b/app.py
@@ -465,7 +465,8 @@ OPERATIONAL_TABLE_NAMES = frozenset({
     "change_log", "staff_watch_history", "qualification_type",
     "person_qualification", "person_qualification_history",
     "roster_publication", "roster_acknowledgement", "scenario",
-    "operational_position", "position_endorsement", "position_requirement",
+    "operational_position", "operational_position_group",
+    "position_endorsement", "position_requirement",
     "break_plan", "achieved_duty", "fatigue_report",
     "roster_rule_version", "mfa_credential",
     "briefing_item", "briefing_delivery", "briefing_audit",
@@ -1682,6 +1683,7 @@ RosterPublication = SaaS.RosterPublication
 RosterAcknowledgement = SaaS.RosterAcknowledgement
 Scenario = SaaS.Scenario
 OperationalPosition = SaaS.OperationalPosition
+OperationalPositionGroup = SaaS.OperationalPositionGroup
 PositionCurrencyCategory = SaaS.PositionCurrencyCategory
 PositionParticipantRole = SaaS.PositionParticipantRole
 PositionStatusEvent = SaaS.PositionStatusEvent
@@ -9677,6 +9679,7 @@ from live_position_blueprint import (
 
 app.register_blueprint(create_live_position_blueprint(LivePositionDependencies(
     db=db, Unit=Unit, OperationalPosition=OperationalPosition,
+    OperationalPositionGroup=OperationalPositionGroup,
     PositionCurrencyCategory=PositionCurrencyCategory,
     PositionStatusEvent=PositionStatusEvent, PositionSession=PositionSession,
     PositionSessionParticipant=PositionSessionParticipant,

--- a/live_position_blueprint.py
+++ b/live_position_blueprint.py
@@ -34,6 +34,7 @@ class LivePositionDependencies:
     db: Any
     Unit: Any
     OperationalPosition: Any
+    OperationalPositionGroup: Any
     PositionCurrencyCategory: Any
     PositionStatusEvent: Any
     PositionSession: Any
@@ -226,7 +227,33 @@ def create_live_position_blueprint(
         if request.method == "POST":
             data = _payload()
             action = str(data.get("action") or "")
-            if action == "create_category":
+            if action == "create_group":
+                name = str(data.get("group_name") or "").strip()[:80]
+                duplicate = dependencies.OperationalPositionGroup.query.filter(
+                    dependencies.OperationalPositionGroup.unit_id == unit_id,
+                    dependencies.db.func.lower(
+                        dependencies.OperationalPositionGroup.name
+                    ) == name.lower(),
+                ).first()
+                if not name:
+                    flash("Enter a group name.", "error")
+                elif duplicate:
+                    flash("That position group already exists.", "error")
+                else:
+                    dependencies.db.session.add(
+                        dependencies.OperationalPositionGroup(
+                            unit_id=unit_id,
+                            name=name,
+                            display_order=max(
+                                0, _int_field(data, "group_display_order", 100)
+                            ),
+                            is_active=True,
+                        )
+                    )
+                    dependencies.db.session.commit()
+                    flash("Position group added.", "ok")
+                    return redirect(url_for("live_position.position_configuration"))
+            elif action == "create_category":
                 code = str(data.get("category_code") or "").strip().upper()
                 label = str(data.get("category_label") or "").strip()
                 if not code or not label:
@@ -274,6 +301,14 @@ def create_live_position_blueprint(
                     if category_id
                     else None
                 )
+                group_id = _int_field(data, "position_group_id")
+                group = (
+                    dependencies.OperationalPositionGroup.query.filter_by(
+                        id=group_id, unit_id=unit_id, is_active=True
+                    ).first()
+                    if group_id
+                    else None
+                )
                 requested_active = str(data.get("is_active") or "") == "on"
                 occupied = bool(
                     position.id
@@ -290,6 +325,8 @@ def create_live_position_blueprint(
                     flash("That position code is already in use.", "error")
                 elif category_id and not category:
                     flash("Select a valid currency category.", "error")
+                elif group_id and not group:
+                    flash("Select a valid position group.", "error")
                 elif occupied and not requested_active:
                     flash(
                         "Log off and close this position before making it inactive.",
@@ -304,7 +341,7 @@ def create_live_position_blueprint(
                     position.display_order = max(
                         0, _int_field(data, "display_order", 100)
                     )
-                    position.group_name = str(data.get("group_name") or "").strip()[:80]
+                    position.group_name = group.name if group else ""
                     position.currency_category_id = category.id if category else None
                     position.supporting_participants_allowed = (
                         str(data.get("supporting_participants_allowed") or "") == "on"
@@ -350,6 +387,14 @@ def create_live_position_blueprint(
                         "ok",
                     )
                     return redirect(url_for("live_position.position_configuration"))
+        groups = (
+            dependencies.OperationalPositionGroup.query.filter_by(unit_id=unit_id)
+            .order_by(
+                dependencies.OperationalPositionGroup.display_order,
+                dependencies.OperationalPositionGroup.name,
+            )
+            .all()
+        )
         categories = (
             dependencies.PositionCurrencyCategory.query.filter_by(unit_id=unit_id)
             .order_by(dependencies.PositionCurrencyCategory.label)
@@ -366,6 +411,7 @@ def create_live_position_blueprint(
         return render_template(
             "live_position/position_configuration.html",
             positions=positions,
+            groups=groups,
             categories=categories,
         )
 
@@ -566,6 +612,17 @@ def create_live_position_blueprint(
     def _state_payload() -> dict[str, Any]:
         unit_id = _unit_id()
         now = dependencies.utcnow()
+        groups = (
+            dependencies.OperationalPositionGroup.query.filter_by(
+                unit_id=unit_id, is_active=True
+            )
+            .order_by(
+                dependencies.OperationalPositionGroup.display_order,
+                dependencies.OperationalPositionGroup.name,
+            )
+            .all()
+        )
+        group_order = {group.name: group.display_order for group in groups}
         positions = (
             dependencies.OperationalPosition.query.filter_by(
                 unit_id=unit_id, is_active=True
@@ -634,6 +691,8 @@ def create_live_position_blueprint(
                     "id": position.id,
                     "code": position.code,
                     "label": position.label,
+                    "group_name": position.group_name,
+                    "group_order": group_order.get(position.group_name, 999999),
                     "physical_status": physical_status,
                     "display_status": display_status,
                     "primary": (

--- a/migrations/versions/20260731_31_position_groups.py
+++ b/migrations/versions/20260731_31_position_groups.py
@@ -1,0 +1,72 @@
+"""add reusable live-position display groups
+
+Revision ID: 20260731_31
+Revises: 20260731_30
+"""
+
+import os
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260731_31"
+down_revision = "20260731_30"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
+    op.create_table(
+        "operational_position_group",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("unit_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(80), nullable=False),
+        sa.Column("display_order", sa.Integer(), nullable=False, server_default="100"),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.UniqueConstraint("unit_id", "name", name="uq_position_group_unit_name"),
+    )
+    op.create_index(
+        "ix_operational_position_group_unit_id",
+        "operational_position_group",
+        ["unit_id"],
+        unique=False,
+    )
+    connection = op.get_bind()
+    existing = connection.execute(
+        sa.text(
+            "SELECT unit_id, group_name, MIN(display_order) AS display_order "
+            "FROM operational_position WHERE group_name <> '' "
+            "GROUP BY unit_id, group_name"
+        )
+    )
+    groups = sa.table(
+        "operational_position_group",
+        sa.column("unit_id", sa.Integer()),
+        sa.column("name", sa.String(80)),
+        sa.column("display_order", sa.Integer()),
+        sa.column("is_active", sa.Boolean()),
+    )
+    rows = [
+        {
+            "unit_id": row.unit_id,
+            "name": row.group_name,
+            "display_order": row.display_order,
+            "is_active": True,
+        }
+        for row in existing
+    ]
+    if rows:
+        connection.execute(groups.insert(), rows)
+
+
+def downgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
+    op.drop_index(
+        "ix_operational_position_group_unit_id",
+        table_name="operational_position_group",
+    )
+    op.drop_table("operational_position_group")

--- a/saas_models.py
+++ b/saas_models.py
@@ -326,6 +326,17 @@ def register_saas_models(db, utcnow):
         approved_by_id = db.Column(db.Integer)
         applied_at = db.Column(db.DateTime)
 
+    class OperationalPositionGroup(db.Model):
+        __tablename__ = "operational_position_group"
+        id = db.Column(db.Integer, primary_key=True)
+        unit_id = db.Column(db.Integer, db.ForeignKey("unit.id"), nullable=False, index=True)
+        name = db.Column(db.String(80), nullable=False)
+        display_order = db.Column(db.Integer, nullable=False, default=100)
+        is_active = db.Column(db.Boolean, nullable=False, default=True)
+        __table_args__ = (
+            db.UniqueConstraint("unit_id", "name", name="uq_position_group_unit_name"),
+        )
+
     class OperationalPosition(db.Model):
         __tablename__ = "operational_position"
         id = db.Column(db.Integer, primary_key=True)

--- a/static/styles.css
+++ b/static/styles.css
@@ -54,6 +54,11 @@
 .live-position-kiosk__connection { justify-self: end; color: #fbbf24; }
 .live-position-kiosk__connection.is-connected { color: #86efac; }
 .live-position-kiosk main { padding: 1.5rem 2rem 6rem; }
+.live-position-groups { display: grid; gap: 2rem; }
+.live-position-group { padding: 1.25rem; border: 1px solid #334155; border-radius: 18px; background: rgb(15 23 42 / 55%); }
+.live-position-group__header { display: flex; align-items: center; justify-content: center; gap: 1rem; margin: 0 0 1.25rem; text-align: center; }
+.live-position-group__header h2 { margin: 0; font-size: clamp(1.6rem, 3vw, 2.5rem); }
+.live-position-group__header span { padding: .25rem .6rem; border-radius: 999px; background: #334155; color: #cbd5e1; font-size: .85rem; }
 .live-position-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.25rem; }
 .live-position-tile { min-height: 210px; padding: 1.25rem; border: 3px solid #64748b; border-radius: 16px; background: #111c2e; box-shadow: 0 12px 35px rgb(0 0 0 / 22%); }
 .live-position-tile > header { display: flex; justify-content: space-between; gap: 1rem; }

--- a/templates/live_position/kiosk.html
+++ b/templates/live_position/kiosk.html
@@ -19,7 +19,7 @@
   </header>
   <main>
     <div id="live-position-warning" class="live-position-kiosk__warning" hidden></div>
-    <section id="live-position-grid" class="live-position-grid" aria-live="polite"></section>
+    <section id="live-position-grid" class="live-position-groups" aria-live="polite"></section>
   </main>
   <dialog id="live-position-dialog" class="live-position-dialog">
     <form id="live-position-action-form">
@@ -70,7 +70,7 @@
     const render = (payload) => {
       const serverTime = Date.parse(payload.server_time);
       if (Number.isFinite(serverTime)) serverOffset = serverTime - Date.now();
-      grid.innerHTML = payload.positions.map((position) => {
+      const renderPosition = (position) => {
         const occupied = position.primary;
         const label = position.display_status.replace('_', ' ').toUpperCase();
         const buttons = position.display_status === 'closed'
@@ -85,7 +85,19 @@
           <div class="live-position-tile__participants">${position.participants.map((p) => `<small><strong>${escapeText(p.role_label)}</strong> ${escapeText(p.person_name)} · <span data-start="${escapeText(p.started_at)}">00:00</span> <button data-operation="participant_remove" data-participant-id="${p.id}">Log off</button></small>`).join('')}</div>
           <footer>${buttons}</footer>
         </article>`;
-      }).join('') || '<p class="empty-state">No active operational positions are configured.</p>';
+      };
+      const grouped = new Map();
+      payload.positions.forEach((position) => {
+        const name = position.group_name || 'Other positions';
+        if (!grouped.has(name)) grouped.set(name, {order: position.group_order, positions: []});
+        grouped.get(name).positions.push(position);
+      });
+      grid.innerHTML = [...grouped.entries()]
+        .sort((a, b) => a[1].order - b[1].order || a[0].localeCompare(b[0]))
+        .map(([name, group]) => `<section class="live-position-group">
+          <header class="live-position-group__header"><h2>${escapeText(name)}</h2><span>${group.positions.length} position${group.positions.length === 1 ? '' : 's'}</span></header>
+          <div class="live-position-grid">${group.positions.map(renderPosition).join('')}</div>
+        </section>`).join('') || '<p class="empty-state">No active operational positions are configured.</p>';
       connection.innerHTML = '<span aria-hidden="true">●</span> Connected';
       connection.classList.add('is-connected');
       refreshed.textContent = `Last refreshed ${new Date().toLocaleTimeString('en-GB')}`;

--- a/templates/live_position/position_configuration.html
+++ b/templates/live_position/position_configuration.html
@@ -11,6 +11,19 @@
 </section>
 
 <details class="card" open>
+  <summary><strong>Position groups</strong><span>{{ groups|length }} configured</span></summary>
+  <p>Create the display sections first, such as Tower and Radar. Their display order controls the order on the live screen.</p>
+  <form method="post" class="admin-form-grid">
+    <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+    <input type="hidden" name="action" value="create_group">
+    <label>Group name<input name="group_name" maxlength="80" placeholder="Tower" required></label>
+    <label>Display order<input name="group_display_order" type="number" min="0" value="100"></label>
+    <div class="form-actions"><button class="btn" type="submit">Add position group</button></div>
+  </form>
+  {% if groups %}<ul class="live-position-category-list">{% for group in groups %}<li><strong>{{ group.name }}</strong> — display order {{ group.display_order }}</li>{% endfor %}</ul>{% endif %}
+</details>
+
+<details class="card" open>
   <summary><strong>Add a physical position</strong></summary>
   <form method="post" class="admin-form-grid live-position-config-form">
     <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
@@ -18,7 +31,9 @@
     <label>Short code<input name="code" maxlength="30" placeholder="AIR" required></label>
     <label>Display name<input name="label" maxlength="120" placeholder="Aerodrome Control" required></label>
     <label>Display order<input name="display_order" type="number" min="0" value="100"></label>
-    <label>Position group<input name="group_name" maxlength="80" placeholder="Tower"></label>
+    <label>Position group
+      <select name="position_group_id"><option value="">No group</option>{% for group in groups if group.is_active %}<option value="{{ group.id }}">{{ group.name }}</option>{% endfor %}</select>
+    </label>
     <label>Currency category
       <select name="currency_category_id"><option value="">No category yet</option>{% for category in categories if category.is_active %}<option value="{{ category.id }}">{{ category.label }}</option>{% endfor %}</select>
     </label>
@@ -46,7 +61,9 @@
       <label>Short code<input name="code" maxlength="30" value="{{ position.code }}" required></label>
       <label>Display name<input name="label" maxlength="120" value="{{ position.label }}" required></label>
       <label>Display order<input name="display_order" type="number" min="0" value="{{ position.display_order }}"></label>
-      <label>Position group<input name="group_name" maxlength="80" value="{{ position.group_name or '' }}"></label>
+      <label>Position group
+        <select name="position_group_id"><option value="">No group</option>{% for group in groups if group.is_active %}<option value="{{ group.id }}" {% if group.name == position.group_name %}selected{% endif %}>{{ group.name }}</option>{% endfor %}</select>
+      </label>
       <label>Currency category
         <select name="currency_category_id"><option value="">No category yet</option>{% for category in categories if category.is_active %}<option value="{{ category.id }}" {% if position.currency_category_id == category.id %}selected{% endif %}>{{ category.label }}</option>{% endfor %}</select>
       </label>

--- a/tests/test_legacy_migration_fixtures.py
+++ b/tests/test_legacy_migration_fixtures.py
@@ -119,7 +119,7 @@ def test_legacy_fixture_upgrades_to_head_without_data_loss(
         inspector = inspect(connection)
         assert connection.execute(
             text("SELECT version_num FROM alembic_version")
-        ).scalar_one() == "20260731_30"
+        ).scalar_one() == "20260731_31"
         for table, count in before.items():
             assert connection.execute(
                 text(f'SELECT COUNT(*) FROM "{table}"')

--- a/tests/test_live_position_monitoring.py
+++ b/tests/test_live_position_monitoring.py
@@ -56,10 +56,14 @@ def live_position_data():
         controller.set_password("controller-password")
         supporter.set_password("supporter-password")
         admin.set_password("admin-password")
+        position_group = app.OperationalPositionGroup(
+            unit_id=1, name="Tower", display_order=10, is_active=True
+        )
         position = app.OperationalPosition(
             unit_id=1,
             code="AIR",
             label="Aerodrome Control",
+            group_name="Tower",
         )
         role = app.PositionParticipantRole(
             unit_id=1,
@@ -68,7 +72,7 @@ def live_position_data():
             is_primary=False,
         )
         app.db.session.add_all(
-            [unit, kiosk, controller, supporter, admin, position, role]
+            [unit, kiosk, controller, supporter, admin, position_group, position, role]
         )
         app.db.session.flush()
         app.db.session.add(
@@ -197,6 +201,14 @@ def test_kiosk_password_login_bypasses_only_mfa_and_is_endpoint_limited(
     blocked = client.get("/roster/2026-07")
     assert blocked.status_code == 302
     assert blocked.headers["Location"].endswith("/live-positions/kiosk")
+
+
+def test_live_state_includes_configured_display_group(live_position_data):
+    client = app.app.test_client()
+    _login_kiosk(client)
+    state = client.get("/live-positions/api/state").get_json()["positions"][0]
+    assert state["group_name"] == "Tower"
+    assert state["group_order"] == 10
 
 
 def _login_kiosk(client):
@@ -443,6 +455,16 @@ def test_admin_can_configure_currency_category_and_position(live_position_data):
     assert page.status_code == 200
     with client.session_transaction() as session:
         csrf = session["_csrf_token"]
+    group = client.post(
+        "/live-positions/admin/positions",
+        data={
+            "_csrf_token": csrf,
+            "action": "create_group",
+            "group_name": "Radar",
+            "group_display_order": "10",
+        },
+    )
+    assert group.status_code == 302
     category = client.post(
         "/live-positions/admin/positions",
         data={
@@ -455,6 +477,7 @@ def test_admin_can_configure_currency_category_and_position(live_position_data):
     assert category.status_code == 302
     with app.app.app_context():
         category_id = app.PositionCurrencyCategory.query.filter_by(code="TWR").one().id
+        group_id = app.OperationalPositionGroup.query.filter_by(name="Radar").one().id
     position = client.post(
         "/live-positions/admin/positions",
         data={
@@ -463,7 +486,7 @@ def test_admin_can_configure_currency_category_and_position(live_position_data):
             "code": "GMC",
             "label": "Ground Movement Control",
             "display_order": "10",
-            "group_name": "Tower",
+            "position_group_id": str(group_id),
             "currency_category_id": str(category_id),
             "supporting_participants_allowed": "on",
             "multiple_supporting_participants_allowed": "on",
@@ -477,7 +500,10 @@ def test_admin_can_configure_currency_category_and_position(live_position_data):
     with app.app.app_context():
         configured = app.OperationalPosition.query.filter_by(code="GMC").one()
         assert configured.label == "Ground Movement Control"
+        assert configured.group_name == "Radar"
         assert configured.currency_category_id == category_id
+    page = client.get("/live-positions/admin/positions")
+    assert b'<option value="%d" selected>Radar</option>' % group_id in page.data
 
 
 def test_live_position_module_must_be_enabled(live_position_data):

--- a/tests/test_postgresql_multidatabase.py
+++ b/tests/test_postgresql_multidatabase.py
@@ -54,9 +54,9 @@ def test_postgresql_control_and_two_airport_databases_are_isolated(
     dispose_operational_engines()
     for url in (CONTROL_URL, AIRPORT_A_URL, AIRPORT_B_URL):
         _reset_postgres(url)
-    assert upgrade_database(CONTROL_URL, "control") == "20260731_30"
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260731_30"
-    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260731_30"
+    assert upgrade_database(CONTROL_URL, "control") == "20260731_31"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260731_31"
+    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260731_31"
     secret_a = "ATCROSTER_UNIT_1_DATABASE_URL"
     secret_b = "ATCROSTER_UNIT_2_DATABASE_URL"
     monkeypatch.setenv(secret_a, AIRPORT_A_URL)


### PR DESCRIPTION
## What changed

- Added reusable, unit-scoped position groups with explicit display ordering.
- Replaced free-text position group entry with a dropdown populated from configured groups.
- Grouped the kiosk HMI into centred Tower/Radar-style sections.
- Migrated existing position group names into the reusable group list.

## Why

This makes the operational display easier to scan and prevents inconsistent group names caused by typing the same value repeatedly.

## Validation

- Full test suite: 230 passed, 2 skipped.
- Legacy migration fixtures and multi-database revision expectations updated.
