### PR TITLE
Show Tower above Radar

### DIFF
--- a/templates/live_position/kiosk.html
+++ b/templates/live_position/kiosk.html
@@ -160,8 +160,14 @@
         if (!grouped.has(name)) grouped.set(name, {order: position.group_order, positions: []});
         grouped.get(name).positions.push(position);
       });
+      const operationalGroupPriority = (name) => {
+        const normalized = name.trim().toLowerCase();
+        if (normalized.startsWith('tower')) return 0;
+        if (normalized.startsWith('radar')) return 1;
+        return 2;
+      };
       grid.innerHTML = [...grouped.entries()]
-        .sort((a, b) => a[1].order - b[1].order || a[0].localeCompare(b[0]))
+        .sort((a, b) => operationalGroupPriority(a[0]) - operationalGroupPriority(b[0]) || a[1].order - b[1].order || a[0].localeCompare(b[0]))
         .map(([name, group]) => `<section class="live-position-group">
           <header class="live-position-group__header"><h2>${escapeText(name)}</h2><span>${group.positions.length} position${group.positions.length === 1 ? '' : 's'}</span></header>
           <div class="live-position-grid">${group.positions.map(renderPosition).join('')}</div>

--- a/tests/test_live_position_monitoring.py
+++ b/tests/test_live_position_monitoring.py
@@ -200,6 +200,9 @@ def test_kiosk_password_login_bypasses_only_mfa_and_is_endpoint_limited(
     assert b"requestFullscreen" in kiosk_page.data
     assert b"live-position-board-viewport" in kiosk_page.data
     assert b"ResizeObserver" in kiosk_page.data
+    assert b"operationalGroupPriority" in kiosk_page.data
+    assert b"startsWith('tower')" in kiosk_page.data
+    assert b"startsWith('radar')" in kiosk_page.data
     state = client.get("/live-positions/api/state")
     assert state.status_code == 200
     assert state.get_json()["positions"][0]["display_status"] == "closed"


### PR DESCRIPTION
## What changed

- Tower-named position groups are always displayed first.
- Radar-named position groups are displayed immediately after Tower.
- Additional groups retain their configured display order.

## Validation

- Full test suite: 230 passed, 2 skipped.
