### PR TITLE
Make position logoff one click

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -63,6 +63,7 @@
 .live-position-kiosk__connection { justify-self: end; color: #fbbf24; }
 .live-position-kiosk__connection.is-connected { color: #86efac; }
 .live-position-kiosk main { display: grid; grid-template-rows: auto minmax(0, 1fr); min-height: 0; padding: clamp(.6rem, 1.5vw, 1.5rem) clamp(.75rem, 2vw, 2rem); overflow: hidden; }
+.live-position-kiosk__warning { margin: 0 0 .75rem; padding: .75rem 1rem; border: 2px solid #f87171; border-radius: 8px; background: #450a0a; color: #fecaca; font-weight: 700; }
 .live-position-board-viewport { min-width: 0; min-height: 0; overflow: hidden; }
 .live-position-groups { display: grid; gap: 2rem; transform-origin: top center; will-change: transform; }
 .live-position-group { padding: 1.25rem; border: 1px solid #334155; border-radius: 18px; background: rgb(15 23 42 / 55%); }

--- a/templates/live_position/kiosk.html
+++ b/templates/live_position/kiosk.html
@@ -74,6 +74,7 @@
   (() => {
     const grid = document.getElementById('live-position-grid');
     const boardViewport = document.getElementById('live-position-board-viewport');
+    const warning = document.getElementById('live-position-warning');
     const connection = document.getElementById('live-position-connection');
     const refreshed = document.getElementById('live-position-refresh');
     const clock = document.getElementById('live-position-clock');
@@ -136,6 +137,7 @@
     if (window.ResizeObserver) new ResizeObserver(fitBoard).observe(boardViewport);
     const escapeText = (value) => String(value ?? '').replace(/[&<>"']/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
     const render = (payload) => {
+      warning.hidden = true;
       const serverTime = Date.parse(payload.server_time);
       if (Number.isFinite(serverTime)) serverOffset = serverTime - Date.now();
       const renderPosition = (position) => {
@@ -221,9 +223,33 @@
       document.getElementById('live-position-action-error').hidden = true;
       dialog.showModal();
     };
-    grid.addEventListener('click', (event) => {
+    grid.addEventListener('click', async (event) => {
       const button = event.target.closest('[data-operation]');
-      if (button) openAction(button);
+      if (!button) return;
+      const operation = button.dataset.operation;
+      if (operation === 'logoff' || operation === 'logoff_close') {
+        const tile = button.closest('[data-position-id]');
+        button.disabled = true;
+        try {
+          const response = await fetch(`/live-positions/api/positions/${tile.dataset.positionId}/logoff`, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json', 'X-CSRF-Token': csrf},
+            body: JSON.stringify({
+              close_position: operation === 'logoff_close',
+              request_key: crypto.randomUUID(),
+            }),
+          });
+          const result = await response.json().catch(() => ({}));
+          if (!response.ok) throw new Error(result.error || 'The controller could not be logged off.');
+          await refresh();
+        } catch (failure) {
+          warning.textContent = failure.message;
+          warning.hidden = false;
+          button.disabled = false;
+        }
+        return;
+      }
+      openAction(button);
     });
     document.querySelector('[data-dialog-close]').addEventListener('click', () => dialog.close());
     document.getElementById('live-position-support-role').addEventListener('change', populateSecondaryPeople);

--- a/tests/test_live_position_monitoring.py
+++ b/tests/test_live_position_monitoring.py
@@ -205,6 +205,8 @@ def test_kiosk_password_login_bypasses_only_mfa_and_is_endpoint_limited(
     assert b"startsWith('radar')" in kiosk_page.data
     assert b'data-primary-id="${occupied ? occupied.id' in kiosk_page.data
     assert b"primarySelect.disabled = operation === 'participant'" in kiosk_page.data
+    assert b"operation === 'logoff' || operation === 'logoff_close'" in kiosk_page.data
+    assert b"close_position: operation === 'logoff_close'" in kiosk_page.data
     state = client.get("/live-positions/api/state")
     assert state.status_code == 200
     assert state.get_json()["positions"][0]["display_status"] == "closed"


### PR DESCRIPTION
## What changed

- Log off now immediately ends the current controller session.
- Log off & close immediately ends the session and closes the position.
- Buttons disable while the request is running to prevent duplicate actions.
- Server errors appear directly on the kiosk board.

## Why

Neither operation requires controller input, so a confirmation dialog added unnecessary operational steps.

## Validation

- Full test suite: 230 passed, 2 skipped.
