### PR TITLE
Remove kiosk group position counts

### DIFF
--- a/templates/live_position/kiosk.html
+++ b/templates/live_position/kiosk.html
@@ -190,7 +190,7 @@
       grid.innerHTML = [...grouped.entries()]
         .sort((a, b) => operationalGroupPriority(a[0]) - operationalGroupPriority(b[0]) || a[1].order - b[1].order || a[0].localeCompare(b[0]))
         .map(([name, group]) => `<section class="live-position-group">
-          <header class="live-position-group__header"><h2>${escapeText(name)}</h2><span>${group.positions.length} position${group.positions.length === 1 ? '' : 's'}</span></header>
+          <header class="live-position-group__header"><h2>${escapeText(name)}</h2></header>
           <div class="live-position-grid">${group.positions.map(renderPosition).join('')}</div>
         </section>`).join('') || '<p class="empty-state">No active operational positions are configured.</p>';
       connection.innerHTML = '<span aria-hidden="true">●</span> Connected';

--- a/tests/test_live_position_monitoring.py
+++ b/tests/test_live_position_monitoring.py
@@ -212,6 +212,7 @@ def test_kiosk_password_login_bypasses_only_mfa_and_is_endpoint_limited(
     assert b"position?.participants.length" in kiosk_page.data
     assert b"data-elapsed-from" in kiosk_page.data
     assert b"data-remaining-from" in kiosk_page.data
+    assert b"group.positions.length} position" not in kiosk_page.data
     assert b'id="live-position-kiosk-logout"' in kiosk_page.data
     assert b"kioskLogout.requestSubmit()" in kiosk_page.data
     assert b"Log out</button>" not in kiosk_page.data


### PR DESCRIPTION
## What changed

- Remove the position-count bubble from each live monitor group heading.
- Keep the Tower, Radar, and other group names unchanged.
- Add a regression assertion that the count label is absent.

## Impact

The kiosk group headings are cleaner and no longer show labels such as “3 positions”.

## Validation

- Diff and template regression assertion checked locally
- Full production-matched test suite will run in GitHub Actions
