### PR TITLE
Add weekly position time matrices

### DIFF
--- a/live_position_blueprint.py
+++ b/live_position_blueprint.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import json
 import time
 from dataclasses import dataclass
-from datetime import date, datetime, time as datetime_time, timedelta
+from datetime import date, datetime, time as datetime_time, timedelta, timezone
 from typing import Any, Callable
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from flask import (
     Blueprint,
@@ -128,6 +129,61 @@ def create_live_position_blueprint(
             return rendered[:-6] + "Z"
         return rendered if getattr(value, "tzinfo", None) else rendered + "Z"
 
+    def _position_time_matrix(position: Any) -> dict[str, int]:
+        try:
+            raw = json.loads(position.maximum_session_duration_matrix_json or "{}")
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return {}
+        if not isinstance(raw, dict):
+            return {}
+        matrix: dict[str, int] = {}
+        for key, value in raw.items():
+            try:
+                weekday, hour = (int(part) for part in str(key).split(":"))
+                minutes = int(value)
+            except (TypeError, ValueError):
+                continue
+            if 0 <= weekday <= 6 and 0 <= hour <= 23 and 1 <= minutes <= 1440:
+                matrix[f"{weekday}:{hour}"] = minutes
+        return matrix
+
+    def _matrix_from_form(data: dict[str, Any]) -> dict[str, int]:
+        matrix: dict[str, int] = {}
+        for weekday in range(7):
+            for hour in range(24):
+                raw = str(data.get(f"allowance_{weekday}_{hour}") or "").strip()
+                if not raw:
+                    continue
+                try:
+                    minutes = int(raw)
+                except ValueError as error:
+                    raise LivePositionValidationError(
+                        "Matrix allowances must be whole minutes."
+                    ) from error
+                if not 1 <= minutes <= 1440:
+                    raise LivePositionValidationError(
+                        "Matrix allowances must be between 1 and 1,440 minutes."
+                    )
+                matrix[f"{weekday}:{hour}"] = minutes
+        return matrix
+
+    def _allowance_minutes(position: Any, at: datetime | None = None) -> int:
+        unit = dependencies.db.session.get(dependencies.Unit, _unit_id())
+        moment = at or dependencies.utcnow()
+        if moment.tzinfo is None:
+            moment = moment.replace(tzinfo=timezone.utc)
+        try:
+            local_timezone = ZoneInfo(
+                getattr(unit, "timezone", "Europe/London") or "Europe/London"
+            )
+        except ZoneInfoNotFoundError:
+            local_timezone = timezone.utc
+        local_moment = moment.astimezone(local_timezone)
+        return _position_time_matrix(position).get(
+            f"{local_moment.weekday()}:{local_moment.hour}",
+            position.maximum_session_duration_minutes,
+        )
+
     def _controller(person_id: int) -> Any:
         person = dependencies.Staff.query.filter_by(
             id=person_id,
@@ -138,6 +194,14 @@ def create_live_position_blueprint(
         if not person:
             raise LivePositionValidationError("Select an active controller.")
         return person
+
+    def _configured_position(position_id: int) -> Any:
+        position = dependencies.OperationalPosition.query.filter_by(
+            id=position_id, unit_id=_unit_id(), is_active=True
+        ).first()
+        if not position:
+            raise LivePositionValidationError("Unknown or inactive position.")
+        return position
 
     def _validate_primary(person: Any) -> None:
         today = dependencies.utcnow().date()
@@ -650,6 +714,11 @@ def create_live_position_blueprint(
                     else None
                 )
                 requested_active = str(data.get("is_active") or "") == "on"
+                try:
+                    allowance_matrix = _matrix_from_form(data)
+                except LivePositionValidationError as error:
+                    allowance_matrix = None
+                    flash(str(error), "error")
                 occupied = bool(
                     position.id
                     and dependencies.PositionSession.query.filter_by(
@@ -667,6 +736,8 @@ def create_live_position_blueprint(
                     flash("Select a valid currency category.", "error")
                 elif group_id and not group:
                     flash("Select a valid position group.", "error")
+                elif allowance_matrix is None:
+                    pass
                 elif occupied and not requested_active:
                     flash(
                         "Log off and close this position before making it inactive.",
@@ -687,6 +758,9 @@ def create_live_position_blueprint(
                             1440,
                             _int_field(data, "maximum_session_duration_minutes", 120),
                         ),
+                    )
+                    position.maximum_session_duration_matrix_json = json.dumps(
+                        allowance_matrix, sort_keys=True
                     )
                     position.group_name = group.name if group else ""
                     position.currency_category_id = category.id if category else None
@@ -720,6 +794,10 @@ def create_live_position_blueprint(
                                     "code": position.code,
                                     "label": position.label,
                                     "is_active": position.is_active,
+                                    "maximum_session_duration_minutes": (
+                                        position.maximum_session_duration_minutes
+                                    ),
+                                    "maximum_session_duration_matrix": allowance_matrix,
                                 },
                                 sort_keys=True,
                             ),
@@ -760,6 +838,19 @@ def create_live_position_blueprint(
             positions=positions,
             groups=groups,
             categories=categories,
+            position_matrices={
+                position.id: _position_time_matrix(position) for position in positions
+            },
+            weekdays=(
+                "Monday",
+                "Tuesday",
+                "Wednesday",
+                "Thursday",
+                "Friday",
+                "Saturday",
+                "Sunday",
+            ),
+            matrix_hours=range(24),
         )
 
     @blueprint.get("/kiosk")
@@ -840,12 +931,14 @@ def create_live_position_blueprint(
             person = _controller(_int_field(data, "person_id"))
             _validate_primary(person)
             participants, session_type = _secondary_selection(data)
+            position = _configured_position(position_id)
             _service().start_session(
                 unit_id=_unit_id(),
                 position_id=position_id,
                 person_id=person.id,
                 actor_id=current_user.id,
                 session_type=session_type,
+                maximum_duration_seconds=_allowance_minutes(position) * 60,
                 request_key=_request_key(data),
                 participants=participants,
             )
@@ -897,12 +990,14 @@ def create_live_position_blueprint(
             incoming = _controller(_int_field(data, "person_id"))
             _validate_primary(incoming)
             participants, session_type = _secondary_selection(data)
+            position = _configured_position(position_id)
             _service().handover(
                 unit_id=_unit_id(),
                 position_id=position_id,
                 incoming_person_id=incoming.id,
                 actor_id=current_user.id,
                 session_type=session_type,
+                maximum_duration_seconds=_allowance_minutes(position) * 60,
                 request_key=_request_key(data),
                 participants=participants,
             )
@@ -1009,7 +1104,10 @@ def create_live_position_blueprint(
             maximum_duration_seconds = (
                 session.maximum_duration_seconds
                 if session and session.maximum_duration_seconds
-                else position.maximum_session_duration_minutes * 60
+                else _allowance_minutes(
+                    position, session.started_at if session else now
+                )
+                * 60
             )
             if session:
                 for row in dependencies.PositionSessionParticipant.query.filter_by(

--- a/live_position_service.py
+++ b/live_position_service.py
@@ -547,6 +547,7 @@ class LivePositionService:
         incoming_person_id: int,
         actor_id: int,
         session_type: str = "operational",
+        maximum_duration_seconds: int | None = None,
         request_key: str | None = None,
         participants: list[dict[str, int]] | None = None,
     ) -> Any:
@@ -579,6 +580,11 @@ class LivePositionService:
         if session_type == "assessment" and not position.assessment_supported:
             raise LivePositionValidationError("Assessment is not supported here.")
         self._end_session_records(outgoing, timestamp, "handover", key)
+        effective_maximum_duration_seconds = (
+            maximum_duration_seconds
+            if maximum_duration_seconds is not None
+            else position.maximum_session_duration_minutes * 60
+        )
         incoming = self.models.PositionSession(
             unit_id=unit_id,
             position_id=position_id,
@@ -586,15 +592,9 @@ class LivePositionService:
             session_type=session_type,
             started_at=timestamp,
             currency_category_id=position.currency_category_id,
-            maximum_duration_seconds=(
-                position.maximum_session_duration_minutes * 60
-            ),
-            due_off_at=(
-                timestamp
-                + timedelta(
-                    minutes=position.maximum_session_duration_minutes
-                )
-            ),
+            maximum_duration_seconds=effective_maximum_duration_seconds,
+            due_off_at=timestamp
+            + timedelta(seconds=effective_maximum_duration_seconds),
             created_by_id=actor_id,
             transaction_key=self.related_key(key, "incoming"),
         )

--- a/migrations/versions/20260801_33_position_time_matrix.py
+++ b/migrations/versions/20260801_33_position_time_matrix.py
@@ -1,0 +1,37 @@
+"""add weekly position controller time matrix
+
+Revision ID: 20260801_33
+Revises: 20260731_32
+"""
+
+import os
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260801_33"
+down_revision = "20260731_32"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
+    with op.batch_alter_table("operational_position") as batch:
+        batch.add_column(
+            sa.Column(
+                "maximum_session_duration_matrix_json",
+                sa.Text(),
+                nullable=False,
+                server_default="{}",
+            )
+        )
+
+
+def downgrade():
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
+    with op.batch_alter_table("operational_position") as batch:
+        batch.drop_column("maximum_session_duration_matrix_json")

--- a/saas_models.py
+++ b/saas_models.py
@@ -349,6 +349,9 @@ def register_saas_models(db, utcnow):
         maximum_session_duration_minutes = db.Column(
             db.Integer, nullable=False, default=120
         )
+        maximum_session_duration_matrix_json = db.Column(
+            db.Text, nullable=False, default="{}"
+        )
         currency_category_id = db.Column(
             db.Integer, db.ForeignKey("position_currency_category.id")
         )

--- a/static/styles.css
+++ b/static/styles.css
@@ -98,6 +98,15 @@
 .live-position-dialog h2, .live-position-dialog p { margin: 0; }
 .live-position-logoff-options { display: grid; gap: .75rem; margin-top: 1rem; }
 .live-position-logoff-options .btn { width: 100%; min-height: 50px; }
+.live-position-time-matrix { grid-column:1/-1; overflow:hidden; border:1px solid var(--line); border-radius:10px; }
+.live-position-time-matrix > summary { display:flex; justify-content:space-between; gap:1rem; padding:.85rem 1rem; cursor:pointer; }
+.live-position-time-matrix > p, .live-position-time-matrix > small { display:block; margin:.75rem 1rem; color:var(--text-muted); }
+.live-position-time-matrix__scroll { overflow-x:auto; padding:0 1rem .5rem; }
+.live-position-time-matrix table { width:max-content; border-collapse:collapse; }
+.live-position-time-matrix th { position:sticky; left:0; z-index:1; min-width:90px; padding:.35rem .5rem; background:var(--card); text-align:left; }
+.live-position-time-matrix thead th { position:static; min-width:58px; text-align:center; }
+.live-position-time-matrix td { padding:.2rem; border-left:1px solid var(--line); }
+.live-position-time-matrix input { width:54px; min-height:38px; padding:.25rem; text-align:center; }
 .operational-report-filters { display:grid; grid-template-columns:repeat(auto-fit,minmax(160px,1fr)); gap:1rem; align-items:end; margin-bottom:1rem; }
 .operational-report-filters label { display:grid; gap:.35rem; }
 .operational-report-filters .btn { min-height:44px; }

--- a/templates/live_position/position_configuration.html
+++ b/templates/live_position/position_configuration.html
@@ -31,7 +31,7 @@
     <label>Short code<input name="code" maxlength="30" placeholder="AIR" required></label>
     <label>Display name<input name="label" maxlength="120" placeholder="Aerodrome Control" required></label>
     <label>Display order<input name="display_order" type="number" min="0" value="100"></label>
-    <label>Maximum controller time (minutes)<input name="maximum_session_duration_minutes" type="number" min="1" max="1440" value="120" required></label>
+    <label>Default maximum controller time (minutes)<input name="maximum_session_duration_minutes" type="number" min="1" max="1440" value="120" required></label>
     <label>Position group
       <select name="position_group_id"><option value="">No group</option>{% for group in groups if group.is_active %}<option value="{{ group.id }}">{{ group.name }}</option>{% endfor %}</select>
     </label>
@@ -62,7 +62,23 @@
       <label>Short code<input name="code" maxlength="30" value="{{ position.code }}" required></label>
       <label>Display name<input name="label" maxlength="120" value="{{ position.label }}" required></label>
       <label>Display order<input name="display_order" type="number" min="0" value="{{ position.display_order }}"></label>
-      <label>Maximum controller time (minutes)<input name="maximum_session_duration_minutes" type="number" min="1" max="1440" value="{{ position.maximum_session_duration_minutes }}" required></label>
+      <label>Default maximum controller time (minutes)<input name="maximum_session_duration_minutes" type="number" min="1" max="1440" value="{{ position.maximum_session_duration_minutes }}" required></label>
+      <details class="live-position-time-matrix">
+        <summary><strong>Maximum-time weekly matrix</strong><span>{{ position_matrices[position.id]|length }} hourly override{{ '' if position_matrices[position.id]|length == 1 else 's' }}</span></summary>
+        <p>Times use the airport’s local timezone. Leave a cell blank to use the default maximum of <strong>{{ position.maximum_session_duration_minutes }} minutes</strong>. The allowance is selected from the hour in which the controller logs on.</p>
+        <div class="live-position-time-matrix__scroll">
+          <table>
+            <thead><tr><th scope="col">Day</th>{% for hour in matrix_hours %}<th scope="col">{{ '%02d'|format(hour) }}</th>{% endfor %}</tr></thead>
+            <tbody>
+            {% for weekday in weekdays %}
+              {% set weekday_index = loop.index0 %}
+              <tr><th scope="row">{{ weekday }}</th>{% for hour in matrix_hours %}{% set matrix_key = weekday_index ~ ':' ~ hour %}<td><input type="number" name="allowance_{{ weekday_index }}_{{ hour }}" min="1" max="1440" value="{{ position_matrices[position.id].get(matrix_key, '') }}" placeholder="{{ position.maximum_session_duration_minutes }}" aria-label="{{ weekday }} {{ '%02d:00'|format(hour) }} maximum minutes"></td>{% endfor %}</tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        <small>Each column begins at the displayed hour; for example, 14 covers logons from 14:00 to 14:59 local time.</small>
+      </details>
       <label>Position group
         <select name="position_group_id"><option value="">No group</option>{% for group in groups if group.is_active %}<option value="{{ group.id }}" {% if group.name == position.group_name %}selected{% endif %}>{{ group.name }}</option>{% endfor %}</select>
       </label>

--- a/tests/test_legacy_migration_fixtures.py
+++ b/tests/test_legacy_migration_fixtures.py
@@ -119,7 +119,7 @@ def test_legacy_fixture_upgrades_to_head_without_data_loss(
         inspector = inspect(connection)
         assert connection.execute(
             text("SELECT version_num FROM alembic_version")
-        ).scalar_one() == "20260731_32"
+        ).scalar_one() == "20260801_33"
         for table, count in before.items():
             assert connection.execute(
                 text(f'SELECT COUNT(*) FROM "{table}"')

--- a/tests/test_live_position_monitoring.py
+++ b/tests/test_live_position_monitoring.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime
+import json
 import re
 
 import pytest
@@ -263,6 +264,49 @@ def _action(client, csrf, path, payload):
 def test_kiosk_controller_selection_runs_full_live_position_workflow(
     live_position_data,
 ):
+    admin_client = app.app.test_client()
+    admin_client.get("/login")
+    with admin_client.session_transaction() as browser_session:
+        admin_csrf = browser_session["_csrf_token"]
+    admin_client.post(
+        "/login",
+        data={
+            "_csrf_token": admin_csrf,
+            "username": "live-admin",
+            "password": "admin-password",
+        },
+    )
+    finish_operational_login(admin_client)
+    with admin_client.session_transaction() as browser_session:
+        admin_csrf = browser_session["_csrf_token"]
+    matrix_update = {
+        "_csrf_token": admin_csrf,
+        "action": "update_position",
+        "position_id": str(live_position_data["position_id"]),
+        "code": "AIR",
+        "label": "Aerodrome Control",
+        "display_order": "100",
+        "maximum_session_duration_minutes": "120",
+        "supporting_participants_allowed": "on",
+        "multiple_supporting_participants_allowed": "on",
+        "training_supported": "on",
+        "assessment_supported": "on",
+        "is_safety_critical": "on",
+        "is_active": "on",
+    }
+    matrix_update.update(
+        {
+            f"allowance_{weekday}_{hour}": "75"
+            for weekday in range(7)
+            for hour in range(24)
+        }
+    )
+    assert (
+        admin_client.post(
+            "/live-positions/admin/positions", data=matrix_update
+        ).status_code
+        == 302
+    )
     client = app.app.test_client()
     csrf = _login_kiosk(client)
     position = live_position_data["position_id"]
@@ -281,8 +325,8 @@ def test_kiosk_controller_selection_runs_full_live_position_workflow(
     state = client.get("/live-positions/api/state").get_json()["positions"][0]
     assert state["display_status"] == "training"
     assert state["physical_status"] == "open"
-    assert state["primary"]["maximum_duration_seconds"] == 7200
-    assert state["participants"][0]["maximum_duration_seconds"] == 7200
+    assert state["primary"]["maximum_duration_seconds"] == 4500
+    assert state["participants"][0]["maximum_duration_seconds"] == 4500
     assert state["primary"]["name"] == "Alex Controller"
     assert state["participants"][0]["role_label"] == "OJTI"
     assert "+00:00Z" not in state["primary"]["started_at"]
@@ -340,12 +384,11 @@ def test_kiosk_controller_selection_runs_full_live_position_workflow(
         },
     )
     assert handed_over.status_code == 200
-    assert (
-        client.get("/live-positions/api/state").get_json()["positions"][0]["primary"][
-            "name"
-        ]
-        == "Sam Instructor"
-    )
+    handover_state = client.get("/live-positions/api/state").get_json()["positions"][0][
+        "primary"
+    ]
+    assert handover_state["name"] == "Sam Instructor"
+    assert handover_state["maximum_duration_seconds"] == 4500
     ended = _action(
         client,
         csrf,
@@ -548,6 +591,8 @@ def test_admin_can_configure_currency_category_and_position(live_position_data):
     assert client.get("/live-positions/kiosk").status_code == 403
     page = client.get("/live-positions/admin/positions")
     assert page.status_code == 200
+    assert b"Maximum-time weekly matrix" in page.data
+    assert b"airport\xe2\x80\x99s local timezone" in page.data
     with client.session_transaction() as session:
         csrf = session["_csrf_token"]
     group = client.post(
@@ -582,6 +627,7 @@ def test_admin_can_configure_currency_category_and_position(live_position_data):
             "label": "Ground Movement Control",
             "display_order": "10",
             "maximum_session_duration_minutes": "90",
+            "allowance_0_8": "75",
             "position_group_id": str(group_id),
             "currency_category_id": str(category_id),
             "supporting_participants_allowed": "on",
@@ -598,6 +644,9 @@ def test_admin_can_configure_currency_category_and_position(live_position_data):
         assert configured.label == "Ground Movement Control"
         assert configured.group_name == "Radar"
         assert configured.maximum_session_duration_minutes == 90
+        assert json.loads(configured.maximum_session_duration_matrix_json) == {
+            "0:8": 75
+        }
         assert configured.currency_category_id == category_id
     page = client.get("/live-positions/admin/positions")
     assert b'<option value="%d" selected>Radar</option>' % group_id in page.data

--- a/tests/test_postgresql_multidatabase.py
+++ b/tests/test_postgresql_multidatabase.py
@@ -54,9 +54,9 @@ def test_postgresql_control_and_two_airport_databases_are_isolated(
     dispose_operational_engines()
     for url in (CONTROL_URL, AIRPORT_A_URL, AIRPORT_B_URL):
         _reset_postgres(url)
-    assert upgrade_database(CONTROL_URL, "control") == "20260731_32"
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260731_32"
-    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260731_32"
+    assert upgrade_database(CONTROL_URL, "control") == "20260801_33"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260801_33"
+    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260801_33"
     secret_a = "ATCROSTER_UNIT_1_DATABASE_URL"
     secret_b = "ATCROSTER_UNIT_2_DATABASE_URL"
     monkeypatch.setenv(secret_a, AIRPORT_A_URL)


### PR DESCRIPTION
## What changed

- Add a 7 × 24 hourly maximum-controller-time matrix to every operational position.
- Keep the existing default maximum as the fallback for blank matrix cells.
- Evaluate matrix hours in the airport’s configured local timezone, including daylight-saving changes.
- Snapshot the selected allowance on initial logon and handover so active sessions remain stable after configuration edits.
- Persist matrix overrides as validated operational configuration and include them in configuration audit records.
- Add the operational database migration and update migration-head checks.

## Admin experience

- Each configured position has an expandable weekly matrix.
- Rows represent Monday through Sunday and columns represent local hours 00 through 23.
- Blank cells visibly inherit the position default.
- Values are restricted to 1–1,440 whole minutes.

## Validation

- Ruff formatting and static analysis passed.
- Jinja template parsing passed.
- Tests cover matrix persistence and application to both logon and handover.
- Full application and PostgreSQL migration tests will run in GitHub Actions.
