### PR TITLE
Show primary when adding secondary

### DIFF
--- a/templates/live_position/kiosk.html
+++ b/templates/live_position/kiosk.html
@@ -146,7 +146,7 @@
           : position.display_status === 'vacant'
             ? '<button class="btn" data-operation="logon">Log on</button><button class="btn btn-secondary" data-operation="close">Close</button>'
             : '<button class="btn" data-operation="handover">Hand over</button><button class="btn btn-secondary" data-operation="logoff">Log off</button><button class="btn btn-secondary" data-operation="logoff_close">Log off & close</button><button class="btn btn-secondary" data-operation="participant">Add secondary</button>';
-        return `<article class="live-position-tile live-position-tile--${escapeText(position.display_status)}" data-position-id="${position.id}" data-position-label="${escapeText(position.code)}">
+        return `<article class="live-position-tile live-position-tile--${escapeText(position.display_status)}" data-position-id="${position.id}" data-position-label="${escapeText(position.code)}" data-primary-id="${occupied ? occupied.id : ''}" data-primary-name="${occupied ? escapeText(occupied.name) : ''}">
           <header><strong>${escapeText(position.code)}</strong><span>${escapeText(label)}</span></header>
           <h2>${escapeText(position.label)}</h2>
           ${occupied ? `<div class="live-position-tile__primary"><strong>${escapeText(occupied.name)}</strong><span data-start="${escapeText(occupied.started_at)}">00:00</span></div>` : '<p>No controller logged on</p>'}
@@ -200,11 +200,19 @@
       document.getElementById('live-position-operation').value = operation;
       document.getElementById('live-position-participant-id').value = button.dataset.participantId || '';
       document.getElementById('live-position-dialog-title').textContent = `${button.textContent.trim()} · ${tile.dataset.positionLabel}`;
-      document.getElementById('live-position-person').innerHTML = '<option value="">Select your name</option>' + people.map((person) => `<option value="${person.id}">${escapeText(person.name)}</option>`).join('');
+      const primarySelect = document.getElementById('live-position-person');
+      primarySelect.innerHTML = '<option value="">Select your name</option>' + people.map((person) => `<option value="${person.id}">${escapeText(person.name)}</option>`).join('');
       const needsPrimary = ['logon', 'handover'].includes(operation);
       const supportsSecondary = needsPrimary || operation === 'participant';
-      document.getElementById('live-position-person-wrap').hidden = !needsPrimary;
-      document.getElementById('live-position-person').required = needsPrimary;
+      if (operation === 'participant' && tile.dataset.primaryId) {
+        if (![...primarySelect.options].some((option) => option.value === tile.dataset.primaryId)) {
+          primarySelect.add(new Option(tile.dataset.primaryName, tile.dataset.primaryId));
+        }
+        primarySelect.value = tile.dataset.primaryId;
+      }
+      document.getElementById('live-position-person-wrap').hidden = !(needsPrimary || operation === 'participant');
+      primarySelect.required = needsPrimary;
+      primarySelect.disabled = operation === 'participant';
       document.getElementById('live-position-support-role-wrap').hidden = !supportsSecondary;
       document.getElementById('live-position-support-role').value = operation === 'participant' ? 'ojti' : '';
       document.getElementById('live-position-support-role').required = operation === 'participant';

--- a/tests/test_live_position_monitoring.py
+++ b/tests/test_live_position_monitoring.py
@@ -203,6 +203,8 @@ def test_kiosk_password_login_bypasses_only_mfa_and_is_endpoint_limited(
     assert b"operationalGroupPriority" in kiosk_page.data
     assert b"startsWith('tower')" in kiosk_page.data
     assert b"startsWith('radar')" in kiosk_page.data
+    assert b'data-primary-id="${occupied ? occupied.id' in kiosk_page.data
+    assert b"primarySelect.disabled = operation === 'participant'" in kiosk_page.data
     state = client.get("/live-positions/api/state")
     assert state.status_code == 200
     assert state.get_json()["positions"][0]["display_status"] == "closed"


### PR DESCRIPTION
## What changed

- Carries the occupied controller identity on each live position tile.
- Shows the primary-controller field for Add secondary.
- Prefills it with the controller currently logged on and locks the field.
- Preserves the primary name even if that controller is no longer in the active selection list.

## Why

Operators need clear confirmation of which primary controller the secondary OJTI or assessor is joining.

## Validation

- Full test suite: 230 passed, 2 skipped.
