### PR TITLE
Run database release tools as Python modules

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -87,10 +87,10 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --disable-pip-version-check -r requirements-prod.txt
-          python scripts/migrate_all_databases.py
-          python scripts/apply_runtime_database_grants.py \
+          python -m scripts.migrate_all_databases
+          python -m scripts.apply_runtime_database_grants \
             --database-url-env CONTROL_DATABASE_URL
-          python scripts/apply_runtime_database_grants.py \
+          python -m scripts.apply_runtime_database_grants \
             --database-url-env ATCROSTER_UNIT_1_DATABASE_URL
 
       - name: Deploy web and worker
@@ -259,10 +259,10 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --disable-pip-version-check -r requirements-prod.txt
-          python scripts/migrate_all_databases.py
-          python scripts/apply_runtime_database_grants.py \
+          python -m scripts.migrate_all_databases
+          python -m scripts.apply_runtime_database_grants \
             --database-url-env CONTROL_DATABASE_URL
-          python scripts/apply_runtime_database_grants.py \
+          python -m scripts.apply_runtime_database_grants \
             --database-url-env ATCROSTER_UNIT_1_DATABASE_URL
 
       - name: Deploy accepted web and worker

--- a/docs/operations/database-roles.md
+++ b/docs/operations/database-roles.md
@@ -40,9 +40,9 @@ named environment variable, then run:
 ```text
 ATCROSTER_RUNTIME_DATABASE_ROLE=<runtime-role>
 ATCROSTER_AUDIT_READ_ROLE=<optional-reader-role>
-python scripts/apply_runtime_database_grants.py \
+python -m scripts.apply_runtime_database_grants \
   --database-url-env CONTROL_DATABASE_OWNER_URL
-python scripts/apply_runtime_database_grants.py \
+python -m scripts.apply_runtime_database_grants \
   --database-url-env ATCROSTER_UNIT_1_DATABASE_OWNER_URL
 ```
 
@@ -52,9 +52,9 @@ without changing grants. Repeat for every routed airport database.
 ## Release verification
 
 ```text
-python scripts/verify_runtime_database_grants.py \
+python -m scripts.verify_runtime_database_grants \
   --database-url-env CONTROL_DATABASE_OWNER_URL
-python scripts/verify_runtime_database_grants.py \
+python -m scripts.verify_runtime_database_grants \
   --database-url-env ATCROSTER_UNIT_1_DATABASE_OWNER_URL
 ```
 


### PR DESCRIPTION
## What changed
Run migration, grant and verification tools with `python -m scripts...` in the controlled promotion and operator documentation.

## Root cause
Launching the grant tool by file path made Python place `scripts/` rather than the repository root on `sys.path`, so its `scripts.database_grants` import failed on GitHub runners.

## Safety and verification
The staging gate completed both Alembic checks and then stopped before application deployment. Workflow YAML parses, diff checks pass, and a real staging control-database dry run generated 49 grant statements successfully using module execution.