### PR TITLE
Choose controllers to log off

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -93,6 +93,8 @@
 .live-position-dialog form { display: grid; gap: 1rem; }
 .live-position-dialog header { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
 .live-position-dialog h2, .live-position-dialog p { margin: 0; }
+.live-position-logoff-options { display: grid; gap: .75rem; margin-top: 1rem; }
+.live-position-logoff-options .btn { width: 100%; min-height: 50px; }
 .live-position-dialog label { display: grid; gap: .35rem; font-weight: 700; }
 .live-position-dialog input, .live-position-dialog select { min-height: 48px; border: 1px solid #64748b; border-radius: 8px; padding: .65rem; background: #f8fafc; color: #0f172a; font-size: 1rem; }
 .live-position-dialog__error { padding: .75rem; border: 2px solid #f87171; border-radius: 8px; background: #450a0a; }

--- a/templates/live_position/kiosk.html
+++ b/templates/live_position/kiosk.html
@@ -63,6 +63,15 @@
       <button class="btn" type="submit" id="live-position-confirm">Confirm</button>
     </form>
   </dialog>
+  <dialog id="live-position-logoff-dialog" class="live-position-dialog">
+    <header>
+      <h2>Choose who to log off</h2>
+      <button type="button" class="btn btn-secondary" data-logoff-dialog-close>Cancel</button>
+    </header>
+    <p id="live-position-logoff-help"></p>
+    <div id="live-position-logoff-options" class="live-position-logoff-options"></div>
+    <p id="live-position-logoff-error" class="live-position-dialog__error" role="alert" hidden></p>
+  </dialog>
   <footer class="live-position-kiosk__footer">
     <span id="live-position-refresh">Awaiting server data</span>
     <form method="post" action="{{ url_for('logout') }}">
@@ -79,12 +88,16 @@
     const refreshed = document.getElementById('live-position-refresh');
     const clock = document.getElementById('live-position-clock');
     const dialog = document.getElementById('live-position-dialog');
+    const logoffDialog = document.getElementById('live-position-logoff-dialog');
+    const logoffOptions = document.getElementById('live-position-logoff-options');
+    const logoffError = document.getElementById('live-position-logoff-error');
     const form = document.getElementById('live-position-action-form');
     const kioskLaunch = document.getElementById('live-position-kiosk-launch');
     const kioskStart = document.getElementById('live-position-kiosk-start');
     const kioskLaunchError = document.getElementById('live-position-kiosk-launch-error');
     const csrf = {{ csrf_token()|tojson }};
     let people = [];
+    let livePositions = new Map();
     let serverOffset = 0;
     const isStandalone = () => window.matchMedia('(display-mode: fullscreen), (display-mode: standalone)').matches || window.navigator.standalone === true;
     const fullscreenElement = () => document.fullscreenElement || document.webkitFullscreenElement;
@@ -138,6 +151,7 @@
     const escapeText = (value) => String(value ?? '').replace(/[&<>"']/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
     const render = (payload) => {
       warning.hidden = true;
+      livePositions = new Map(payload.positions.map((position) => [position.id, position]));
       const serverTime = Date.parse(payload.server_time);
       if (Number.isFinite(serverTime)) serverOffset = serverTime - Date.now();
       const renderPosition = (position) => {
@@ -223,12 +237,39 @@
       document.getElementById('live-position-action-error').hidden = true;
       dialog.showModal();
     };
+    const openLogoffChoice = (position) => {
+      logoffDialog.dataset.positionId = position.id;
+      document.getElementById('live-position-logoff-help').textContent = `${position.primary.name} is the primary controller. Choose whether to log off everyone or only a secondary controller.`;
+      logoffOptions.replaceChildren();
+      const allButton = document.createElement('button');
+      allButton.type = 'button';
+      allButton.className = 'btn';
+      allButton.dataset.logoffChoice = 'all';
+      allButton.textContent = 'Log off all controllers';
+      logoffOptions.append(allButton);
+      position.participants.forEach((participant) => {
+        const secondaryButton = document.createElement('button');
+        secondaryButton.type = 'button';
+        secondaryButton.className = 'btn btn-secondary';
+        secondaryButton.dataset.logoffChoice = 'secondary';
+        secondaryButton.dataset.participantId = participant.id;
+        secondaryButton.textContent = `Log off ${participant.person_name} (${participant.role_label}) only`;
+        logoffOptions.append(secondaryButton);
+      });
+      logoffError.hidden = true;
+      logoffDialog.showModal();
+    };
     grid.addEventListener('click', async (event) => {
       const button = event.target.closest('[data-operation]');
       if (!button) return;
       const operation = button.dataset.operation;
       if (operation === 'logoff' || operation === 'logoff_close') {
         const tile = button.closest('[data-position-id]');
+        const position = livePositions.get(Number(tile.dataset.positionId));
+        if (operation === 'logoff' && position?.participants.length) {
+          openLogoffChoice(position);
+          return;
+        }
         button.disabled = true;
         try {
           const response = await fetch(`/live-positions/api/positions/${tile.dataset.positionId}/logoff`, {
@@ -250,6 +291,32 @@
         return;
       }
       openAction(button);
+    });
+    document.querySelector('[data-logoff-dialog-close]').addEventListener('click', () => logoffDialog.close());
+    logoffOptions.addEventListener('click', async (event) => {
+      const button = event.target.closest('[data-logoff-choice]');
+      if (!button) return;
+      const positionId = logoffDialog.dataset.positionId;
+      const logoffAll = button.dataset.logoffChoice === 'all';
+      const route = logoffAll
+        ? `/live-positions/api/positions/${positionId}/logoff`
+        : `/live-positions/api/positions/${positionId}/participants/${button.dataset.participantId}/logoff`;
+      button.disabled = true;
+      try {
+        const response = await fetch(route, {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json', 'X-CSRF-Token': csrf},
+          body: JSON.stringify({close_position: false, request_key: crypto.randomUUID()}),
+        });
+        const result = await response.json().catch(() => ({}));
+        if (!response.ok) throw new Error(result.error || 'The controller could not be logged off.');
+        logoffDialog.close();
+        await refresh();
+      } catch (failure) {
+        logoffError.textContent = failure.message;
+        logoffError.hidden = false;
+        button.disabled = false;
+      }
     });
     document.querySelector('[data-dialog-close]').addEventListener('click', () => dialog.close());
     document.getElementById('live-position-support-role').addEventListener('change', populateSecondaryPeople);

--- a/tests/test_live_position_monitoring.py
+++ b/tests/test_live_position_monitoring.py
@@ -207,6 +207,9 @@ def test_kiosk_password_login_bypasses_only_mfa_and_is_endpoint_limited(
     assert b"primarySelect.disabled = operation === 'participant'" in kiosk_page.data
     assert b"operation === 'logoff' || operation === 'logoff_close'" in kiosk_page.data
     assert b"close_position: operation === 'logoff_close'" in kiosk_page.data
+    assert b"Log off all controllers" in kiosk_page.data
+    assert b"data-logoff-choice" in kiosk_page.data
+    assert b"position?.participants.length" in kiosk_page.data
     state = client.get("/live-positions/api/state")
     assert state.status_code == 200
     assert state.get_json()["positions"][0]["display_status"] == "closed"
@@ -288,6 +291,12 @@ def test_kiosk_controller_selection_runs_full_live_position_workflow(
         },
     )
     assert removed.status_code == 200
+    primary_only_state = client.get(
+        "/live-positions/api/state"
+    ).get_json()["positions"][0]
+    assert primary_only_state["primary"]["name"] == "Alex Controller"
+    assert primary_only_state["participants"] == []
+    assert primary_only_state["display_status"] == "operational"
     assessed = _action(
         client,
         csrf,


### PR DESCRIPTION
## What changed

- Keeps primary logoff as one click when no secondary is present.
- Shows a scoped logoff choice when secondary controllers are active.
- Offers Log off all controllers and a named button for each secondary controller.
- Logging off only a secondary leaves the primary session active and recalculates its operational mode.
- Log off & close continues to end the complete position session.

## Validation

- Full test suite: 230 passed, 2 skipped.
- Workflow verifies secondary-only logoff preserves the primary controller and returns the position to operational mode.
