### PR TITLE
Pass the pinned psycopg driver URL to Alembic

### DIFF
--- a/scripts/migrate_all_databases.py
+++ b/scripts/migrate_all_databases.py
@@ -105,7 +105,7 @@ def upgrade_database(database_url: str, schema_role: str) -> str:
         raise RuntimeError("Combined schema migrations are forbidden in production.")
     previous = os.environ.get("DATABASE_URL")
     previous_role = os.environ.get("ATCROSTER_SCHEMA_ROLE")
-    os.environ["DATABASE_URL"] = database_url
+    os.environ["DATABASE_URL"] = _sqlalchemy_database_url(database_url)
     os.environ["ATCROSTER_SCHEMA_ROLE"] = schema_role
     try:
         config = Config(str(REPOSITORY / "alembic.ini"))


### PR DESCRIPTION
## What changed
Pass the normalized `postgresql+psycopg` URL through `DATABASE_URL` while Alembic runs, restoring the previous environment value afterward.

## Root cause
The prior fix normalized direct SQLAlchemy connections, but Alembic independently consumed the unmodified Railway `postgresql://` URL and attempted to import psycopg2.

## Safety and verification
Both failed promotion attempts stopped before staging deployment. Ruff and diff checks pass, and real Alembic no-op upgrades against the live staging control and operational databases both reached `20260801_37` using the pinned psycopg 3 driver.