### PR TITLE
Launch position monitor in full screen

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -45,6 +45,15 @@
 .live-position-config-list summary, details.card > summary { display: flex; justify-content: space-between; gap: 1rem; cursor: pointer; }
 .live-position-category-list { margin: 1rem 0 0; padding-left: 1.25rem; }
 .live-position-kiosk { margin: 0; min-height: 100vh; background: #07111f; color: #f8fafc; font-family: system-ui, sans-serif; }
+.live-position-kiosk-launch { position: fixed; z-index: 10000; inset: 0; display: grid; place-items: center; padding: 1.5rem; background: #07111f; text-align: center; }
+.live-position-kiosk-launch[hidden] { display: none; }
+.live-position-kiosk-launch > div { display: grid; justify-items: center; gap: 1rem; width: min(520px, 100%); padding: 2.5rem; border: 2px solid #475569; border-radius: 20px; background: #111c2e; box-shadow: 0 24px 70px rgb(0 0 0 / 45%); }
+.live-position-kiosk-launch p, .live-position-kiosk-launch h1, .live-position-kiosk-launch span { margin: 0; }
+.live-position-kiosk-launch p { color: #94a3b8; text-transform: uppercase; letter-spacing: .08em; }
+.live-position-kiosk-launch h1 { font-size: clamp(2rem, 6vw, 3.5rem); }
+.live-position-kiosk-launch span { color: #cbd5e1; }
+.live-position-kiosk-launch .btn { min-width: 220px; min-height: 58px; font-size: 1.15rem; }
+.live-position-kiosk-launch small { color: #fca5a5; }
 .live-position-kiosk__header { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 2rem; padding: 1.25rem 2rem; border-bottom: 2px solid #334155; }
 .live-position-kiosk__header p, .live-position-kiosk__header h1 { margin: 0; }
 .live-position-kiosk__header p { color: #94a3b8; font-size: .9rem; text-transform: uppercase; letter-spacing: .08em; }

--- a/templates/live_position/kiosk.html
+++ b/templates/live_position/kiosk.html
@@ -3,10 +3,23 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <title>Live positions · {{ unit.name }}</title>
+  <link rel="manifest" href="{{ url_for('static', filename='manifest.webmanifest') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
 <body class="live-position-kiosk">
+  <section id="live-position-kiosk-launch" class="live-position-kiosk-launch" role="dialog" aria-modal="true" aria-labelledby="live-position-kiosk-launch-title">
+    <div>
+      <p>Live Position Monitoring</p>
+      <h1 id="live-position-kiosk-launch-title">Start kiosk display</h1>
+      <span>This opens the monitor full screen and hides the browser controls.</span>
+      <button class="btn" type="button" id="live-position-kiosk-start">Start kiosk</button>
+      <small id="live-position-kiosk-launch-error" role="alert" hidden></small>
+    </div>
+  </section>
   <header class="live-position-kiosk__header">
     <div><p>Live Position Monitoring</p><h1>{{ unit.name }}</h1></div>
     <div class="live-position-kiosk__clock">
@@ -63,9 +76,42 @@
     const clock = document.getElementById('live-position-clock');
     const dialog = document.getElementById('live-position-dialog');
     const form = document.getElementById('live-position-action-form');
+    const kioskLaunch = document.getElementById('live-position-kiosk-launch');
+    const kioskStart = document.getElementById('live-position-kiosk-start');
+    const kioskLaunchError = document.getElementById('live-position-kiosk-launch-error');
     const csrf = {{ csrf_token()|tojson }};
     let people = [];
     let serverOffset = 0;
+    const isStandalone = () => window.matchMedia('(display-mode: fullscreen), (display-mode: standalone)').matches || window.navigator.standalone === true;
+    const fullscreenElement = () => document.fullscreenElement || document.webkitFullscreenElement;
+    const updateKioskLaunch = () => {
+      kioskLaunch.hidden = Boolean(fullscreenElement()) || isStandalone();
+    };
+    const startKiosk = async () => {
+      const root = document.documentElement;
+      const enterFullscreen = root.requestFullscreen || root.webkitRequestFullscreen;
+      kioskLaunchError.hidden = true;
+      if (!enterFullscreen) {
+        kioskLaunchError.textContent = 'This browser cannot hide its controls automatically. Install the app or use the browser kiosk/full-screen command.';
+        kioskLaunchError.hidden = false;
+        return;
+      }
+      try {
+        try {
+          await enterFullscreen.call(root, {navigationUI: 'hide'});
+        } catch (_optionsError) {
+          await enterFullscreen.call(root);
+        }
+      } catch (_error) {
+        kioskLaunchError.textContent = 'Full screen was blocked. Select Start kiosk again or allow full-screen access for this site.';
+        kioskLaunchError.hidden = false;
+      }
+      updateKioskLaunch();
+    };
+    kioskStart.addEventListener('click', startKiosk);
+    document.addEventListener('fullscreenchange', updateKioskLaunch);
+    document.addEventListener('webkitfullscreenchange', updateKioskLaunch);
+    updateKioskLaunch();
     const escapeText = (value) => String(value ?? '').replace(/[&<>"']/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
     const render = (payload) => {
       const serverTime = Date.parse(payload.server_time);

--- a/tests/test_live_position_monitoring.py
+++ b/tests/test_live_position_monitoring.py
@@ -194,7 +194,10 @@ def test_kiosk_password_login_bypasses_only_mfa_and_is_endpoint_limited(
     )
     assert response.status_code == 302
     assert response.headers["Location"].endswith("/live-positions/kiosk")
-    assert client.get("/live-positions/kiosk").status_code == 200
+    kiosk_page = client.get("/live-positions/kiosk")
+    assert kiosk_page.status_code == 200
+    assert b"Start kiosk display" in kiosk_page.data
+    assert b"requestFullscreen" in kiosk_page.data
     state = client.get("/live-positions/api/state")
     assert state.status_code == 200
     assert state.get_json()["positions"][0]["display_status"] == "closed"


### PR DESCRIPTION
## What changed

- Added a dedicated Start kiosk launch screen.
- Requests browser full-screen mode with navigation controls hidden.
- Supports the standard and WebKit full-screen APIs plus installed standalone apps.
- Restores the launch screen if full-screen mode is exited.

## Browser security note

Browsers require a user gesture before a website may hide browser chrome, so the kiosk uses one deliberate Start kiosk action. Installed standalone apps start without the launch overlay.

## Validation

- Full test suite: 230 passed, 2 skipped.
