### PR TITLE
Add report totals and position breakdowns

### DIFF
--- a/live_position_blueprint.py
+++ b/live_position_blueprint.py
@@ -468,7 +468,25 @@ def create_live_position_blueprint(
         person_summary: dict[int, dict[str, Any]] = {}
         position_summary: dict[int, dict[str, Any]] = {}
         instruction_summary: dict[int, dict[str, Any]] = {}
+        report_totals: dict[str, Any] = {
+            "roles": {},
+            "controller_activity": 0,
+            "occupied": 0,
+            "instruction": 0,
+            "people": set(),
+            "sessions": set(),
+        }
         for row in activity:
+            report_totals["roles"][row["role"]] = (
+                report_totals["roles"].get(row["role"], 0) + row["minutes"]
+            )
+            report_totals["controller_activity"] += row["minutes"]
+            report_totals["people"].add(row["person"].id)
+            report_totals["sessions"].add(row["session_id"])
+            if row["role"] in {"solo", "under_training", "under_assessment"}:
+                report_totals["occupied"] += row["minutes"]
+            if row["role"] in {"ojti", "assessor"}:
+                report_totals["instruction"] += row["minutes"]
             person_total = person_summary.setdefault(
                 row["person"].id,
                 {"person": row["person"], "roles": {}, "total": 0},
@@ -479,11 +497,18 @@ def create_live_position_blueprint(
             person_total["total"] += row["minutes"]
             position_total = position_summary.setdefault(
                 row["position"].id,
-                {"position": row["position"], "roles": {}, "total": 0, "people": set()},
+                {
+                    "position": row["position"],
+                    "roles": {},
+                    "total": 0,
+                    "people": set(),
+                    "sessions": set(),
+                },
             )
             position_total["roles"][row["role"]] = (
                 position_total["roles"].get(row["role"], 0) + row["minutes"]
             )
+            position_total["sessions"].add(row["session_id"])
             if row["role"] in {"solo", "under_training", "under_assessment"}:
                 position_total["total"] += row["minutes"]
                 position_total["people"].add(row["person"].id)
@@ -520,6 +545,7 @@ def create_live_position_blueprint(
             instruction_summary=sorted(
                 instruction_summary.values(), key=lambda row: row["person"].name
             ),
+            report_totals=report_totals,
             people=people,
             watches=watches,
             positions=positions,

--- a/static/styles.css
+++ b/static/styles.css
@@ -102,6 +102,20 @@
 .operational-report-filters label { display:grid; gap:.35rem; }
 .operational-report-filters .btn { min-height:44px; }
 .operational-report-section { margin-top:1rem; overflow:hidden; }
+.operational-report-totals { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:1rem; margin-top:1rem; }
+.operational-report-totals article { display:grid; gap:.25rem; padding:1rem 1.15rem; border:1px solid var(--line); border-radius:12px; background:var(--card); }
+.operational-report-totals span, .operational-report-totals small { color:var(--text-muted); }
+.operational-report-totals strong { font-size:clamp(1.5rem,3vw,2.25rem); }
+.operational-position-breakdown { display:grid; gap:.75rem; margin-top:1.25rem; }
+.operational-position-breakdown > h2 { margin:0 0 .25rem; font-size:1.15rem; }
+.operational-position-detail { overflow:hidden; }
+.operational-position-detail > summary { display:flex; align-items:center; justify-content:space-between; gap:1rem; padding:1rem 1.15rem; cursor:pointer; list-style-position:inside; }
+.operational-position-detail > summary span { display:grid; gap:.15rem; }
+.operational-position-detail > summary span:last-child { text-align:right; }
+.operational-position-detail > summary small { color:var(--text-muted); }
+.operational-position-metrics { display:grid; grid-template-columns:repeat(auto-fit,minmax(145px,1fr)); gap:.75rem; padding:0 1.15rem 1rem; }
+.operational-position-metrics span { display:grid; gap:.2rem; padding:.65rem .75rem; border:1px solid var(--line); border-radius:8px; color:var(--text-muted); }
+.operational-position-metrics strong { color:var(--text); font-size:1.05rem; }
 .operational-report-table { min-width:900px; margin-bottom:0; }
 .operational-report-table th, .operational-report-table td { white-space:nowrap; vertical-align:middle; }
 .operational-report-table tfoot th { white-space:normal; color:var(--text-muted); }
@@ -111,7 +125,11 @@
   .operational-report-filters, .operational-report-header .btn, .report-output-actions, .operational-report-notes { display:none !important; }
   .operational-report-section { break-inside:avoid; border:0; }
   .operational-report-table { min-width:0; font-size:9pt; }
+  .operational-report-totals { grid-template-columns:repeat(3,1fr); }
+  .operational-position-detail { break-inside:avoid; }
+  .operational-position-detail:not([open]) > :not(summary) { display:block !important; }
 }
+@media (max-width:700px) { .operational-report-totals { grid-template-columns:1fr; } }
 .live-position-dialog label { display: grid; gap: .35rem; font-weight: 700; }
 .live-position-dialog input, .live-position-dialog select { min-height: 48px; border: 1px solid #64748b; border-radius: 8px; padding: .65rem; background: #f8fafc; color: #0f172a; font-size: 1rem; }
 .live-position-dialog__error { padding: .75rem; border: 2px solid #f87171; border-radius: 8px; background: #450a0a; }

--- a/templates/live_position/operational_activity_report.html
+++ b/templates/live_position/operational_activity_report.html
@@ -47,6 +47,22 @@
 
 {% include "_report_actions.html" %}
 
+<section class="operational-report-totals" aria-label="Report totals">
+  {% if report_type == 'individual' %}
+  <article><span>Operational activity total</span><strong>{{ duration(report_totals.controller_activity) }}</strong><small>{{ report_totals.people|length }} controller{{ '' if report_totals.people|length == 1 else 's' }} · {{ report_totals.sessions|length }} session{{ '' if report_totals.sessions|length == 1 else 's' }}</small></article>
+  <article><span>Solo total</span><strong>{{ duration(report_totals.roles.get('solo', 0)) }}</strong><small>{{ percentage(report_totals.roles.get('solo', 0), report_totals.controller_activity) }} of recorded activity</small></article>
+  <article><span>OJTI total</span><strong>{{ duration(report_totals.roles.get('ojti', 0)) }}</strong><small>{{ percentage(report_totals.roles.get('ojti', 0), report_totals.controller_activity) }} of recorded activity</small></article>
+  {% elif report_type == 'position' %}
+  <article><span>Total position occupancy</span><strong>{{ duration(report_totals.occupied) }}</strong><small>{{ position_summary|length }} position{{ '' if position_summary|length == 1 else 's' }}</small></article>
+  <article><span>Solo occupancy</span><strong>{{ duration(report_totals.roles.get('solo', 0)) }}</strong><small>{{ percentage(report_totals.roles.get('solo', 0), report_totals.occupied) }} utilisation</small></article>
+  <article><span>Training and assessment</span><strong>{{ duration(report_totals.roles.get('under_training', 0) + report_totals.roles.get('under_assessment', 0)) }}</strong><small>Primary-controller time</small></article>
+  {% else %}
+  <article><span>Total contribution</span><strong>{{ duration(report_totals.instruction) }}</strong><small>{{ report_totals.sessions|length }} session{{ '' if report_totals.sessions|length == 1 else 's' }}</small></article>
+  <article><span>OJTI total</span><strong>{{ duration(report_totals.roles.get('ojti', 0)) }}</strong><small>{{ percentage(report_totals.roles.get('ojti', 0), report_totals.instruction) }} of contribution</small></article>
+  <article><span>Assessor total</span><strong>{{ duration(report_totals.roles.get('assessor', 0)) }}</strong><small>{{ percentage(report_totals.roles.get('assessor', 0), report_totals.instruction) }} of contribution</small></article>
+  {% endif %}
+</section>
+
 {% if report_type == 'individual' %}
 <section class="card operational-report-section">
   <div class="card-hd">Individual activity summary · {{ start_day.strftime('%d %b %Y') }} to {{ end_day.strftime('%d %b %Y') }}</div>
@@ -61,20 +77,25 @@
   </table></div>
 </section>
 
-<section class="card operational-report-section">
-  <div class="card-hd">Daily activity detail</div>
-  <div class="table-responsive"><table class="table operational-report-table">
-    <thead><tr><th>Date</th><th>Controller</th><th>Watch</th><th>Group</th><th>Position</th><th>Activity</th><th>Duration</th></tr></thead>
-    <tbody>{% for row in activity %}<tr><td>{{ row.day.strftime('%d %b %Y') }}</td><td>{{ row.person.name }}</td><td>{{ row.watch.name if row.watch else '—' }}</td><td>{{ row.position.group_name or 'Other' }}</td><td>{{ row.position.code }} · {{ row.position.label }}</td><td>{{ row.role_label }}</td><td>{{ duration(row.minutes) }}</td></tr>{% else %}<tr><td colspan="7" class="empty-state">No daily activity matches these filters.</td></tr>{% endfor %}</tbody>
-  </table></div>
+<section class="operational-position-breakdown">
+  <h2>Breakdown by position</h2>
+  {% for position_row in position_summary %}
+  <details class="card operational-position-detail">
+    <summary><span><small>{{ position_row.position.group_name or 'Other' }}</small><strong>{{ position_row.position.code }} · {{ position_row.position.label }}</strong></span><span><small>Recorded activity</small><strong>{{ duration(position_row.roles.values()|sum) }}</strong></span></summary>
+    <div class="operational-position-metrics"><span>Solo <strong>{{ duration(position_row.roles.get('solo', 0)) }}</strong></span><span>Under instruction <strong>{{ duration(position_row.roles.get('under_training', 0)) }}</strong></span><span>OJTI <strong>{{ duration(position_row.roles.get('ojti', 0)) }}</strong></span><span>Under assessment <strong>{{ duration(position_row.roles.get('under_assessment', 0)) }}</strong></span><span>Assessor <strong>{{ duration(position_row.roles.get('assessor', 0)) }}</strong></span></div>
+    <div class="table-responsive"><table class="table operational-report-table"><thead><tr><th>Date</th><th>Controller</th><th>Watch</th><th>Activity</th><th>Duration</th></tr></thead><tbody>{% for row in activity if row.position.id == position_row.position.id %}<tr><td>{{ row.day.strftime('%d %b %Y') }}</td><td>{{ row.person.name }}</td><td>{{ row.watch.name if row.watch else '—' }}</td><td>{{ row.role_label }}</td><td>{{ duration(row.minutes) }}</td></tr>{% endfor %}</tbody></table></div>
+  </details>
+  {% else %}<p class="card card-body empty-state">No position activity matches these filters.</p>{% endfor %}
 </section>
 {% elif report_type == 'position' %}
-<section class="card operational-report-section">
-  <div class="card-hd">Position utilisation · {{ start_day.strftime('%d %b %Y') }} to {{ end_day.strftime('%d %b %Y') }}</div>
-  <div class="table-responsive"><table class="table operational-report-table">
-    <thead><tr><th>Group</th><th>Position</th><th>Occupied</th><th>Solo</th><th>Training</th><th>Assessment</th><th>OJTI contribution</th><th>Assessor contribution</th><th>Controllers</th><th>Solo utilisation</th></tr></thead>
-    <tbody>{% for row in position_summary %}<tr><td>{{ row.position.group_name or 'Other' }}</td><th>{{ row.position.code }} · {{ row.position.label }}</th><td>{{ duration(row.total) }}</td><td>{{ duration(row.roles.get('solo', 0)) }}</td><td>{{ duration(row.roles.get('under_training', 0)) }}</td><td>{{ duration(row.roles.get('under_assessment', 0)) }}</td><td>{{ duration(row.roles.get('ojti', 0)) }}</td><td>{{ duration(row.roles.get('assessor', 0)) }}</td><td>{{ row.people|length }}</td><td>{{ percentage(row.roles.get('solo', 0), row.total) }}</td></tr>{% else %}<tr><td colspan="10" class="empty-state">No position activity matches these filters.</td></tr>{% endfor %}</tbody>
-  </table></div>
+<section class="operational-position-breakdown">
+  <h2>Breakdown by position</h2>
+  {% for row in position_summary %}
+  <details class="card operational-position-detail">
+    <summary><span><small>{{ row.position.group_name or 'Other' }}</small><strong>{{ row.position.code }} · {{ row.position.label }}</strong></span><span><small>Occupied total</small><strong>{{ duration(row.total) }}</strong></span></summary>
+    <div class="operational-position-metrics"><span>Solo <strong>{{ duration(row.roles.get('solo', 0)) }}</strong></span><span>Training <strong>{{ duration(row.roles.get('under_training', 0)) }}</strong></span><span>Assessment <strong>{{ duration(row.roles.get('under_assessment', 0)) }}</strong></span><span>OJTI contribution <strong>{{ duration(row.roles.get('ojti', 0)) }}</strong></span><span>Assessor contribution <strong>{{ duration(row.roles.get('assessor', 0)) }}</strong></span><span>Controllers <strong>{{ row.people|length }}</strong></span><span>Sessions <strong>{{ row.sessions|length }}</strong></span><span>Solo utilisation <strong>{{ percentage(row.roles.get('solo', 0), row.total) }}</strong></span></div>
+  </details>
+  {% else %}<p class="card card-body empty-state">No position activity matches these filters.</p>{% endfor %}
 </section>
 {% else %}
 <section class="card operational-report-section">
@@ -83,6 +104,16 @@
     <thead><tr><th>Instructor / assessor</th><th>Watch</th><th>OJTI time</th><th>Assessor time</th><th>Total contribution</th><th>Recorded sessions</th><th>OJTI share</th></tr></thead>
     <tbody>{% for row in instruction_summary %}{% set total = row.ojti + row.assessor %}<tr><th>{{ row.person.name }}</th><td>{{ row.person.watch.name if row.person.watch else '—' }}</td><td>{{ duration(row.ojti) }}</td><td>{{ duration(row.assessor) }}</td><td>{{ duration(total) }}</td><td>{{ row.sessions|length }}</td><td>{{ percentage(row.ojti, total) }}</td></tr>{% else %}<tr><td colspan="7" class="empty-state">No OJTI or assessor activity matches these filters.</td></tr>{% endfor %}</tbody>
   </table></div>
+</section>
+<section class="operational-position-breakdown">
+  <h2>Breakdown by position</h2>
+  {% for row in position_summary if row.roles.get('ojti', 0) or row.roles.get('assessor', 0) %}
+  {% set position_contribution = row.roles.get('ojti', 0) + row.roles.get('assessor', 0) %}
+  <details class="card operational-position-detail">
+    <summary><span><small>{{ row.position.group_name or 'Other' }}</small><strong>{{ row.position.code }} · {{ row.position.label }}</strong></span><span><small>Contribution total</small><strong>{{ duration(position_contribution) }}</strong></span></summary>
+    <div class="operational-position-metrics"><span>OJTI <strong>{{ duration(row.roles.get('ojti', 0)) }}</strong></span><span>Assessor <strong>{{ duration(row.roles.get('assessor', 0)) }}</strong></span><span>OJTI share <strong>{{ percentage(row.roles.get('ojti', 0), position_contribution) }}</strong></span><span>Sessions <strong>{{ row.sessions|length }}</strong></span></div>
+  </details>
+  {% else %}<p class="card card-body empty-state">No position contribution matches these filters.</p>{% endfor %}
 </section>
 {% endif %}
 

--- a/tests/test_live_position_monitoring.py
+++ b/tests/test_live_position_monitoring.py
@@ -501,6 +501,9 @@ def test_operational_activity_reports_split_solo_and_ojti_time(live_position_dat
     individual = client.get(f"/live-positions/reports/operational-activity?{query}")
     assert individual.status_code == 200
     assert b"Individual activity summary" in individual.data
+    assert b"Operational activity total" in individual.data
+    assert b"Breakdown by position" in individual.data
+    assert b"operational-position-detail" in individual.data
     assert b"Alex Controller" in individual.data
     assert b"01:30" in individual.data
     assert b"Sam Instructor" in individual.data
@@ -511,11 +514,13 @@ def test_operational_activity_reports_split_solo_and_ojti_time(live_position_dat
     )
     assert position.status_code == 200
     assert b"Position utilisation" in position.data
+    assert b"Total position occupancy" in position.data
     instruction = client.get(
         f"/live-positions/reports/operational-activity?{query}&report_type=instruction"
     )
     assert instruction.status_code == 200
     assert b"OJTI and assessor contribution" in instruction.data
+    assert b"Total contribution" in instruction.data
     assert b"100.0%" in instruction.data
 
 


### PR DESCRIPTION
## What changed

- Add prominent overall totals to every operational activity report.
- Group report detail into expandable position sections.
- Show day-by-day controller activity inside each position on the individual report.
- Show occupancy, solo, training, assessment, staffing and session totals per position.
- Show OJTI and assessor contribution per position.
- Expand closed position sections in print and Save as PDF output.

## Validation

- Ruff formatting and static analysis passed.
- Jinja template parsing passed.
- Added regression assertions for totals and expandable position breakdowns.
- Full production-matched tests will run in GitHub Actions.
