### PR TITLE
Show controller time remaining

### DIFF
--- a/live_position_blueprint.py
+++ b/live_position_blueprint.py
@@ -341,6 +341,15 @@ def create_live_position_blueprint(
                     position.display_order = max(
                         0, _int_field(data, "display_order", 100)
                     )
+                    position.maximum_session_duration_minutes = max(
+                        1,
+                        min(
+                            1440,
+                            _int_field(
+                                data, "maximum_session_duration_minutes", 120
+                            ),
+                        ),
+                    )
                     position.group_name = group.name if group else ""
                     position.currency_category_id = category.id if category else None
                     position.supporting_participants_allowed = (
@@ -659,6 +668,11 @@ def create_live_position_blueprint(
                 else None
             )
             participants = []
+            maximum_duration_seconds = (
+                session.maximum_duration_seconds
+                if session and session.maximum_duration_seconds
+                else position.maximum_session_duration_minutes * 60
+            )
             if session:
                 for row in dependencies.PositionSessionParticipant.query.filter_by(
                     unit_id=unit_id, session_id=session.id, ended_at=None
@@ -676,6 +690,7 @@ def create_live_position_blueprint(
                             "role_id": row.role_id,
                             "role_label": role.label if role else "Supporting",
                             "started_at": _iso_timestamp(row.started_at),
+                            "maximum_duration_seconds": maximum_duration_seconds,
                         }
                     )
             physical_status = status_event.status if status_event else "closed"
@@ -700,6 +715,7 @@ def create_live_position_blueprint(
                             "id": primary.id,
                             "name": primary.name,
                             "started_at": _iso_timestamp(session.started_at),
+                            "maximum_duration_seconds": maximum_duration_seconds,
                             "due_off_at": (
                                 _iso_timestamp(session.due_off_at)
                                 if session.due_off_at

--- a/live_position_service.py
+++ b/live_position_service.py
@@ -10,7 +10,7 @@ import json
 import hashlib
 import secrets
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Callable
 
 from sqlalchemy.exc import IntegrityError
@@ -280,6 +280,14 @@ class LivePositionService:
                 raise LivePositionValidationError("Training is not supported here.")
             if session_type == "assessment" and not position.assessment_supported:
                 raise LivePositionValidationError("Assessment is not supported here.")
+            effective_maximum_duration_seconds = (
+                maximum_duration_seconds
+                if maximum_duration_seconds is not None
+                else position.maximum_session_duration_minutes * 60
+            )
+            effective_due_off_at = due_off_at or (
+                timestamp + timedelta(seconds=effective_maximum_duration_seconds)
+            )
             if position_was_closed:
                 open_key = self.related_key(key, "position-opened")
                 self.db.session.add(
@@ -313,9 +321,9 @@ class LivePositionService:
                 currency_category_id=(
                     currency_category_id or position.currency_category_id
                 ),
-                maximum_duration_seconds=maximum_duration_seconds,
+                maximum_duration_seconds=effective_maximum_duration_seconds,
                 warning_threshold_seconds=warning_threshold_seconds,
-                due_off_at=due_off_at,
+                due_off_at=effective_due_off_at,
                 created_by_id=actor_id,
                 transaction_key=key,
             )
@@ -578,6 +586,15 @@ class LivePositionService:
             session_type=session_type,
             started_at=timestamp,
             currency_category_id=position.currency_category_id,
+            maximum_duration_seconds=(
+                position.maximum_session_duration_minutes * 60
+            ),
+            due_off_at=(
+                timestamp
+                + timedelta(
+                    minutes=position.maximum_session_duration_minutes
+                )
+            ),
             created_by_id=actor_id,
             transaction_key=self.related_key(key, "incoming"),
         )

--- a/migrations/versions/20260731_32_position_time_allowance.py
+++ b/migrations/versions/20260731_32_position_time_allowance.py
@@ -1,0 +1,37 @@
+"""add position controller time allowance
+
+Revision ID: 20260731_32
+Revises: 20260731_31
+"""
+
+import os
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260731_32"
+down_revision = "20260731_31"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
+    with op.batch_alter_table("operational_position") as batch:
+        batch.add_column(
+            sa.Column(
+                "maximum_session_duration_minutes",
+                sa.Integer(),
+                nullable=False,
+                server_default="120",
+            )
+        )
+
+
+def downgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
+    with op.batch_alter_table("operational_position") as batch:
+        batch.drop_column("maximum_session_duration_minutes")

--- a/saas_models.py
+++ b/saas_models.py
@@ -346,6 +346,9 @@ def register_saas_models(db, utcnow):
         description = db.Column(db.Text, nullable=False, default="")
         display_order = db.Column(db.Integer, nullable=False, default=100)
         group_name = db.Column(db.String(80), nullable=False, default="")
+        maximum_session_duration_minutes = db.Column(
+            db.Integer, nullable=False, default=120
+        )
         currency_category_id = db.Column(
             db.Integer, db.ForeignKey("position_currency_category.id")
         )

--- a/static/styles.css
+++ b/static/styles.css
@@ -81,11 +81,14 @@
 .live-position-tile--operational { border-color: #4ade80; }
 .live-position-tile--training, .live-position-tile--supervised { border-color: #60a5fa; }
 .live-position-tile--assessment { border-color: #c084fc; }
-.live-position-tile__primary { display: flex; align-items: baseline; justify-content: space-between; gap: 1rem; }
+.live-position-tile__primary { display: flex; align-items: start; justify-content: space-between; gap: 1rem; }
 .live-position-tile__primary strong { font-size: 1.5rem; }
-.live-position-tile__primary span { font-size: 1.4rem; font-variant-numeric: tabular-nums; }
+.live-position-controller-times { display: grid; gap: .2rem; text-align: right; font-variant-numeric: tabular-nums; }
+.live-position-controller-times > span { display: flex; justify-content: space-between; gap: .75rem; color: #cbd5e1; font-size: .85rem; }
+.live-position-controller-times b { color: #f8fafc; font-size: 1rem; }
+.live-position-controller-times b.is-overdue { color: #fca5a5; }
 .live-position-tile__participants { display: grid; gap: .4rem; margin-top: .75rem; }
-.live-position-tile__participants small { display: flex; align-items: center; gap: .4rem; }
+.live-position-tile__participants small { display: grid; grid-template-columns: minmax(0, 1fr) auto auto; align-items: center; gap: .75rem; padding-top: .5rem; border-top: 1px solid #334155; }
 .live-position-tile__participants button { margin-left: auto; border: 1px solid #94a3b8; border-radius: 6px; background: transparent; color: inherit; }
 .live-position-tile > footer { display: flex; flex-wrap: wrap; gap: .5rem; margin-top: 1.25rem; }
 .live-position-dialog { width: min(520px, calc(100vw - 2rem)); padding: 1.5rem; border: 2px solid #475569; border-radius: 16px; background: #111c2e; color: #f8fafc; }

--- a/templates/live_position/kiosk.html
+++ b/templates/live_position/kiosk.html
@@ -165,8 +165,8 @@
         return `<article class="live-position-tile live-position-tile--${escapeText(position.display_status)}" data-position-id="${position.id}" data-position-label="${escapeText(position.code)}" data-primary-id="${occupied ? occupied.id : ''}" data-primary-name="${occupied ? escapeText(occupied.name) : ''}">
           <header><strong>${escapeText(position.code)}</strong><span>${escapeText(label)}</span></header>
           <h2>${escapeText(position.label)}</h2>
-          ${occupied ? `<div class="live-position-tile__primary"><strong>${escapeText(occupied.name)}</strong><span data-start="${escapeText(occupied.started_at)}">00:00</span></div>` : '<p>No controller logged on</p>'}
-          <div class="live-position-tile__participants">${position.participants.map((p) => `<small><strong>${escapeText(p.role_label)}</strong> ${escapeText(p.person_name)} · <span data-start="${escapeText(p.started_at)}">00:00</span> <button data-operation="participant_remove" data-participant-id="${p.id}">Log off</button></small>`).join('')}</div>
+          ${occupied ? `<div class="live-position-tile__primary"><strong>${escapeText(occupied.name)}</strong><div class="live-position-controller-times"><span>Elapsed <b data-elapsed-from="${escapeText(occupied.started_at)}">00:00:00</b></span><span>Remaining <b data-remaining-from="${escapeText(occupied.started_at)}" data-maximum-seconds="${occupied.maximum_duration_seconds}">00:00:00</b></span></div></div>` : '<p>No controller logged on</p>'}
+          <div class="live-position-tile__participants">${position.participants.map((p) => `<small><span><strong>${escapeText(p.role_label)}</strong> ${escapeText(p.person_name)}</span><span class="live-position-controller-times"><span>Elapsed <b data-elapsed-from="${escapeText(p.started_at)}">00:00:00</b></span><span>Remaining <b data-remaining-from="${escapeText(p.started_at)}" data-maximum-seconds="${p.maximum_duration_seconds}">00:00:00</b></span></span><button data-operation="participant_remove" data-participant-id="${p.id}">Log off</button></small>`).join('')}</div>
           <footer>${buttons}</footer>
         </article>`;
       };
@@ -373,9 +373,19 @@
       const now = new Date(Date.now() + serverOffset);
       if (!Number.isFinite(now.getTime())) return;
       clock.textContent = now.toISOString().slice(11, 19);
-      document.querySelectorAll('[data-start]').forEach((node) => {
-        const seconds = Math.max(0, Math.floor((now - new Date(node.dataset.start)) / 1000));
-        node.textContent = `${String(Math.floor(seconds / 3600)).padStart(2, '0')}:${String(Math.floor((seconds % 3600) / 60)).padStart(2, '0')}`;
+      const formatDuration = (totalSeconds) => {
+        const seconds = Math.max(0, Math.floor(totalSeconds));
+        return `${String(Math.floor(seconds / 3600)).padStart(2, '0')}:${String(Math.floor((seconds % 3600) / 60)).padStart(2, '0')}:${String(seconds % 60).padStart(2, '0')}`;
+      };
+      document.querySelectorAll('[data-elapsed-from]').forEach((node) => {
+        const seconds = Math.max(0, Math.floor((now - new Date(node.dataset.elapsedFrom)) / 1000));
+        node.textContent = formatDuration(seconds);
+      });
+      document.querySelectorAll('[data-remaining-from]').forEach((node) => {
+        const elapsed = Math.max(0, Math.floor((now - new Date(node.dataset.remainingFrom)) / 1000));
+        const remaining = Number(node.dataset.maximumSeconds) - elapsed;
+        node.textContent = remaining >= 0 ? formatDuration(remaining) : `Over ${formatDuration(-remaining)}`;
+        node.classList.toggle('is-overdue', remaining < 0);
       });
     };
     updateClocks();

--- a/templates/live_position/position_configuration.html
+++ b/templates/live_position/position_configuration.html
@@ -31,6 +31,7 @@
     <label>Short code<input name="code" maxlength="30" placeholder="AIR" required></label>
     <label>Display name<input name="label" maxlength="120" placeholder="Aerodrome Control" required></label>
     <label>Display order<input name="display_order" type="number" min="0" value="100"></label>
+    <label>Maximum controller time (minutes)<input name="maximum_session_duration_minutes" type="number" min="1" max="1440" value="120" required></label>
     <label>Position group
       <select name="position_group_id"><option value="">No group</option>{% for group in groups if group.is_active %}<option value="{{ group.id }}">{{ group.name }}</option>{% endfor %}</select>
     </label>
@@ -61,6 +62,7 @@
       <label>Short code<input name="code" maxlength="30" value="{{ position.code }}" required></label>
       <label>Display name<input name="label" maxlength="120" value="{{ position.label }}" required></label>
       <label>Display order<input name="display_order" type="number" min="0" value="{{ position.display_order }}"></label>
+      <label>Maximum controller time (minutes)<input name="maximum_session_duration_minutes" type="number" min="1" max="1440" value="{{ position.maximum_session_duration_minutes }}" required></label>
       <label>Position group
         <select name="position_group_id"><option value="">No group</option>{% for group in groups if group.is_active %}<option value="{{ group.id }}" {% if group.name == position.group_name %}selected{% endif %}>{{ group.name }}</option>{% endfor %}</select>
       </label>

--- a/tests/test_legacy_migration_fixtures.py
+++ b/tests/test_legacy_migration_fixtures.py
@@ -119,7 +119,7 @@ def test_legacy_fixture_upgrades_to_head_without_data_loss(
         inspector = inspect(connection)
         assert connection.execute(
             text("SELECT version_num FROM alembic_version")
-        ).scalar_one() == "20260731_31"
+        ).scalar_one() == "20260731_32"
         for table, count in before.items():
             assert connection.execute(
                 text(f'SELECT COUNT(*) FROM "{table}"')

--- a/tests/test_live_position_monitoring.py
+++ b/tests/test_live_position_monitoring.py
@@ -210,6 +210,8 @@ def test_kiosk_password_login_bypasses_only_mfa_and_is_endpoint_limited(
     assert b"Log off all controllers" in kiosk_page.data
     assert b"data-logoff-choice" in kiosk_page.data
     assert b"position?.participants.length" in kiosk_page.data
+    assert b"data-elapsed-from" in kiosk_page.data
+    assert b"data-remaining-from" in kiosk_page.data
     state = client.get("/live-positions/api/state")
     assert state.status_code == 200
     assert state.get_json()["positions"][0]["display_status"] == "closed"
@@ -273,6 +275,8 @@ def test_kiosk_controller_selection_runs_full_live_position_workflow(
     state = client.get("/live-positions/api/state").get_json()["positions"][0]
     assert state["display_status"] == "training"
     assert state["physical_status"] == "open"
+    assert state["primary"]["maximum_duration_seconds"] == 7200
+    assert state["participants"][0]["maximum_duration_seconds"] == 7200
     assert state["primary"]["name"] == "Alex Controller"
     assert state["participants"][0]["role_label"] == "OJTI"
     assert "+00:00Z" not in state["primary"]["started_at"]
@@ -504,6 +508,7 @@ def test_admin_can_configure_currency_category_and_position(live_position_data):
             "code": "GMC",
             "label": "Ground Movement Control",
             "display_order": "10",
+            "maximum_session_duration_minutes": "90",
             "position_group_id": str(group_id),
             "currency_category_id": str(category_id),
             "supporting_participants_allowed": "on",
@@ -519,6 +524,7 @@ def test_admin_can_configure_currency_category_and_position(live_position_data):
         configured = app.OperationalPosition.query.filter_by(code="GMC").one()
         assert configured.label == "Ground Movement Control"
         assert configured.group_name == "Radar"
+        assert configured.maximum_session_duration_minutes == 90
         assert configured.currency_category_id == category_id
     page = client.get("/live-positions/admin/positions")
     assert b'<option value="%d" selected>Radar</option>' % group_id in page.data

--- a/tests/test_postgresql_multidatabase.py
+++ b/tests/test_postgresql_multidatabase.py
@@ -54,9 +54,9 @@ def test_postgresql_control_and_two_airport_databases_are_isolated(
     dispose_operational_engines()
     for url in (CONTROL_URL, AIRPORT_A_URL, AIRPORT_B_URL):
         _reset_postgres(url)
-    assert upgrade_database(CONTROL_URL, "control") == "20260731_31"
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260731_31"
-    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260731_31"
+    assert upgrade_database(CONTROL_URL, "control") == "20260731_32"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260731_32"
+    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260731_32"
     secret_a = "ATCROSTER_UNIT_1_DATABASE_URL"
     secret_b = "ATCROSTER_UNIT_2_DATABASE_URL"
     monkeypatch.setenv(secret_a, AIRPORT_A_URL)


### PR DESCRIPTION
## What changed

- Added a per-position Maximum controller time setting for unit administrators.
- Defaults existing and new positions to 120 minutes, with a supported range of 1 to 1440 minutes.
- Stores the allowance and due-off time on new primary sessions and handovers.
- Shows live elapsed and remaining HH:MM:SS timers for primary and secondary controllers.
- Starts each secondary countdown from that controller’s own logon time.
- Marks a timer overdue after the allowance expires.
- Added migration 20260731_32 for every operational database.

## Validation

- Full test suite: 230 passed, 2 skipped.
- Legacy migration fixtures and multi-database upgrade checks pass.
- Live workflow verifies primary and secondary duration values.
