### PR TITLE
Open closed positions on logon

### DIFF
--- a/live_position_service.py
+++ b/live_position_service.py
@@ -253,8 +253,7 @@ class LivePositionService:
         timestamp = self.now()
         try:
             position = self._position_for_update(unit_id, position_id)
-            if self._latest_status(unit_id, position_id) != "open":
-                raise LivePositionConflict("The position is closed.")
+            position_was_closed = self._latest_status(unit_id, position_id) != "open"
             if self._open_session(unit_id, position_id):
                 raise LivePositionConflict("The position is already occupied.")
             participant_ids = [int(item["person_id"]) for item in (participants or [])]
@@ -281,6 +280,30 @@ class LivePositionService:
                 raise LivePositionValidationError("Training is not supported here.")
             if session_type == "assessment" and not position.assessment_supported:
                 raise LivePositionValidationError("Assessment is not supported here.")
+            if position_was_closed:
+                open_key = self.related_key(key, "position-opened")
+                self.db.session.add(
+                    self.models.PositionStatusEvent(
+                        unit_id=unit_id,
+                        position_id=position_id,
+                        status="open",
+                        occurred_at=timestamp,
+                        actor_id=actor_id,
+                        reason="Opened automatically on controller logon",
+                        transaction_key=open_key,
+                    )
+                )
+                self._audit(
+                    unit_id=unit_id,
+                    actor_id=actor_id,
+                    action="position_opened",
+                    occurred_at=timestamp,
+                    transaction_key=open_key,
+                    position_id=position_id,
+                    old={"status": "closed"},
+                    new={"status": "open"},
+                    reason="Opened automatically on controller logon",
+                )
             session = self.models.PositionSession(
                 unit_id=unit_id,
                 position_id=position_id,

--- a/templates/live_position/kiosk.html
+++ b/templates/live_position/kiosk.html
@@ -142,7 +142,7 @@
         const occupied = position.primary;
         const label = position.display_status.replace('_', ' ').toUpperCase();
         const buttons = position.display_status === 'closed'
-          ? '<button class="btn" data-operation="open">Open position</button>'
+          ? '<button class="btn" data-operation="logon">Log on</button>'
           : position.display_status === 'vacant'
             ? '<button class="btn" data-operation="logon">Log on</button><button class="btn btn-secondary" data-operation="close">Close</button>'
             : '<button class="btn" data-operation="handover">Hand over</button><button class="btn btn-secondary" data-operation="logoff">Log off</button><button class="btn btn-secondary" data-operation="logoff_close">Log off & close</button><button class="btn btn-secondary" data-operation="participant">Add secondary</button>';

--- a/tests/test_live_position_monitoring.py
+++ b/tests/test_live_position_monitoring.py
@@ -251,15 +251,6 @@ def test_kiosk_controller_selection_runs_full_live_position_workflow(
     client = app.app.test_client()
     csrf = _login_kiosk(client)
     position = live_position_data["position_id"]
-    opened = _action(
-        client,
-        csrf,
-        f"/live-positions/api/positions/{position}/open",
-        {
-            "request_key": "open-workflow",
-        },
-    )
-    assert opened.status_code == 200
     logged_on = _action(
         client,
         csrf,
@@ -274,10 +265,16 @@ def test_kiosk_controller_selection_runs_full_live_position_workflow(
     assert logged_on.status_code == 200
     state = client.get("/live-positions/api/state").get_json()["positions"][0]
     assert state["display_status"] == "training"
+    assert state["physical_status"] == "open"
     assert state["primary"]["name"] == "Alex Controller"
     assert state["participants"][0]["role_label"] == "OJTI"
     assert "+00:00Z" not in state["primary"]["started_at"]
     participant_id = state["participants"][0]["id"]
+    with app.app.app_context():
+        opened = app.PositionStatusEvent.query.filter_by(
+            position_id=position, status="open"
+        ).one()
+        assert opened.reason == "Opened automatically on controller logon"
     removed = _action(
         client,
         csrf,


### PR DESCRIPTION
## What changed

- Replaced the closed-position Open action with Log on.
- Automatically opens a closed position when a controller session starts.
- Writes the opening event, audit record and session atomically.
- Keeps explicit open/close endpoints available for exceptional operational use.

## Why

Controllers should not have to open a position and then perform a separate logon.

## Validation

- Full test suite: 230 passed, 2 skipped.
- Workflow test now starts from a closed position and verifies both open status and the automatic-opening audit reason.
