### PR TITLE
Add secure kiosk keyboard logout

### DIFF
--- a/templates/kiosk_accounts.html
+++ b/templates/kiosk_accounts.html
@@ -6,6 +6,7 @@
     <p class="eyebrow">Administration · Live Position Monitoring</p>
     <h1>Kiosk accounts</h1>
     <p>Create dedicated accounts for Live Position displays. These accounts cannot access the roster or administration tools.</p>
+    <p>To securely leave a running kiosk, press <strong>Ctrl + Alt + K</strong>. The kiosk display deliberately has no visible account log-out button.</p>
   </div>
   <a class="btn btn-secondary" href="{{ url_for('administration_home') }}">Back to administration</a>
 </section>

--- a/templates/live_position/kiosk.html
+++ b/templates/live_position/kiosk.html
@@ -74,9 +74,8 @@
   </dialog>
   <footer class="live-position-kiosk__footer">
     <span id="live-position-refresh">Awaiting server data</span>
-    <form method="post" action="{{ url_for('logout') }}">
+    <form id="live-position-kiosk-logout" method="post" action="{{ url_for('logout') }}" hidden>
       <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
-      <button class="btn btn-secondary" type="submit">Log out</button>
     </form>
   </footer>
   <script nonce="{{ csp_nonce() }}">
@@ -95,6 +94,7 @@
     const kioskLaunch = document.getElementById('live-position-kiosk-launch');
     const kioskStart = document.getElementById('live-position-kiosk-start');
     const kioskLaunchError = document.getElementById('live-position-kiosk-launch-error');
+    const kioskLogout = document.getElementById('live-position-kiosk-logout');
     const csrf = {{ csrf_token()|tojson }};
     let people = [];
     let livePositions = new Map();
@@ -129,6 +129,11 @@
     document.addEventListener('fullscreenchange', updateKioskLaunch);
     document.addEventListener('webkitfullscreenchange', updateKioskLaunch);
     updateKioskLaunch();
+    document.addEventListener('keydown', (event) => {
+      if (event.repeat || event.key.toLowerCase() !== 'k' || !event.ctrlKey || !event.altKey || event.shiftKey || event.metaKey) return;
+      event.preventDefault();
+      kioskLogout.requestSubmit();
+    });
     let fitFrame = 0;
     const fitBoard = () => {
       cancelAnimationFrame(fitFrame);

--- a/tests/test_live_position_monitoring.py
+++ b/tests/test_live_position_monitoring.py
@@ -212,6 +212,9 @@ def test_kiosk_password_login_bypasses_only_mfa_and_is_endpoint_limited(
     assert b"position?.participants.length" in kiosk_page.data
     assert b"data-elapsed-from" in kiosk_page.data
     assert b"data-remaining-from" in kiosk_page.data
+    assert b'id="live-position-kiosk-logout"' in kiosk_page.data
+    assert b"kioskLogout.requestSubmit()" in kiosk_page.data
+    assert b"Log out</button>" not in kiosk_page.data
     state = client.get("/live-positions/api/state")
     assert state.status_code == 200
     assert state.get_json()["positions"][0]["display_status"] == "closed"


### PR DESCRIPTION
## What changed

- Remove the visible account log-out button from the live position kiosk.
- Add Ctrl + Alt + K as the dedicated keyboard shortcut for leaving a kiosk session.
- Document the shortcut for unit administrators on the Kiosk Accounts page.
- Correct malformed multi-exception handlers found while validating the current main branch.

## Impact

The operational display stays uncluttered and cannot be casually logged out with an on-screen button. Authorised staff can still leave the dedicated kiosk account using a memorable keyboard chord.

## Validation

- Python compile check
- Live position monitoring tests: 10 passed
- Full test suite: 230 passed, 2 skipped
