### PR TITLE
Make vacant position close single click

### DIFF
--- a/templates/live_position/kiosk.html
+++ b/templates/live_position/kiosk.html
@@ -268,6 +268,25 @@
       const button = event.target.closest('[data-operation]');
       if (!button) return;
       const operation = button.dataset.operation;
+      if (operation === 'close') {
+        const tile = button.closest('[data-position-id]');
+        button.disabled = true;
+        try {
+          const response = await fetch(`/live-positions/api/positions/${tile.dataset.positionId}/close`, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json', 'X-CSRF-Token': csrf},
+            body: JSON.stringify({request_key: crypto.randomUUID()}),
+          });
+          const result = await response.json().catch(() => ({}));
+          if (!response.ok) throw new Error(result.error || 'The position could not be closed.');
+          await refresh();
+        } catch (failure) {
+          warning.textContent = failure.message;
+          warning.hidden = false;
+          button.disabled = false;
+        }
+        return;
+      }
       if (operation === 'logoff' || operation === 'logoff_close') {
         const tile = button.closest('[data-position-id]');
         const position = livePositions.get(Number(tile.dataset.positionId));

--- a/tests/test_live_position_monitoring.py
+++ b/tests/test_live_position_monitoring.py
@@ -206,6 +206,8 @@ def test_kiosk_password_login_bypasses_only_mfa_and_is_endpoint_limited(
     assert b'data-primary-id="${occupied ? occupied.id' in kiosk_page.data
     assert b"primarySelect.disabled = operation === 'participant'" in kiosk_page.data
     assert b"operation === 'logoff' || operation === 'logoff_close'" in kiosk_page.data
+    assert b"if (operation === 'close')" in kiosk_page.data
+    assert b"The position could not be closed." in kiosk_page.data
     assert b"close_position: operation === 'logoff_close'" in kiosk_page.data
     assert b"Log off all controllers" in kiosk_page.data
     assert b"data-logoff-choice" in kiosk_page.data


### PR DESCRIPTION
## What changed

- Make Close on an open, vacant live position execute immediately.
- Remove the action-dialog path for vacant position closure.
- Preserve the existing occupied-position log-off and log-off-and-close workflows.
- Add a regression assertion for the direct close handler.

## Impact

Operators can close an open position with nobody logged on using one click, without selecting a controller or confirming a form.

## Validation

- Static analysis and formatting passed.
- Full production-matched tests will run in GitHub Actions.
