### PR TITLE
Add operational activity reports

### DIFF
--- a/app.py
+++ b/app.py
@@ -9686,8 +9686,10 @@ app.register_blueprint(create_live_position_blueprint(LivePositionDependencies(
     PositionParticipantRole=PositionParticipantRole,
     PositionSessionAudit=PositionSessionAudit,
     PositionEndorsement=PositionEndorsement, Staff=Staff,
+    Watch=Watch,
     utcnow=utcnow, is_admin_user=is_admin_user,
     live_position_enabled=live_position_enabled,
+    competency_enabled=competency_enabled,
 )))
 
 app.register_blueprint(create_auth_blueprint(AuthDependencies(

--- a/live_position_blueprint.py
+++ b/live_position_blueprint.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import time
 from dataclasses import dataclass
+from datetime import date, datetime, time as datetime_time, timedelta
 from typing import Any, Callable
 
 from flask import (
@@ -43,9 +44,36 @@ class LivePositionDependencies:
     PositionSessionAudit: Any
     PositionEndorsement: Any
     Staff: Any
+    Watch: Any
     utcnow: Callable[[], Any]
     is_admin_user: Callable[[Any], bool]
     live_position_enabled: Callable[[int], bool]
+    competency_enabled: Callable[[int], bool]
+
+
+def _minutes_between(start: datetime, end: datetime) -> int:
+    return max(0, round((end - start).total_seconds() / 60))
+
+
+def _overlap_minutes(
+    start: datetime, end: datetime, intervals: list[tuple[datetime, datetime]]
+) -> int:
+    clipped = sorted(
+        (max(start, item_start), min(end, item_end))
+        for item_start, item_end in intervals
+        if item_start < end and item_end > start
+    )
+    if not clipped:
+        return 0
+    merged: list[list[datetime]] = []
+    for item_start, item_end in clipped:
+        if not merged or item_start > merged[-1][1]:
+            merged.append([item_start, item_end])
+        else:
+            merged[-1][1] = max(merged[-1][1], item_end)
+    return sum(
+        _minutes_between(item_start, item_end) for item_start, item_end in merged
+    )
 
 
 def create_live_position_blueprint(
@@ -217,6 +245,291 @@ def create_live_position_blueprint(
             abort(403)
         return redirect(url_for("administration_home"))
 
+    @blueprint.get("/reports/operational-activity")
+    @login_required
+    def operational_activity():
+        _require_module()
+        if getattr(current_user, "role", "") == "position_monitor":
+            abort(403)
+        unit_id = _unit_id()
+        today = dependencies.utcnow().date()
+        try:
+            start_day = date.fromisoformat(
+                request.args.get("start") or (today - timedelta(days=29)).isoformat()
+            )
+            end_day = date.fromisoformat(request.args.get("end") or today.isoformat())
+        except ValueError:
+            abort(400, "Enter valid report dates.")
+        if end_day < start_day or (end_day - start_day).days > 731:
+            abort(400, "Choose a date range of no more than two years.")
+
+        can_view_all = bool(
+            dependencies.is_admin_user(current_user)
+            or getattr(current_user, "role", "") == "editor"
+            or getattr(current_user, "is_wm", False)
+            or getattr(current_user, "is_dwm", False)
+            or getattr(current_user, "has_ojti", False)
+            or getattr(current_user, "has_assessor", False)
+        )
+        people = (
+            dependencies.Staff.query.filter_by(
+                unit_id=unit_id, membership_status="active", is_operational=True
+            )
+            .order_by(dependencies.Staff.name)
+            .all()
+        )
+        watches = (
+            dependencies.Watch.query.filter_by(unit_id=unit_id)
+            .order_by(dependencies.Watch.order_index, dependencies.Watch.name)
+            .all()
+        )
+        positions = (
+            dependencies.OperationalPosition.query.filter_by(unit_id=unit_id)
+            .order_by(
+                dependencies.OperationalPosition.group_name,
+                dependencies.OperationalPosition.display_order,
+                dependencies.OperationalPosition.code,
+            )
+            .all()
+        )
+        people_by_id = {person.id: person for person in people}
+        positions_by_id = {position.id: position for position in positions}
+        roles = {
+            role.id: role
+            for role in dependencies.PositionParticipantRole.query.filter_by(
+                unit_id=unit_id
+            ).all()
+        }
+        selected_person_id = request.args.get("person_id", type=int)
+        selected_watch_id = request.args.get("watch_id", type=int)
+        selected_position_id = request.args.get("position_id", type=int)
+        report_type = request.args.get("report_type") or "individual"
+        if report_type not in {"individual", "position", "instruction"}:
+            abort(400, "Unknown operational report type.")
+        if not can_view_all:
+            selected_person_id = current_user.id
+            selected_watch_id = None
+        if selected_person_id and selected_person_id not in people_by_id:
+            abort(404)
+        if selected_watch_id and selected_watch_id not in {row.id for row in watches}:
+            abort(404)
+        if selected_position_id and selected_position_id not in positions_by_id:
+            abort(404)
+
+        range_start = datetime.combine(start_day, datetime_time.min)
+        range_end = datetime.combine(end_day + timedelta(days=1), datetime_time.min)
+        now = dependencies.utcnow()
+        sessions = dependencies.PositionSession.query.filter(
+            dependencies.PositionSession.unit_id == unit_id,
+            dependencies.PositionSession.is_void.is_(False),
+            dependencies.PositionSession.started_at < range_end,
+            dependencies.db.or_(
+                dependencies.PositionSession.ended_at.is_(None),
+                dependencies.PositionSession.ended_at > range_start,
+            ),
+        ).all()
+        session_ids = [row.id for row in sessions]
+        participant_rows = (
+            dependencies.PositionSessionParticipant.query.filter(
+                dependencies.PositionSessionParticipant.unit_id == unit_id,
+                dependencies.PositionSessionParticipant.session_id.in_(session_ids),
+            ).all()
+            if session_ids
+            else []
+        )
+        participants_by_session: dict[int, list[Any]] = {}
+        for participant in participant_rows:
+            participants_by_session.setdefault(participant.session_id, []).append(
+                participant
+            )
+
+        activity: list[dict[str, Any]] = []
+        role_labels = {
+            "solo": "Solo",
+            "under_training": "Under instruction",
+            "under_assessment": "Under assessment",
+            "ojti": "OJTI",
+            "assessor": "Assessor",
+        }
+
+        def add_activity(
+            person_id: int,
+            position: Any,
+            day: date,
+            role_code: str,
+            minutes: int,
+            session_id: int,
+        ) -> None:
+            person = people_by_id.get(person_id)
+            if not person or minutes <= 0:
+                return
+            if selected_person_id and person.id != selected_person_id:
+                return
+            if selected_watch_id and person.watch_id != selected_watch_id:
+                return
+            if selected_position_id and position.id != selected_position_id:
+                return
+            activity.append(
+                {
+                    "day": day,
+                    "person": person,
+                    "watch": person.watch,
+                    "position": position,
+                    "role": role_code,
+                    "role_label": role_labels.get(role_code, role_code.title()),
+                    "minutes": minutes,
+                    "session_id": session_id,
+                }
+            )
+
+        for session_row in sessions:
+            position = positions_by_id.get(session_row.position_id)
+            if not position:
+                continue
+            session_start = max(session_row.started_at, range_start)
+            session_end = min(session_row.ended_at or now, range_end)
+            if session_end <= session_start:
+                continue
+            participants = participants_by_session.get(session_row.id, [])
+            cursor_day = session_start.date()
+            while cursor_day <= session_end.date():
+                day_start = max(
+                    session_start, datetime.combine(cursor_day, datetime_time.min)
+                )
+                day_end = min(
+                    session_end,
+                    datetime.combine(cursor_day + timedelta(days=1), datetime_time.min),
+                )
+                if day_end > day_start:
+                    all_intervals: list[tuple[datetime, datetime]] = []
+                    role_intervals: dict[str, list[tuple[datetime, datetime]]] = {
+                        "ojti": [],
+                        "assessor": [],
+                    }
+                    for participant in participants:
+                        participant_end = participant.ended_at or now
+                        if (
+                            participant.started_at < day_end
+                            and participant_end > day_start
+                        ):
+                            interval = (participant.started_at, participant_end)
+                            all_intervals.append(interval)
+                            role = roles.get(participant.role_id)
+                            role_code = (
+                                "assessor"
+                                if role and role.code in {"assessor", "examiner"}
+                                else "ojti"
+                            )
+                            role_intervals[role_code].append(interval)
+                            add_activity(
+                                participant.person_id,
+                                position,
+                                cursor_day,
+                                role_code,
+                                _overlap_minutes(day_start, day_end, [interval]),
+                                session_row.id,
+                            )
+                    total_minutes = _minutes_between(day_start, day_end)
+                    supported_minutes = _overlap_minutes(
+                        day_start, day_end, all_intervals
+                    )
+                    add_activity(
+                        session_row.primary_person_id,
+                        position,
+                        cursor_day,
+                        "solo",
+                        max(0, total_minutes - supported_minutes),
+                        session_row.id,
+                    )
+                    for support_role, primary_role in (
+                        ("ojti", "under_training"),
+                        ("assessor", "under_assessment"),
+                    ):
+                        add_activity(
+                            session_row.primary_person_id,
+                            position,
+                            cursor_day,
+                            primary_role,
+                            _overlap_minutes(
+                                day_start, day_end, role_intervals[support_role]
+                            ),
+                            session_row.id,
+                        )
+                cursor_day += timedelta(days=1)
+
+        activity.sort(
+            key=lambda row: (
+                row["day"],
+                row["person"].name,
+                row["position"].code,
+                row["role"],
+            )
+        )
+        person_summary: dict[int, dict[str, Any]] = {}
+        position_summary: dict[int, dict[str, Any]] = {}
+        instruction_summary: dict[int, dict[str, Any]] = {}
+        for row in activity:
+            person_total = person_summary.setdefault(
+                row["person"].id,
+                {"person": row["person"], "roles": {}, "total": 0},
+            )
+            person_total["roles"][row["role"]] = (
+                person_total["roles"].get(row["role"], 0) + row["minutes"]
+            )
+            person_total["total"] += row["minutes"]
+            position_total = position_summary.setdefault(
+                row["position"].id,
+                {"position": row["position"], "roles": {}, "total": 0, "people": set()},
+            )
+            position_total["roles"][row["role"]] = (
+                position_total["roles"].get(row["role"], 0) + row["minutes"]
+            )
+            if row["role"] in {"solo", "under_training", "under_assessment"}:
+                position_total["total"] += row["minutes"]
+                position_total["people"].add(row["person"].id)
+            if row["role"] in {"ojti", "assessor"}:
+                instruction_total = instruction_summary.setdefault(
+                    row["person"].id,
+                    {
+                        "person": row["person"],
+                        "ojti": 0,
+                        "assessor": 0,
+                        "sessions": set(),
+                    },
+                )
+                instruction_total[row["role"]] += row["minutes"]
+                instruction_total["sessions"].add(row["session_id"])
+
+        return render_template(
+            "live_position/operational_activity_report.html",
+            start_day=start_day,
+            end_day=end_day,
+            report_type=report_type,
+            activity=activity,
+            person_summary=sorted(
+                person_summary.values(), key=lambda row: row["person"].name
+            ),
+            position_summary=sorted(
+                position_summary.values(),
+                key=lambda row: (
+                    row["position"].group_name,
+                    row["position"].display_order,
+                    row["position"].code,
+                ),
+            ),
+            instruction_summary=sorted(
+                instruction_summary.values(), key=lambda row: row["person"].name
+            ),
+            people=people,
+            watches=watches,
+            positions=positions,
+            selected_person_id=selected_person_id,
+            selected_watch_id=selected_watch_id,
+            selected_position_id=selected_position_id,
+            can_view_all=can_view_all,
+            competency_location=dependencies.competency_enabled(unit_id),
+        )
+
     @blueprint.route("/admin/positions", methods=["GET", "POST"])
     @login_required
     def position_configuration():
@@ -233,7 +546,8 @@ def create_live_position_blueprint(
                     dependencies.OperationalPositionGroup.unit_id == unit_id,
                     dependencies.db.func.lower(
                         dependencies.OperationalPositionGroup.name
-                    ) == name.lower(),
+                    )
+                    == name.lower(),
                 ).first()
                 if not name:
                     flash("Enter a group name.", "error")
@@ -345,9 +659,7 @@ def create_live_position_blueprint(
                         1,
                         min(
                             1440,
-                            _int_field(
-                                data, "maximum_session_duration_minutes", 120
-                            ),
+                            _int_field(data, "maximum_session_duration_minutes", 120),
                         ),
                     )
                     position.group_name = group.name if group else ""

--- a/static/styles.css
+++ b/static/styles.css
@@ -98,6 +98,20 @@
 .live-position-dialog h2, .live-position-dialog p { margin: 0; }
 .live-position-logoff-options { display: grid; gap: .75rem; margin-top: 1rem; }
 .live-position-logoff-options .btn { width: 100%; min-height: 50px; }
+.operational-report-filters { display:grid; grid-template-columns:repeat(auto-fit,minmax(160px,1fr)); gap:1rem; align-items:end; margin-bottom:1rem; }
+.operational-report-filters label { display:grid; gap:.35rem; }
+.operational-report-filters .btn { min-height:44px; }
+.operational-report-section { margin-top:1rem; overflow:hidden; }
+.operational-report-table { min-width:900px; margin-bottom:0; }
+.operational-report-table th, .operational-report-table td { white-space:nowrap; vertical-align:middle; }
+.operational-report-table tfoot th { white-space:normal; color:var(--text-muted); }
+.operational-report-notes { margin-top:1rem; }
+.operational-report-notes h2 { font-size:1rem; }
+@media print {
+  .operational-report-filters, .operational-report-header .btn, .report-output-actions, .operational-report-notes { display:none !important; }
+  .operational-report-section { break-inside:avoid; border:0; }
+  .operational-report-table { min-width:0; font-size:9pt; }
+}
 .live-position-dialog label { display: grid; gap: .35rem; font-weight: 700; }
 .live-position-dialog input, .live-position-dialog select { min-height: 48px; border: 1px solid #64748b; border-radius: 8px; padding: .65rem; background: #f8fafc; color: #0f172a; font-size: 1rem; }
 .live-position-dialog__error { padding: .75rem; border: 2px solid #f87171; border-radius: 8px; background: #450a0a; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,7 +9,7 @@
   <meta name="theme-color" content="#11161d">
   {% set in_briefing_module = request.endpoint and request.endpoint.startswith('briefing.') %}
   {% set in_training_module = request.endpoint and request.endpoint.startswith('training_') %}
-  {% set in_competency_module = request.endpoint and request.endpoint.startswith('competency_') %}
+  {% set in_competency_module = request.endpoint and (request.endpoint.startswith('competency_') or (request.endpoint == 'live_position.operational_activity' and has_competency_module)) %}
   {% set in_shared_admin = request.endpoint in (
     'administration_home', 'unit_accounts', 'kiosk_accounts',
     'live_position.position_configuration'
@@ -17,6 +17,7 @@
   {% set report_endpoints = (
     'report_leave', 'report_leave_year', 'report_sickness', 'report_fatigue',
     'metrics', 'coverage_heatmap', 'operations_assurance', 'training_analytics',
+    'live_position.operational_activity',
     'admin_sms_audit', 'briefing.audit', 'briefing.assurance'
   ) %}
   <title>{% block title %}{% endblock %} – {{ 'ATC Administration' if in_shared_admin else ('ATC Competency' if in_competency_module else ('ATC Training' if in_training_module else ('ATC Briefing' if in_briefing_module else 'ATC Roster'))) }}</title>
@@ -134,6 +135,9 @@
             {% if is_admin or is_editor %}
               <a href="{{ url_for('leave') }}" class="nav-link roster-nav__admin-start {% if request.endpoint == 'leave' %}active{% endif %}"><i class="fa-solid fa-user-clock" aria-hidden="true"></i> Leave / Sickness</a>
               <a href="{{ url_for('reports_index') }}" class="nav-link {% if request.endpoint in ('reports_index','report_leave','report_fatigue','report_leave_year','report_leave_month','report_sickness') %}active{% endif %}"><i class="fa-solid fa-chart-line" aria-hidden="true"></i> Reports</a>
+            {% endif %}
+            {% if has_live_position_module and not has_competency_module %}
+              <a href="{{ url_for('live_position.operational_activity') }}" class="nav-link {% if request.endpoint == 'live_position.operational_activity' %}active{% endif %}"><i class="fa-solid fa-headset" aria-hidden="true"></i> Operational activity</a>
             {% endif %}
             {% if is_admin %}
               <a href="{{ url_for('admin') }}" class="nav-link {% if request.endpoint == 'admin' %}active{% endif %}"><i class="fa-solid fa-sliders" aria-hidden="true"></i> Roster setup</a>

--- a/templates/competency/_nav_links.html
+++ b/templates/competency/_nav_links.html
@@ -9,3 +9,8 @@
   <i class="fa-solid fa-users" aria-hidden="true"></i> People
 </a>
 {% endif %}
+{% if has_live_position_module %}
+<a href="{{ url_for('live_position.operational_activity') }}" class="nav-link {% if request.endpoint == 'live_position.operational_activity' %}active{% endif %}">
+  <i class="fa-solid fa-headset" aria-hidden="true"></i> Operational activity
+</a>
+{% endif %}

--- a/templates/competency_home.html
+++ b/templates/competency_home.html
@@ -5,6 +5,9 @@
   <div><span class="admin-step">Competency</span><h2>Licences, endorsements and ongoing validity</h2><p>CAA licence details, medical validity, English language and every unit endorsement in one shared record.</p></div>
   <a class="btn btn-primary" href="{{ url_for('competency_profile', sid=current_user.id) }}">Open my competency profile</a>
 </section>
+{% if has_live_position_module %}
+<section class="training-module-summary"><article class="card"><span>Live position records</span><strong>Operational activity reports</strong><p>Review solo, OJTI, assessment and position activity by date, person or watch.</p><a href="{{ url_for('live_position.operational_activity') }}">Open reports</a></article></section>
+{% endif %}
 {% if can_view_people %}
 <section class="card training-people" id="people"><div class="card-hd">Staff competency profiles</div><div class="card-bd training-people-grid">
 {% for person in people %}<a href="{{ url_for('competency_profile', sid=person.id) }}"><span class="training-person-avatar" aria-hidden="true">{{ person.name[:1] }}</span><span><strong>{{ person.name }}</strong><small>{{ person.staff_no }}{% if person.watch %} · {{ person.watch.name }}{% endif %}</small></span><span class="status-pill">Competency</span><i class="fa-solid fa-chevron-right" aria-hidden="true"></i></a>{% else %}<p class="empty-state">No staff profiles are available.</p>{% endfor %}

--- a/templates/live_position/operational_activity_report.html
+++ b/templates/live_position/operational_activity_report.html
@@ -1,0 +1,93 @@
+{% extends "base.html" %}
+{% block title %}Operational activity{% endblock %}
+{% macro duration(minutes) -%}{{ '%02d:%02d'|format((minutes or 0) // 60, (minutes or 0) % 60) }}{%- endmacro %}
+{% macro percentage(value, total) -%}{{ '%.1f'|format((100 * (value or 0) / total) if total else 0) }}%{%- endmacro %}
+{% block content %}
+<section class="page-header operational-report-header">
+  <div>
+    <p class="eyebrow">{{ 'Competency' if competency_location else 'Roster' }} · Live Position Monitoring</p>
+    <h1>Operational activity</h1>
+    <p>Auditable operational time recorded by the live position monitor. Durations are shown as hours and minutes.</p>
+  </div>
+  <a class="btn btn-secondary" href="{{ url_for('competency_home') if competency_location else url_for('index') }}">Back to {{ 'competency' if competency_location else 'roster' }}</a>
+</section>
+
+<form class="card card-body operational-report-filters" method="get">
+  <label>Report
+    <select name="report_type">
+      <option value="individual" {% if report_type == 'individual' %}selected{% endif %}>Individual activity</option>
+      <option value="position" {% if report_type == 'position' %}selected{% endif %}>Position utilisation</option>
+      <option value="instruction" {% if report_type == 'instruction' %}selected{% endif %}>OJTI and assessor contribution</option>
+    </select>
+  </label>
+  <label>From <input type="date" name="start" value="{{ start_day.isoformat() }}" required></label>
+  <label>To <input type="date" name="end" value="{{ end_day.isoformat() }}" required></label>
+  {% if can_view_all %}
+  <label>Controller
+    <select name="person_id">
+      <option value="">All controllers</option>
+      {% for person in people %}<option value="{{ person.id }}" {% if selected_person_id == person.id %}selected{% endif %}>{{ person.name }}</option>{% endfor %}
+    </select>
+  </label>
+  <label>Watch
+    <select name="watch_id">
+      <option value="">All watches</option>
+      {% for watch in watches %}<option value="{{ watch.id }}" {% if selected_watch_id == watch.id %}selected{% endif %}>{{ watch.name }}</option>{% endfor %}
+    </select>
+  </label>
+  {% endif %}
+  <label>Position
+    <select name="position_id">
+      <option value="">All positions</option>
+      {% for position in positions %}<option value="{{ position.id }}" {% if selected_position_id == position.id %}selected{% endif %}>{{ position.group_name }} · {{ position.code }} — {{ position.label }}</option>{% endfor %}
+    </select>
+  </label>
+  <button class="btn btn-primary" type="submit">Run report</button>
+</form>
+
+{% include "_report_actions.html" %}
+
+{% if report_type == 'individual' %}
+<section class="card operational-report-section">
+  <div class="card-hd">Individual activity summary · {{ start_day.strftime('%d %b %Y') }} to {{ end_day.strftime('%d %b %Y') }}</div>
+  <div class="table-responsive"><table class="table operational-report-table">
+    <thead><tr><th>Controller</th><th>Watch</th><th>Solo</th><th>Under instruction</th><th>OJTI</th><th>Under assessment</th><th>Assessor</th><th>Total</th><th>Solo score</th><th>OJTI score</th></tr></thead>
+    <tbody>
+    {% for row in person_summary %}
+      <tr><th>{{ row.person.name }}</th><td>{{ row.person.watch.name if row.person.watch else '—' }}</td><td>{{ duration(row.roles.get('solo', 0)) }}</td><td>{{ duration(row.roles.get('under_training', 0)) }}</td><td>{{ duration(row.roles.get('ojti', 0)) }}</td><td>{{ duration(row.roles.get('under_assessment', 0)) }}</td><td>{{ duration(row.roles.get('assessor', 0)) }}</td><td><strong>{{ duration(row.total) }}</strong></td><td>{{ percentage(row.roles.get('solo', 0), row.total) }}</td><td>{{ percentage(row.roles.get('ojti', 0), row.total) }}</td></tr>
+    {% else %}<tr><td colspan="10" class="empty-state">No operational activity matches these filters.</td></tr>{% endfor %}
+    </tbody>
+    {% if person_summary %}<tfoot><tr><th colspan="8">Percentage scores show each role as a share of that controller’s total recorded activity in this report.</th><th>Solo %</th><th>OJTI %</th></tr></tfoot>{% endif %}
+  </table></div>
+</section>
+
+<section class="card operational-report-section">
+  <div class="card-hd">Daily activity detail</div>
+  <div class="table-responsive"><table class="table operational-report-table">
+    <thead><tr><th>Date</th><th>Controller</th><th>Watch</th><th>Group</th><th>Position</th><th>Activity</th><th>Duration</th></tr></thead>
+    <tbody>{% for row in activity %}<tr><td>{{ row.day.strftime('%d %b %Y') }}</td><td>{{ row.person.name }}</td><td>{{ row.watch.name if row.watch else '—' }}</td><td>{{ row.position.group_name or 'Other' }}</td><td>{{ row.position.code }} · {{ row.position.label }}</td><td>{{ row.role_label }}</td><td>{{ duration(row.minutes) }}</td></tr>{% else %}<tr><td colspan="7" class="empty-state">No daily activity matches these filters.</td></tr>{% endfor %}</tbody>
+  </table></div>
+</section>
+{% elif report_type == 'position' %}
+<section class="card operational-report-section">
+  <div class="card-hd">Position utilisation · {{ start_day.strftime('%d %b %Y') }} to {{ end_day.strftime('%d %b %Y') }}</div>
+  <div class="table-responsive"><table class="table operational-report-table">
+    <thead><tr><th>Group</th><th>Position</th><th>Occupied</th><th>Solo</th><th>Training</th><th>Assessment</th><th>OJTI contribution</th><th>Assessor contribution</th><th>Controllers</th><th>Solo utilisation</th></tr></thead>
+    <tbody>{% for row in position_summary %}<tr><td>{{ row.position.group_name or 'Other' }}</td><th>{{ row.position.code }} · {{ row.position.label }}</th><td>{{ duration(row.total) }}</td><td>{{ duration(row.roles.get('solo', 0)) }}</td><td>{{ duration(row.roles.get('under_training', 0)) }}</td><td>{{ duration(row.roles.get('under_assessment', 0)) }}</td><td>{{ duration(row.roles.get('ojti', 0)) }}</td><td>{{ duration(row.roles.get('assessor', 0)) }}</td><td>{{ row.people|length }}</td><td>{{ percentage(row.roles.get('solo', 0), row.total) }}</td></tr>{% else %}<tr><td colspan="10" class="empty-state">No position activity matches these filters.</td></tr>{% endfor %}</tbody>
+  </table></div>
+</section>
+{% else %}
+<section class="card operational-report-section">
+  <div class="card-hd">OJTI and assessor contribution · {{ start_day.strftime('%d %b %Y') }} to {{ end_day.strftime('%d %b %Y') }}</div>
+  <div class="table-responsive"><table class="table operational-report-table">
+    <thead><tr><th>Instructor / assessor</th><th>Watch</th><th>OJTI time</th><th>Assessor time</th><th>Total contribution</th><th>Recorded sessions</th><th>OJTI share</th></tr></thead>
+    <tbody>{% for row in instruction_summary %}{% set total = row.ojti + row.assessor %}<tr><th>{{ row.person.name }}</th><td>{{ row.person.watch.name if row.person.watch else '—' }}</td><td>{{ duration(row.ojti) }}</td><td>{{ duration(row.assessor) }}</td><td>{{ duration(total) }}</td><td>{{ row.sessions|length }}</td><td>{{ percentage(row.ojti, total) }}</td></tr>{% else %}<tr><td colspan="7" class="empty-state">No OJTI or assessor activity matches these filters.</td></tr>{% endfor %}</tbody>
+  </table></div>
+</section>
+{% endif %}
+
+<section class="card card-body operational-report-notes">
+  <h2>How the figures are calculated</h2>
+  <p><strong>Solo</strong> is primary-controller time with no OJTI or assessor logged on. <strong>Under instruction</strong> and <strong>under assessment</strong> are primary-controller time while that supporting role is present. <strong>OJTI</strong> and <strong>Assessor</strong> are the supporting controller’s own logged-on time. Active sessions are included up to the time the report is run.</p>
+</section>
+{% endblock %}

--- a/templates/reports_index.html
+++ b/templates/reports_index.html
@@ -42,6 +42,13 @@
       <span>Every annotation available for this airport</span>
     </a>
 
+    {% if has_live_position_module and not has_competency_module %}
+    <a class="btn report-menu-item" href="{{ url_for('live_position.operational_activity') }}">
+      <strong>Operational Activity</strong>
+      <span>Solo, OJTI, assessment and position utilisation</span>
+    </a>
+    {% endif %}
+
   </div>
 </section>
 

--- a/tests/test_live_position_monitoring.py
+++ b/tests/test_live_position_monitoring.py
@@ -299,9 +299,9 @@ def test_kiosk_controller_selection_runs_full_live_position_workflow(
         },
     )
     assert removed.status_code == 200
-    primary_only_state = client.get(
-        "/live-positions/api/state"
-    ).get_json()["positions"][0]
+    primary_only_state = client.get("/live-positions/api/state").get_json()[
+        "positions"
+    ][0]
     assert primary_only_state["primary"]["name"] == "Alex Controller"
     assert primary_only_state["participants"] == []
     assert primary_only_state["display_status"] == "operational"
@@ -453,6 +453,68 @@ def test_secondary_role_requires_the_matching_qualification(live_position_data):
     )
     assert rejected.status_code == 422
     assert "OJTI" in rejected.get_json()["error"]
+
+
+def test_operational_activity_reports_split_solo_and_ojti_time(live_position_data):
+    with app.app.app_context():
+        session_row = app.PositionSession(
+            unit_id=1,
+            position_id=live_position_data["position_id"],
+            primary_person_id=live_position_data["controller_id"],
+            session_type="training",
+            started_at=datetime(2026, 7, 30, 8, 0),
+            ended_at=datetime(2026, 7, 30, 10, 0),
+            created_by_id=live_position_data["kiosk_id"],
+            transaction_key="activity-report-session",
+        )
+        app.db.session.add(session_row)
+        app.db.session.flush()
+        app.db.session.add(
+            app.PositionSessionParticipant(
+                unit_id=1,
+                session_id=session_row.id,
+                person_id=live_position_data["supporter_id"],
+                role_id=live_position_data["role_id"],
+                started_at=datetime(2026, 7, 30, 9, 0),
+                ended_at=datetime(2026, 7, 30, 9, 30),
+                transaction_key="activity-report-participant",
+            )
+        )
+        app.db.session.commit()
+
+    client = app.app.test_client()
+    client.get("/login")
+    with client.session_transaction() as browser_session:
+        csrf = browser_session["_csrf_token"]
+    client.post(
+        "/login",
+        data={
+            "_csrf_token": csrf,
+            "username": "live-admin",
+            "password": "admin-password",
+        },
+    )
+    finish_operational_login(client)
+    query = "start=2026-07-30&end=2026-07-30"
+    individual = client.get(f"/live-positions/reports/operational-activity?{query}")
+    assert individual.status_code == 200
+    assert b"Individual activity summary" in individual.data
+    assert b"Alex Controller" in individual.data
+    assert b"01:30" in individual.data
+    assert b"Sam Instructor" in individual.data
+    assert b"00:30" in individual.data
+    assert b"75.0%" in individual.data
+    position = client.get(
+        f"/live-positions/reports/operational-activity?{query}&report_type=position"
+    )
+    assert position.status_code == 200
+    assert b"Position utilisation" in position.data
+    instruction = client.get(
+        f"/live-positions/reports/operational-activity?{query}&report_type=instruction"
+    )
+    assert instruction.status_code == 200
+    assert b"OJTI and assessor contribution" in instruction.data
+    assert b"100.0%" in instruction.data
 
 
 def test_admin_can_configure_currency_category_and_position(live_position_data):


### PR DESCRIPTION
## What changed

- Add individual operational activity reporting with selectable date range, controller, watch and position.
- Split recorded activity into solo, under instruction, OJTI, under assessment and assessor time with percentage shares.
- Add position-utilisation and OJTI/assessor-contribution reports.
- Place the reports in Competency when enabled, otherwise in the Roster reporting area.
- Reuse the established Print and Save as PDF controls.
- Restrict ordinary controllers to their own activity while allowing authorised operational supervisors and training roles to run wider reports.

## Calculation rules

- Solo is primary-controller time with no supporting participant logged on.
- Under instruction/assessment is primary time overlapping the corresponding supporting participant.
- OJTI/assessor contribution is the supporting controller’s own elapsed time.
- Sessions spanning midnight are split by day; active sessions are included up to report runtime.

## Validation

- Ruff formatting and static analysis passed.
- All changed Jinja templates parse successfully.
- Production Python 3.14 container builds successfully.
- Added workflow coverage for a two-hour session containing 30 minutes of OJTI support.
- Full production-matched tests will run in GitHub Actions.
