### PR TITLE
Separate migration-owner and runtime database credentials

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -63,6 +63,9 @@ jobs:
       APP_ORIGIN: https://pilot.atcroster.com
       ACCEPTANCE_USERNAME: ${{ secrets.STAGING_USERNAME }}
       ACCEPTANCE_PASSWORD: ${{ secrets.STAGING_PASSWORD }}
+      CONTROL_DATABASE_URL: ${{ secrets.CONTROL_DATABASE_OWNER_URL }}
+      ATCROSTER_UNIT_1_DATABASE_URL: ${{ secrets.OPERATIONAL_DATABASE_OWNER_URL }}
+      ATCROSTER_RUNTIME_DATABASE_ROLE: atcroster_runtime
     steps:
       - name: Check out the exact commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -72,6 +75,23 @@ jobs:
 
       - name: Install pinned Railway CLI
         run: npm install --global "@railway/cli@$RAILWAY_CLI_VERSION"
+
+      - name: Use supported migration Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-prod.txt
+
+      - name: Migrate and enforce database grants
+        run: |
+          set -euo pipefail
+          python -m pip install --disable-pip-version-check -r requirements-prod.txt
+          python scripts/migrate_all_databases.py
+          python scripts/apply_runtime_database_grants.py \
+            --database-url-env CONTROL_DATABASE_URL
+          python scripts/apply_runtime_database_grants.py \
+            --database-url-env ATCROSTER_UNIT_1_DATABASE_URL
 
       - name: Deploy web and worker
         env:
@@ -214,6 +234,10 @@ jobs:
       RAILWAY_WEB_SERVICE: 0a09e66c-43f6-4a8f-995e-97066c29cf07
       RAILWAY_WORKER_SERVICE: 1a7871f2-7b28-4abf-b78c-ed92532e9e27
       APP_ORIGIN: https://www.atcroster.com
+      CONTROL_DATABASE_URL: ${{ secrets.CONTROL_DATABASE_OWNER_URL }}
+      ATCROSTER_UNIT_1_DATABASE_URL: ${{ secrets.OPERATIONAL_DATABASE_OWNER_URL }}
+      ATCROSTER_UNIT_2_DATABASE_URL: ${{ secrets.OPERATIONAL_DATABASE_OWNER_URL }}
+      ATCROSTER_RUNTIME_DATABASE_ROLE: atcroster_runtime
     steps:
       - name: Check out the accepted commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -223,6 +247,23 @@ jobs:
 
       - name: Install pinned Railway CLI
         run: npm install --global "@railway/cli@$RAILWAY_CLI_VERSION"
+
+      - name: Use supported migration Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-prod.txt
+
+      - name: Migrate and enforce database grants
+        run: |
+          set -euo pipefail
+          python -m pip install --disable-pip-version-check -r requirements-prod.txt
+          python scripts/migrate_all_databases.py
+          python scripts/apply_runtime_database_grants.py \
+            --database-url-env CONTROL_DATABASE_URL
+          python scripts/apply_runtime_database_grants.py \
+            --database-url-env ATCROSTER_UNIT_1_DATABASE_URL
 
       - name: Deploy accepted web and worker
         env:

--- a/docs/operations/database-roles.md
+++ b/docs/operations/database-roles.md
@@ -19,7 +19,19 @@ Provider administrators and the database owner remain technically able to
 alter evidence. Their accounts require provider MFA, access logging and an
 approved break-glass procedure; this is outside application enforcement.
 
-## Apply after every migration
+## Controlled deployment
+
+Railway web and worker services contain only runtime database URLs. Migration
+owner URLs are stored as protected GitHub environment secrets named
+`CONTROL_DATABASE_OWNER_URL` and `OPERATIONAL_DATABASE_OWNER_URL`. The
+controlled-promotion workflow migrates with those credentials, reapplies and
+verifies runtime grants, and only then deploys the application services.
+
+Do not restore Railway's per-service pre-deploy migration command: Railway
+runs it in the application service environment and that would require exposing
+owner credentials to web and worker processes.
+
+## Manual application after a migration
 
 Create the roles and passwords through the managed PostgreSQL control plane.
 Do not store them in the repository. Set the migration-owner database URL in a
@@ -64,4 +76,3 @@ The PostgreSQL integration suite creates a real login role and proves:
 - audit update/delete fails with `InsufficientPrivilege`;
 - schema creation (representing migration authority) fails;
 - programmatic privilege verification passes.
-

--- a/railway.toml
+++ b/railway.toml
@@ -3,7 +3,6 @@ builder = "DOCKERFILE"
 dockerfilePath = "Dockerfile"
 
 [deploy]
-preDeployCommand = "python scripts/migrate_all_databases.py"
 startCommand = "python scripts/start_service.py"
 healthcheckPath = "/health/ready"
 healthcheckTimeout = 300

--- a/scripts/bootstrap_runtime_database_role.py
+++ b/scripts/bootstrap_runtime_database_role.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Create or rotate a PostgreSQL runtime login without printing credentials."""
+
+from __future__ import annotations
+
+import argparse
+import re
+
+import psycopg
+from psycopg import sql
+
+from scripts.database_backup import psycopg_dsn
+from scripts.database_grants import required_environment
+
+
+ROLE_PATTERN = re.compile(r"[a-z_][a-z0-9_]{0,62}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--database-url-env", required=True)
+    arguments = parser.parse_args()
+    database_url = required_environment(arguments.database_url_env)
+    role = required_environment("ATCROSTER_RUNTIME_DATABASE_ROLE")
+    password = required_environment("ATCROSTER_RUNTIME_DATABASE_PASSWORD")
+    if not ROLE_PATTERN.fullmatch(role):
+        raise RuntimeError("Runtime role has an invalid PostgreSQL identifier.")
+    with psycopg.connect(psycopg_dsn(database_url)) as connection:
+        exists = connection.execute(
+            "SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = %s", (role,)
+        ).fetchone()
+        identifier = sql.Identifier(role)
+        password_literal = sql.Literal(password)
+        if exists:
+            connection.execute(
+                sql.SQL("ALTER ROLE {} LOGIN PASSWORD {}").format(
+                    identifier, password_literal
+                )
+            )
+        else:
+            connection.execute(
+                sql.SQL("CREATE ROLE {} LOGIN PASSWORD {}").format(
+                    identifier, password_literal
+                )
+            )
+        connection.execute(
+            sql.SQL("ALTER ROLE {} NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION")
+            .format(identifier)
+        )
+        connection.commit()
+    print("Runtime database role is present with restricted role attributes.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed
- move production and staging migrations into protected GitHub deployment environments
- reapply and verify least-privilege grants before every application deployment
- remove Railway application-service pre-deploy migrations
- add a safe bootstrap/rotation tool for the restricted PostgreSQL login
- document the credential boundary and release procedure

## Why
Railway web and worker previously needed owner-capable database URLs because their shared pre-deploy command ran Alembic. That left migration authority available to application processes. The release workflow now holds owner URLs only in protected GitHub environments, while Railway application services receive runtime-only URLs.

## Environment preparation
Staging and production runtime roles have been created and verified. Protected owner secrets and pending Railway runtime URLs are configured without displaying credentials.

## Verification
- Ruff passed
- workflow YAML parsed
- platform security lifecycle: 6 passed
- staging control grants: 16 tables, 2 audit tables, 14 sequences
- staging operational grants: 52 tables, 7 audit tables, 51 sequences
- production control grants: 16 tables, 2 audit tables, 14 sequences
- production operational grants: 52 tables, 7 audit tables, 51 sequences