### PR TITLE
Incrementally modularise app security and tenant boundaries

### DIFF
--- a/app.py
+++ b/app.py
@@ -98,6 +98,10 @@ from atcroster.security.headers import (
     csp_nonce,
     register_security_headers,
 )
+from atcroster.security.sessions import (
+    SessionLifecycle,
+    SessionLifecycleDependencies,
+)
 from tenancy import (
     authenticated_unit_id,
     bind_authenticated_unit,
@@ -296,64 +300,9 @@ def _bind_tenant_context():
     g.csp_nonce = secrets.token_urlsafe(18)
     g.tenant_context_token = None
     g.platform_control_token = None
-    if session.get("_user_id") and not current_user.is_authenticated:
-        # Flask-Login treats a principal rejected by the user loader as
-        # anonymous but otherwise leaves the stale signed session cookie in
-        # place. Remove it immediately when a membership/account is disabled.
-        session.clear()
-    if current_user.is_authenticated:
-        now_epoch = int(utcnow().timestamp())
-        idle_limit = int(
-            os.environ.get("ATCROSTER_SESSION_IDLE_MINUTES", "30")
-        ) * 60
-        last_seen = int(session.get("_last_seen_epoch") or now_epoch)
-        absolute_limit = int(
-            os.environ.get("ATCROSTER_SESSION_ABSOLUTE_MINUTES", "720")
-        ) * 60
-        started_raw = session.get("_session_started_at")
-        try:
-            started_epoch = int(
-                datetime.fromisoformat(str(started_raw)).timestamp()
-            )
-        except (TypeError, ValueError):
-            started_epoch = now_epoch
-            session["_session_started_at"] = utcnow().isoformat()
-        expiry_reason = (
-            "absolute" if now_epoch - started_epoch > absolute_limit
-            else "idle" if now_epoch - last_seen > idle_limit
-            else ""
-        )
-        if expiry_reason:
-            _security_event(
-                "session_expired", reason=expiry_reason,
-                principal=hashlib.sha256(
-                    str(current_user.get_id()).encode()
-                ).hexdigest()[:16],
-            )
-            logout_user()
-            session.clear()
-            flash("Your secure session has expired. Sign in again.", "error")
-            return redirect(url_for("login"))
-        expected_stamp = session.get("_auth_stamp")
-        current_stamp = _current_auth_stamp(current_user)
-        if expected_stamp and not secrets.compare_digest(
-            str(expected_stamp), current_stamp
-        ):
-            _security_event(
-                "session_forced_invalidation",
-                principal=hashlib.sha256(
-                    str(current_user.get_id()).encode()
-                ).hexdigest()[:16],
-            )
-            logout_user()
-            session.clear()
-            flash(
-                "Your account security or permissions changed. Sign in again.",
-                "error",
-            )
-            return redirect(url_for("login"))
-        session["_auth_stamp"] = current_stamp
-        session["_last_seen_epoch"] = now_epoch
+    session_response = _session_lifecycle.enforce_request(current_user)
+    if session_response is not None:
+        return session_response
     if (
         current_user.is_authenticated
         and getattr(current_user, "role", "") == "superadmin"
@@ -8720,46 +8669,24 @@ def _security_event(event: str, **safe_fields) -> None:
     )
 
 
-def _current_auth_stamp(user) -> str:
-    """Bind a session to mutable authentication and authorisation state."""
-    parts = [
-        str(getattr(user, "password_hash", "")),
-        str(getattr(user, "role", "")),
-        str(getattr(user, "membership_status", "")),
-    ]
+def _credential_for_auth_stamp(user):
     if getattr(user, "role", "") == "superadmin":
-        credential = PlatformMfaCredential.query.filter_by(
+        return PlatformMfaCredential.query.filter_by(
             identity_id=user.id
         ).first()
-    else:
-        # The user loader binds the verified membership's operational route
-        # before this is called. Including airport MFA state ensures that
-        # enrolment, replacement or reset revokes every previously issued
-        # browser session for that person.
-        credential = MfaCredential.query.filter_by(person_id=user.id).first()
-    enrolled_at = getattr(credential, "enrolled_at", None)
-    if enrolled_at and enrolled_at.tzinfo is not None:
-        enrolled_at = enrolled_at.astimezone(timezone.utc).replace(tzinfo=None)
-    parts.extend([
-        str(bool(credential and credential.enabled)),
-        str(bool(getattr(credential, "reset_required", False))),
-        hashlib.sha256(
-            str(getattr(credential, "encrypted_secret", "")).encode()
-        ).hexdigest(),
-        enrolled_at.isoformat() if enrolled_at else "",
-    ])
-    return hashlib.sha256("\x1f".join(parts).encode()).hexdigest()
+    # The user loader has already bound the verified operational tenant.
+    return MfaCredential.query.filter_by(person_id=user.id).first()
 
 
-def _initialize_authenticated_session(user, *, platform_mfa=False) -> None:
-    """Regenerate authenticated session state after the final auth factor."""
-    session.permanent = True
-    session["_session_nonce"] = secrets.token_urlsafe(24)
-    session["_session_started_at"] = utcnow().isoformat()
-    session["_last_seen_epoch"] = int(utcnow().timestamp())
-    session["_auth_stamp"] = _current_auth_stamp(user)
-    if platform_mfa:
-        session["_platform_mfa_verified"] = True
+_session_lifecycle = SessionLifecycle(
+    SessionLifecycleDependencies(
+        now=utcnow,
+        credential_for_user=_credential_for_auth_stamp,
+        security_event=lambda event, **facts: _security_event(event, **facts),
+    )
+)
+_current_auth_stamp = _session_lifecycle.auth_stamp
+_initialize_authenticated_session = _session_lifecycle.initialize
 
 
 def _central_security_event(

--- a/app.py
+++ b/app.py
@@ -91,6 +91,7 @@ from access_policy import (
 )
 from atcroster import create_app, get_runtime_settings
 from atcroster.errors import ErrorHandlerDependencies, register_error_handlers
+from atcroster.public import public_blueprint
 from atcroster.security.headers import (
     SecurityHeaderDependencies,
     csp_nonce,
@@ -269,55 +270,7 @@ def _enforce_csrf():
         _validate_csrf()
 
 
-@app.route("/favicon.ico")
-def favicon():
-    return send_from_directory(
-        app.static_folder, "favicon.svg", mimetype="image/svg+xml"
-    )
-
-
-def _legal_context() -> dict[str, str]:
-    """Public contact details used by the legal and privacy notices."""
-    return {
-        "legal_entity": os.environ.get(
-            "ATCROSTER_LEGAL_ENTITY",
-            "Ian John Dickson trading as IDAviation",
-        ).strip(),
-        "privacy_email": os.environ.get(
-            "ATCROSTER_PRIVACY_EMAIL",
-            os.environ.get(
-                "ATCROSTER_SUPPORT_EMAIL", "privacy@atcroster.com"
-            ),
-        ).strip(),
-        "legal_address": os.environ.get(
-            "ATCROSTER_LEGAL_ADDRESS",
-            "Flat 0/2, 24 Caird Drive, Glasgow, Scotland, G11 5DT",
-        ).strip(),
-        "company_number": os.environ.get(
-            "ATCROSTER_COMPANY_NUMBER", ""
-        ).strip(),
-        "policy_date": "27 July 2026",
-    }
-
-
-@app.get("/privacy")
-def privacy_notice():
-    return render_template("privacy.html", **_legal_context())
-
-
-@app.get("/cookies")
-def cookie_notice():
-    return render_template("cookies.html", **_legal_context())
-
-
-@app.get("/terms")
-def terms_of_service():
-    return render_template("terms.html", **_legal_context())
-
-
-@app.get("/subprocessors")
-def subprocessor_notice():
-    return render_template("subprocessors.html", **_legal_context())
+app.register_blueprint(public_blueprint)
 
 
 _error_handlers = register_error_handlers(

--- a/app.py
+++ b/app.py
@@ -92,6 +92,7 @@ from access_policy import (
 from atcroster import create_app, get_runtime_settings
 from atcroster.errors import ErrorHandlerDependencies, register_error_handlers
 from atcroster.public import public_blueprint
+from atcroster.security.csrf import csrf_token, register_csrf_protection
 from atcroster.security.headers import (
     SecurityHeaderDependencies,
     csp_nonce,
@@ -234,40 +235,13 @@ def _current_unit_id() -> int:
     return int(getattr(current_user, "unit_id", 0) or 0)
 
 
-def csrf_token() -> str:
-    token = session.get("_csrf_token")
-    if not token:
-        token = secrets.token_urlsafe(32)
-        session["_csrf_token"] = token
-    return token
-
-
-def _validate_csrf() -> None:
-    supplied = request.form.get("_csrf_token") or request.headers.get("X-CSRF-Token")
-    expected = session.get("_csrf_token")
-    if not expected or not supplied or not secrets.compare_digest(str(expected), str(supplied)):
-        abort(400, "Invalid or missing CSRF token.")
-
-
-app.jinja_env.globals["csrf_token"] = csrf_token
-
-
 @app.before_request
 def _start_request_tenant_boundary():
     clear_request_context()
     g.metrics_started_at = begin_request(_operational_metrics)
 
 
-@app.before_request
-def _enforce_csrf():
-    """Apply a default-deny CSRF boundary to every browser mutation.
-
-    There are currently no exempt unsafe routes. New machine-to-machine
-    endpoints must use a separate authenticated blueprint and document any
-    exemption explicitly rather than weakening this browser boundary.
-    """
-    if request.method in {"POST", "PUT", "PATCH", "DELETE"}:
-        _validate_csrf()
+_validate_csrf, _enforce_csrf = register_csrf_protection(app)
 
 
 app.register_blueprint(public_blueprint)

--- a/app.py
+++ b/app.py
@@ -102,6 +102,7 @@ from atcroster.security.sessions import (
     SessionLifecycle,
     SessionLifecycleDependencies,
 )
+from atcroster.tenancy_hooks import TenantHookDependencies, register_tenant_hooks
 from tenancy import (
     authenticated_unit_id,
     bind_authenticated_unit,
@@ -293,21 +294,30 @@ login_manager = LoginManager(app)
 login_manager.login_view = "login"
 
 
+_bind_tenant_context, _reset_tenant_context = register_tenant_hooks(
+    app,
+    TenantHookDependencies(
+        deployment_environment=DEPLOYMENT_ENV,
+        current_user=lambda: current_user,
+        enforce_session=lambda user: _session_lifecycle.enforce_request(user),
+        routing_for_unit=lambda unit_id: db.session.get(
+            DatabaseRoutingMetadata, unit_id
+        ),
+        clear_context=clear_request_context,
+        bind_authenticated_unit=bind_authenticated_unit,
+        reset_authenticated_unit=reset_authenticated_unit,
+        bind_platform_control=bind_platform_control,
+        reset_platform_control=reset_platform_control,
+    ),
+)
+
+
 @app.before_request
-def _bind_tenant_context():
-    clear_request_context()
-    g.request_id = request.headers.get("X-Request-ID") or secrets.token_hex(12)
-    g.csp_nonce = secrets.token_urlsafe(18)
-    g.tenant_context_token = None
-    g.platform_control_token = None
-    session_response = _session_lifecycle.enforce_request(current_user)
-    if session_response is not None:
-        return session_response
+def _enforce_principal_boundaries():
     if (
         current_user.is_authenticated
         and getattr(current_user, "role", "") == "superadmin"
     ):
-        g.platform_control_token = bind_platform_control()
         if not session.get("_platform_mfa_verified"):
             logout_user()
             session.clear()
@@ -322,15 +332,6 @@ def _bind_tenant_context():
             return redirect(url_for("platform_admin"))
         if request.endpoint not in allowed_platform_endpoints:
             abort(403)
-    if current_user.is_authenticated and getattr(current_user, "role", "") != "superadmin":
-        unit_id = int(getattr(current_user, "unit_id", 0) or 0)
-        if unit_id and g.tenant_context_token is None:
-            routing = db.session.get(DatabaseRoutingMetadata, unit_id)
-            if DEPLOYMENT_ENV == "production" and not routing:
-                abort(503, "Operational database routing is unavailable.")
-            g.tenant_context_token = bind_authenticated_unit(
-                unit_id, routing.secret_name if routing else None
-            )
     if (
         current_user.is_authenticated
         and getattr(current_user, "role", "") == "position_monitor"
@@ -382,26 +383,6 @@ _security_headers = register_security_headers(
         finish_request=finish_request,
     ),
 )
-
-
-@app.teardown_request
-def _reset_tenant_context(_error=None):
-    token = getattr(g, "tenant_context_token", None)
-    g.tenant_context_token = None
-    if token is not None:
-        try:
-            reset_authenticated_unit(token)
-        except RuntimeError:
-            # Flask test/request contexts may invoke teardown more than once.
-            pass
-    platform_token = getattr(g, "platform_control_token", None)
-    g.platform_control_token = None
-    if platform_token is not None:
-        try:
-            reset_platform_control(platform_token)
-        except RuntimeError:
-            pass
-    clear_request_context()
 
 
 _LOGIN_NEXT_ENDPOINTS = {

--- a/app.py
+++ b/app.py
@@ -90,6 +90,11 @@ from access_policy import (
     permissions_for,
 )
 from atcroster import create_app, get_runtime_settings
+from atcroster.security.headers import (
+    SecurityHeaderDependencies,
+    csp_nonce,
+    register_security_headers,
+)
 from tenancy import (
     authenticated_unit_id,
     bind_authenticated_unit,
@@ -243,13 +248,6 @@ def _validate_csrf() -> None:
 
 
 app.jinja_env.globals["csrf_token"] = csrf_token
-
-
-def csp_nonce() -> str:
-    return getattr(g, "csp_nonce", "")
-
-
-app.jinja_env.globals["csp_nonce"] = csp_nonce
 
 
 @app.before_request
@@ -638,68 +636,14 @@ def _bind_tenant_context():
             return redirect(url_for("mfa_setup"))
 
 
-@app.after_request
-def _security_headers(response):
-    response.headers["X-Request-ID"] = getattr(g, "request_id", "")
-    response.headers.setdefault("X-Content-Type-Options", "nosniff")
-    response.headers.setdefault("X-Frame-Options", "DENY")
-    response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
-    response.headers.setdefault(
-        "Permissions-Policy", "camera=(), microphone=(), geolocation=()"
-    )
-    response.headers.setdefault(
-        "Content-Security-Policy",
-        "default-src 'self'; "
-        "base-uri 'self'; "
-        "form-action 'self'; "
-        "frame-ancestors 'none'; "
-        "object-src 'none'; "
-        "img-src 'self' data:; "
-        "font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; "
-        f"style-src 'self' 'nonce-{getattr(g, 'csp_nonce', '')}' "
-        "https://fonts.googleapis.com "
-        "https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; "
-        "style-src-attr 'none'; "
-        f"script-src 'self' 'nonce-{getattr(g, 'csp_nonce', '')}' "
-        "https://cdn.jsdelivr.net; "
-        "connect-src 'self'; worker-src 'self'; manifest-src 'self'"
-        + ("; upgrade-insecure-requests" if DEPLOYMENT_ENV == "production" else ""),
-    )
-    if request.is_secure or DEPLOYMENT_ENV == "production":
-        response.headers.setdefault(
-            "Strict-Transport-Security", "max-age=31536000; includeSubDomains"
-        )
-    if current_user.is_authenticated:
-        response.headers.setdefault("Cache-Control", "no-store, private")
-    started_at = getattr(g, "metrics_started_at", None)
-    if started_at is not None:
-        route = request.endpoint or "unmatched"
-        duration = finish_request(
-            _operational_metrics,
-            started_at,
-            route=route,
-            method=request.method,
-            status=response.status_code,
-        )
-        g.metrics_started_at = None
-        if DEPLOYMENT_ENV == "production":
-            app.logger.info(
-                "request_completed",
-                extra={
-                    "structured_fields": {
-                        "request_id": getattr(g, "request_id", ""),
-                        "route": route,
-                        "unit_id": getattr(current_user, "unit_id", None),
-                        "actor_id": getattr(current_user, "id", None),
-                        "outcome": (
-                            "success" if response.status_code < 400 else "error"
-                        ),
-                        "http_status": response.status_code,
-                        "duration_ms": round(duration * 1000, 2),
-                    }
-                },
-            )
-    return response
+_security_headers = register_security_headers(
+    app,
+    SecurityHeaderDependencies(
+        deployment_environment=DEPLOYMENT_ENV,
+        metrics=_operational_metrics,
+        finish_request=finish_request,
+    ),
+)
 
 
 @app.teardown_request

--- a/app.py
+++ b/app.py
@@ -90,6 +90,7 @@ from access_policy import (
     permissions_for,
 )
 from atcroster import create_app, get_runtime_settings
+from atcroster.errors import ErrorHandlerDependencies, register_error_handlers
 from atcroster.security.headers import (
     SecurityHeaderDependencies,
     csp_nonce,
@@ -319,123 +320,18 @@ def subprocessor_notice():
     return render_template("subprocessors.html", **_legal_context())
 
 
-@app.errorhandler(500)
-def _internal_error(error):
-    app.logger.error(
-        "unhandled_request_error request_id=%s path=%s",
-        getattr(g, "request_id", ""), request.path, exc_info=error,
-    )
-    module_context = _module_error_navigation()
-    return render_template(
-        "error.html", request_id=getattr(g, "request_id", ""),
-        **module_context,
-    ), 500
-
-
-def _module_error_navigation() -> dict[str, str]:
-    """Keep module errors inside the module instead of linking to Roster."""
-    if request.path.startswith("/briefing"):
-        return {
-            "home_url": url_for("briefing.home"),
-            "home_label": "Return to briefing",
-        }
-    if request.path.startswith("/training"):
-        return {
-            "home_url": url_for("training_home"),
-            "home_label": "Return to training",
-        }
-    if request.path.startswith("/competency"):
-        return {
-            "home_url": url_for("competency_home"),
-            "home_label": "Return to competency",
-        }
-    return {}
-
-
-@app.errorhandler(400)
-def _bad_request(error):
-    if isinstance(error, SecurityError):
-        return Response(
-            "Bad Request: untrusted host.",
-            status=400,
-            content_type="text/plain; charset=utf-8",
+_error_handlers = register_error_handlers(
+    app,
+    ErrorHandlerDependencies(
+        security_event=lambda event, **safe_fields: _security_event(
+            event, **safe_fields
         )
-    description = getattr(error, "description", "") or ""
-    if "CSRF" in description:
-        _security_event("csrf_rejected", route=request.endpoint or "unmatched")
-        message = (
-            "This page or form has expired. Reload the page and try the action "
-            "once more."
-        )
-    elif description and not description.startswith(
-        "The browser (or proxy) sent a request"
-    ):
-        message = description
-    else:
-        message = (
-            "The request was not valid. Check the entered values and try again."
-        )
-    return render_template(
-        "error.html",
-        status_code=400,
-        error_title="We could not validate that request",
-        error_message=message,
-        request_id=getattr(g, "request_id", ""),
-        **_module_error_navigation(),
-    ), 400
-
-
-@app.errorhandler(403)
-def _forbidden(_error):
-    _security_event(
-        "forbidden_role_action",
-        route=request.endpoint or "unmatched",
-        unit_id=getattr(current_user, "unit_id", None),
-        actor_id=getattr(current_user, "id", None),
-    )
-    is_platform_admin = (
-        getattr(current_user, "is_authenticated", False)
-        and getattr(current_user, "role", "") == "superadmin"
-    )
-    module_context = _module_error_navigation()
-    return render_template(
-        "error.html",
-        status_code=403,
-        error_title="You do not have access to this area",
-        error_message=(
-            "Platform administrators cannot access airport personnel or "
-            "operational roster data. Return to Platform Administration."
-            if is_platform_admin
-            else (
-                "Your account role does not permit this action. Ask your Unit "
-                "Administrator for access."
-            )
-        ),
-        home_url=(
-            url_for("platform_admin") if is_platform_admin
-            else module_context.get("home_url", url_for("index"))
-        ),
-        home_label=(
-            "Return to Platform Administration"
-            if is_platform_admin
-            else module_context.get("home_label", "Return to roster")
-        ),
-        request_id=getattr(g, "request_id", ""),
-    ), 403
-
-
-@app.errorhandler(404)
-def _not_found(_error):
-    return render_template(
-        "error.html",
-        status_code=404,
-        error_title="That page or record was not found",
-        error_message=(
-            "It may have moved, been removed, or belong to a different airport."
-        ),
-        request_id=getattr(g, "request_id", ""),
-        **_module_error_navigation(),
-    ), 404
+    ),
+)
+_bad_request = _error_handlers[400]
+_forbidden = _error_handlers[403]
+_not_found = _error_handlers[404]
+_internal_error = _error_handlers[500]
 
 OPERATIONAL_TABLE_NAMES = frozenset({
     "roster_setting", "annotation_type", "watch", "staff", "shift_type",

--- a/app.py
+++ b/app.py
@@ -23,7 +23,6 @@ import hashlib
 import pyotp
 import qrcode
 import qrcode.image.svg
-from cryptography.fernet import Fernet, InvalidToken
 
 from flask_sqlalchemy import SQLAlchemy
 from flask_sqlalchemy.session import Session as FlaskSqlAlchemySession
@@ -93,6 +92,7 @@ from atcroster import create_app, get_runtime_settings
 from atcroster.errors import ErrorHandlerDependencies, register_error_handlers
 from atcroster.public import public_blueprint
 from atcroster.security.csrf import csrf_token, register_csrf_protection
+from atcroster.security.encryption import FieldEncryptionService
 from atcroster.security.headers import (
     SecurityHeaderDependencies,
     csp_nonce,
@@ -143,46 +143,12 @@ else:
     _rate_limiter = MemoryRateLimiter()
 
 
-def _field_ciphers() -> list[tuple[str, Fernet]]:
-    result = []
-    for item in FIELD_ENCRYPTION_KEYS.split(","):
-        version, separator, key = item.strip().partition(":")
-        if not separator or not re.fullmatch(r"[A-Za-z0-9_-]{1,20}", version):
-            raise RuntimeError("Invalid field-encryption key version.")
-        try:
-            result.append((version, Fernet(key.encode())))
-        except (ValueError, TypeError) as exc:
-            raise RuntimeError("Invalid field-encryption key material.") from exc
-    if not result:
-        raise RuntimeError("At least one field-encryption key is required.")
-    return result
-
-
-def _encrypt_field(value: str) -> str:
-    version, cipher = _field_ciphers()[0]
-    return f"{version}.{cipher.encrypt(value.encode()).decode()}"
-
-
-def _decrypt_field(value: str) -> str:
-    version, separator, ciphertext = value.partition(".")
-    if separator:
-        candidates = [
-            cipher for candidate, cipher in _field_ciphers()
-            if candidate == version
-        ]
-    else:
-        ciphertext = value
-        candidates = [cipher for _version, cipher in _field_ciphers()]
-    for cipher in candidates:
-        try:
-            return cipher.decrypt(ciphertext.encode()).decode()
-        except InvalidToken:
-            continue
-    raise ValueError("Encrypted field cannot be decrypted with configured keys.")
-
-
-# Validate configured material during startup rather than at first MFA use.
-_field_ciphers()
+# Constructing the service validates configured material during startup rather
+# than at first MFA use. Aliases preserve callers during incremental extraction.
+_field_encryption = FieldEncryptionService(FIELD_ENCRYPTION_KEYS)
+_field_ciphers = _field_encryption.ciphers
+_encrypt_field = _field_encryption.encrypt
+_decrypt_field = _field_encryption.decrypt
 
 # Jinja helper
 app.jinja_env.globals['now'] = lambda: datetime.now()

--- a/atcroster/errors.py
+++ b/atcroster/errors.py
@@ -1,1 +1,168 @@
-"""Error-handler registration boundary for the next extraction step."""
+"""Application error handlers with explicit logging and security dependencies."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from flask import Flask, Response, g, render_template, request, url_for
+from flask_login import current_user
+from werkzeug.exceptions import SecurityError
+
+
+@dataclass(frozen=True)
+class ErrorHandlerDependencies:
+    security_event: Callable[..., None]
+
+
+def module_error_navigation() -> dict[str, str]:
+    """Keep module errors inside the module instead of linking to Roster."""
+    if request.path.startswith("/briefing"):
+        return {
+            "home_url": url_for("briefing.home"),
+            "home_label": "Return to briefing",
+        }
+    if request.path.startswith("/training"):
+        return {
+            "home_url": url_for("training_home"),
+            "home_label": "Return to training",
+        }
+    if request.path.startswith("/competency"):
+        return {
+            "home_url": url_for("competency_home"),
+            "home_label": "Return to competency",
+        }
+    return {}
+
+
+def register_error_handlers(
+    app: Flask,
+    dependencies: ErrorHandlerDependencies,
+) -> dict[int, Callable[..., Any]]:
+    """Register the stable 400, 403, 404 and 500 response contracts."""
+
+    def internal_error(error):
+        app.logger.error(
+            "unhandled_request_error request_id=%s path=%s",
+            getattr(g, "request_id", ""),
+            request.path,
+            exc_info=error,
+        )
+        return (
+            render_template(
+                "error.html",
+                request_id=getattr(g, "request_id", ""),
+                **module_error_navigation(),
+            ),
+            500,
+        )
+
+    def bad_request(error):
+        if isinstance(error, SecurityError):
+            return Response(
+                "Bad Request: untrusted host.",
+                status=400,
+                content_type="text/plain; charset=utf-8",
+            )
+        description = getattr(error, "description", "") or ""
+        if "CSRF" in description:
+            dependencies.security_event(
+                "csrf_rejected", route=request.endpoint or "unmatched"
+            )
+            message = (
+                "This page or form has expired. Reload the page and try the action "
+                "once more."
+            )
+        elif description and not description.startswith(
+            "The browser (or proxy) sent a request"
+        ):
+            message = description
+        else:
+            message = (
+                "The request was not valid. Check the entered values and try again."
+            )
+        return (
+            render_template(
+                "error.html",
+                status_code=400,
+                error_title="We could not validate that request",
+                error_message=message,
+                request_id=getattr(g, "request_id", ""),
+                **module_error_navigation(),
+            ),
+            400,
+        )
+
+    def forbidden(_error):
+        dependencies.security_event(
+            "forbidden_role_action",
+            route=request.endpoint or "unmatched",
+            unit_id=getattr(current_user, "unit_id", None),
+            actor_id=getattr(current_user, "id", None),
+        )
+        is_platform_admin = (
+            getattr(current_user, "is_authenticated", False)
+            and getattr(current_user, "role", "") == "superadmin"
+        )
+        module_context = module_error_navigation()
+        return (
+            render_template(
+                "error.html",
+                status_code=403,
+                error_title="You do not have access to this area",
+                error_message=(
+                    "Platform administrators cannot access airport personnel or "
+                    "operational roster data. Return to Platform Administration."
+                    if is_platform_admin
+                    else (
+                        "Your account role does not permit this action. Ask your Unit "
+                        "Administrator for access."
+                    )
+                ),
+                home_url=(
+                    url_for("platform_admin")
+                    if is_platform_admin
+                    else module_context.get("home_url", url_for("index"))
+                ),
+                home_label=(
+                    "Return to Platform Administration"
+                    if is_platform_admin
+                    else module_context.get("home_label", "Return to roster")
+                ),
+                request_id=getattr(g, "request_id", ""),
+            ),
+            403,
+        )
+
+    def not_found(_error):
+        return (
+            render_template(
+                "error.html",
+                status_code=404,
+                error_title="That page or record was not found",
+                error_message=(
+                    "It may have moved, been removed, or belong to a different airport."
+                ),
+                request_id=getattr(g, "request_id", ""),
+                **module_error_navigation(),
+            ),
+            404,
+        )
+
+    handlers = {
+        400: bad_request,
+        403: forbidden,
+        404: not_found,
+        500: internal_error,
+    }
+    names = {
+        400: "_bad_request",
+        403: "_forbidden",
+        404: "_not_found",
+        500: "_internal_error",
+    }
+    for status_code, handler in handlers.items():
+        handler.__name__ = names[status_code]
+        app.register_error_handler(status_code, handler)
+    return handlers

--- a/atcroster/public/__init__.py
+++ b/atcroster/public/__init__.py
@@ -1,0 +1,5 @@
+"""Unauthenticated public-information routes."""
+
+from .blueprint import public_blueprint
+
+__all__ = ["public_blueprint"]

--- a/atcroster/public/blueprint.py
+++ b/atcroster/public/blueprint.py
@@ -1,0 +1,71 @@
+"""Public and legal pages with stable legacy endpoint names."""
+
+from __future__ import annotations
+
+import os
+
+from flask import Blueprint, current_app, render_template, send_from_directory
+
+public_blueprint = Blueprint("public", __name__)
+
+
+def legal_context() -> dict[str, str]:
+    """Return public contact details used by the legal and privacy notices."""
+    return {
+        "legal_entity": os.environ.get(
+            "ATCROSTER_LEGAL_ENTITY",
+            "Ian John Dickson trading as IDAviation",
+        ).strip(),
+        "privacy_email": os.environ.get(
+            "ATCROSTER_PRIVACY_EMAIL",
+            os.environ.get("ATCROSTER_SUPPORT_EMAIL", "privacy@atcroster.com"),
+        ).strip(),
+        "legal_address": os.environ.get(
+            "ATCROSTER_LEGAL_ADDRESS",
+            "Flat 0/2, 24 Caird Drive, Glasgow, Scotland, G11 5DT",
+        ).strip(),
+        "company_number": os.environ.get("ATCROSTER_COMPANY_NUMBER", "").strip(),
+        "policy_date": "27 July 2026",
+    }
+
+
+def favicon():
+    return send_from_directory(
+        current_app.static_folder,
+        "favicon.svg",
+        mimetype="image/svg+xml",
+    )
+
+
+def privacy_notice():
+    return render_template("privacy.html", **legal_context())
+
+
+def cookie_notice():
+    return render_template("cookies.html", **legal_context())
+
+
+def terms_of_service():
+    return render_template("terms.html", **legal_context())
+
+
+def subprocessor_notice():
+    return render_template("subprocessors.html", **legal_context())
+
+
+@public_blueprint.record_once
+def register_legacy_endpoints(state) -> None:
+    """Register through the blueprint without changing public endpoint names.
+
+    Flask prefixes ordinary blueprint endpoints. These long-lived endpoints are
+    referenced by templates and are therefore installed explicitly on the app.
+    """
+    routes = (
+        ("/favicon.ico", "favicon", favicon),
+        ("/privacy", "privacy_notice", privacy_notice),
+        ("/cookies", "cookie_notice", cookie_notice),
+        ("/terms", "terms_of_service", terms_of_service),
+        ("/subprocessors", "subprocessor_notice", subprocessor_notice),
+    )
+    for rule, endpoint, view_func in routes:
+        state.app.add_url_rule(rule, endpoint, view_func, methods=("GET",))

--- a/atcroster/security/__init__.py
+++ b/atcroster/security/__init__.py
@@ -1,0 +1,1 @@
+"""Security boundaries registered by the application bootstrap."""

--- a/atcroster/security/csrf.py
+++ b/atcroster/security/csrf.py
@@ -1,0 +1,46 @@
+"""Default-deny CSRF protection for browser mutation routes."""
+
+from __future__ import annotations
+
+import secrets
+from collections.abc import Callable
+
+from flask import Flask, abort, request, session
+
+UNSAFE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+
+def csrf_token() -> str:
+    """Return the session token, creating it with cryptographic randomness."""
+    token = session.get("_csrf_token")
+    if not token:
+        token = secrets.token_urlsafe(32)
+        session["_csrf_token"] = token
+    return token
+
+
+def validate_csrf() -> None:
+    """Validate form or header input using a constant-time comparison."""
+    supplied = request.form.get("_csrf_token") or request.headers.get("X-CSRF-Token")
+    expected = session.get("_csrf_token")
+    if (
+        not expected
+        or not supplied
+        or not secrets.compare_digest(str(expected), str(supplied))
+    ):
+        abort(400, "Invalid or missing CSRF token.")
+
+
+def register_csrf_protection(
+    app: Flask,
+) -> tuple[Callable[[], None], Callable[[], None]]:
+    """Register the Jinja helper and global unsafe-method enforcement hook."""
+    app.jinja_env.globals["csrf_token"] = csrf_token
+
+    def enforce_csrf() -> None:
+        if request.method in UNSAFE_METHODS:
+            validate_csrf()
+
+    enforce_csrf.__name__ = "_enforce_csrf"
+    app.before_request(enforce_csrf)
+    return validate_csrf, enforce_csrf

--- a/atcroster/security/encryption.py
+++ b/atcroster/security/encryption.py
@@ -1,0 +1,55 @@
+"""Versioned encryption for security-sensitive application fields."""
+
+from __future__ import annotations
+
+import re
+
+from cryptography.fernet import Fernet, InvalidToken
+
+
+class FieldEncryptionService:
+    """Encrypt with the current key and decrypt with the matching key version."""
+
+    def __init__(self, serialized_keys: str) -> None:
+        self._ciphers = self._parse_keys(serialized_keys)
+
+    @staticmethod
+    def _parse_keys(serialized_keys: str) -> tuple[tuple[str, Fernet], ...]:
+        result: list[tuple[str, Fernet]] = []
+        for item in serialized_keys.split(","):
+            version, separator, key = item.strip().partition(":")
+            if not separator or not re.fullmatch(r"[A-Za-z0-9_-]{1,20}", version):
+                raise RuntimeError("Invalid field-encryption key version.")
+            try:
+                result.append((version, Fernet(key.encode())))
+            except (ValueError, TypeError) as exc:
+                raise RuntimeError("Invalid field-encryption key material.") from exc
+        if not result:
+            raise RuntimeError("At least one field-encryption key is required.")
+        return tuple(result)
+
+    def ciphers(self) -> list[tuple[str, Fernet]]:
+        """Return the parsed key ring for the temporary compatibility API."""
+        return list(self._ciphers)
+
+    def encrypt(self, value: str) -> str:
+        version, cipher = self._ciphers[0]
+        return f"{version}.{cipher.encrypt(value.encode()).decode()}"
+
+    def decrypt(self, value: str) -> str:
+        version, separator, ciphertext = value.partition(".")
+        if separator:
+            candidates = (
+                cipher
+                for candidate_version, cipher in self._ciphers
+                if candidate_version == version
+            )
+        else:
+            ciphertext = value
+            candidates = (cipher for _version, cipher in self._ciphers)
+        for cipher in candidates:
+            try:
+                return cipher.decrypt(ciphertext.encode()).decode()
+            except InvalidToken:
+                continue
+        raise ValueError("Encrypted field cannot be decrypted with configured keys.")

--- a/atcroster/security/headers.py
+++ b/atcroster/security/headers.py
@@ -1,0 +1,106 @@
+"""Response security headers, CSP nonce access and request completion hooks."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from flask import Flask, Response, g, request
+from flask_login import current_user
+
+
+@dataclass(frozen=True)
+class SecurityHeaderDependencies:
+    deployment_environment: str
+    metrics: Any
+    finish_request: Callable[..., float]
+
+
+def csp_nonce() -> str:
+    """Return the per-request nonce without creating or persisting one."""
+    return getattr(g, "csp_nonce", "")
+
+
+def content_security_policy(nonce: str, *, production: bool) -> str:
+    """Build the established policy as a directly testable pure function."""
+    return (
+        "default-src 'self'; "
+        "base-uri 'self'; "
+        "form-action 'self'; "
+        "frame-ancestors 'none'; "
+        "object-src 'none'; "
+        "img-src 'self' data:; "
+        "font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; "
+        f"style-src 'self' 'nonce-{nonce}' "
+        "https://fonts.googleapis.com "
+        "https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; "
+        "style-src-attr 'none'; "
+        f"script-src 'self' 'nonce-{nonce}' "
+        "https://cdn.jsdelivr.net; "
+        "connect-src 'self'; worker-src 'self'; manifest-src 'self'"
+        + ("; upgrade-insecure-requests" if production else "")
+    )
+
+
+def register_security_headers(
+    app: Flask,
+    dependencies: SecurityHeaderDependencies,
+) -> Callable[[Response], Response]:
+    """Register the explicit Jinja nonce and after-request security boundary."""
+    production = dependencies.deployment_environment == "production"
+    app.jinja_env.globals["csp_nonce"] = csp_nonce
+
+    def security_headers(response: Response) -> Response:
+        response.headers["X-Request-ID"] = getattr(g, "request_id", "")
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        response.headers.setdefault(
+            "Referrer-Policy", "strict-origin-when-cross-origin"
+        )
+        response.headers.setdefault(
+            "Permissions-Policy", "camera=(), microphone=(), geolocation=()"
+        )
+        response.headers.setdefault(
+            "Content-Security-Policy",
+            content_security_policy(csp_nonce(), production=production),
+        )
+        if request.is_secure or production:
+            response.headers.setdefault(
+                "Strict-Transport-Security", "max-age=31536000; includeSubDomains"
+            )
+        if current_user.is_authenticated:
+            response.headers.setdefault("Cache-Control", "no-store, private")
+        started_at = getattr(g, "metrics_started_at", None)
+        if started_at is not None:
+            route = request.endpoint or "unmatched"
+            duration = dependencies.finish_request(
+                dependencies.metrics,
+                started_at,
+                route=route,
+                method=request.method,
+                status=response.status_code,
+            )
+            g.metrics_started_at = None
+            if production:
+                app.logger.info(
+                    "request_completed",
+                    extra={
+                        "structured_fields": {
+                            "request_id": getattr(g, "request_id", ""),
+                            "route": route,
+                            "unit_id": getattr(current_user, "unit_id", None),
+                            "actor_id": getattr(current_user, "id", None),
+                            "outcome": (
+                                "success" if response.status_code < 400 else "error"
+                            ),
+                            "http_status": response.status_code,
+                            "duration_ms": round(duration * 1000, 2),
+                        }
+                    },
+                )
+        return response
+
+    security_headers.__name__ = "_security_headers"
+    app.after_request(security_headers)
+    return security_headers

--- a/atcroster/security/sessions.py
+++ b/atcroster/security/sessions.py
@@ -1,0 +1,124 @@
+"""Authenticated browser-session lifecycle and revocation checks."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import secrets
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from flask import Response, flash, redirect, session, url_for
+from flask_login import logout_user
+
+
+@dataclass(frozen=True)
+class SessionLifecycleDependencies:
+    now: Callable[[], datetime]
+    credential_for_user: Callable[[Any], Any | None]
+    security_event: Callable[..., None]
+
+
+class SessionLifecycle:
+    """Bind sessions to mutable identity state and enforce time limits."""
+
+    def __init__(self, dependencies: SessionLifecycleDependencies) -> None:
+        self._dependencies = dependencies
+
+    def auth_stamp(self, user: Any) -> str:
+        parts = [
+            str(getattr(user, "password_hash", "")),
+            str(getattr(user, "role", "")),
+            str(getattr(user, "membership_status", "")),
+        ]
+        credential = self._dependencies.credential_for_user(user)
+        enrolled_at = getattr(credential, "enrolled_at", None)
+        if enrolled_at and enrolled_at.tzinfo is not None:
+            enrolled_at = enrolled_at.astimezone(timezone.utc).replace(tzinfo=None)
+        parts.extend(
+            [
+                str(bool(credential and credential.enabled)),
+                str(bool(getattr(credential, "reset_required", False))),
+                hashlib.sha256(
+                    str(getattr(credential, "encrypted_secret", "")).encode()
+                ).hexdigest(),
+                enrolled_at.isoformat() if enrolled_at else "",
+            ]
+        )
+        return hashlib.sha256("\x1f".join(parts).encode()).hexdigest()
+
+    def initialize(self, user: Any, *, platform_mfa: bool = False) -> None:
+        """Regenerate authenticated state after the final authentication factor."""
+        now = self._dependencies.now()
+        session.permanent = True
+        session["_session_nonce"] = secrets.token_urlsafe(24)
+        session["_session_started_at"] = now.isoformat()
+        session["_last_seen_epoch"] = int(now.timestamp())
+        session["_auth_stamp"] = self.auth_stamp(user)
+        if platform_mfa:
+            session["_platform_mfa_verified"] = True
+
+    def enforce_request(self, user: Any) -> Response | None:
+        """Clear rejected principals and revoke expired or stale sessions."""
+        if session.get("_user_id") and not user.is_authenticated:
+            session.clear()
+            return None
+        if not user.is_authenticated:
+            return None
+
+        now = self._dependencies.now()
+        now_epoch = int(now.timestamp())
+        idle_limit = int(os.environ.get("ATCROSTER_SESSION_IDLE_MINUTES", "30")) * 60
+        absolute_limit = (
+            int(os.environ.get("ATCROSTER_SESSION_ABSOLUTE_MINUTES", "720")) * 60
+        )
+        last_seen = int(session.get("_last_seen_epoch") or now_epoch)
+        started_raw = session.get("_session_started_at")
+        try:
+            started_epoch = int(datetime.fromisoformat(str(started_raw)).timestamp())
+        except (TypeError, ValueError):
+            started_epoch = now_epoch
+            session["_session_started_at"] = now.isoformat()
+        expiry_reason = (
+            "absolute"
+            if now_epoch - started_epoch > absolute_limit
+            else "idle"
+            if now_epoch - last_seen > idle_limit
+            else ""
+        )
+        if expiry_reason:
+            self._dependencies.security_event(
+                "session_expired",
+                reason=expiry_reason,
+                principal=self._principal_digest(user),
+            )
+            logout_user()
+            session.clear()
+            flash("Your secure session has expired. Sign in again.", "error")
+            return redirect(url_for("login"))
+
+        expected_stamp = session.get("_auth_stamp")
+        current_stamp = self.auth_stamp(user)
+        if expected_stamp and not secrets.compare_digest(
+            str(expected_stamp), current_stamp
+        ):
+            self._dependencies.security_event(
+                "session_forced_invalidation",
+                principal=self._principal_digest(user),
+            )
+            logout_user()
+            session.clear()
+            flash(
+                "Your account security or permissions changed. Sign in again.",
+                "error",
+            )
+            return redirect(url_for("login"))
+        session["_auth_stamp"] = current_stamp
+        session["_last_seen_epoch"] = now_epoch
+        return None
+
+    @staticmethod
+    def _principal_digest(user: Any) -> str:
+        return hashlib.sha256(str(user.get_id()).encode()).hexdigest()[:16]

--- a/atcroster/tenancy_hooks.py
+++ b/atcroster/tenancy_hooks.py
@@ -1,0 +1,82 @@
+"""Flask request hooks for verified tenant binding and guaranteed cleanup."""
+
+from __future__ import annotations
+
+import secrets
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from flask import Flask, abort, g, request
+
+
+@dataclass(frozen=True)
+class TenantHookDependencies:
+    deployment_environment: str
+    current_user: Callable[[], Any]
+    enforce_session: Callable[[Any], Any]
+    routing_for_unit: Callable[[int], Any | None]
+    clear_context: Callable[[], None]
+    bind_authenticated_unit: Callable[[int, str | None], Any]
+    reset_authenticated_unit: Callable[[Any], None]
+    bind_platform_control: Callable[[], Any]
+    reset_platform_control: Callable[[Any], None]
+
+
+def register_tenant_hooks(
+    app: Flask,
+    dependencies: TenantHookDependencies,
+) -> tuple[Callable[[], Any], Callable[[BaseException | None], None]]:
+    """Register request binding and teardown with explicit infrastructure edges."""
+
+    def bind_tenant_context():
+        dependencies.clear_context()
+        g.request_id = request.headers.get("X-Request-ID") or secrets.token_hex(12)
+        g.csp_nonce = secrets.token_urlsafe(18)
+        g.tenant_context_token = None
+        g.platform_control_token = None
+
+        user = dependencies.current_user()
+        session_response = dependencies.enforce_session(user)
+        if session_response is not None:
+            return session_response
+        if not user.is_authenticated:
+            return None
+        if getattr(user, "role", "") == "superadmin":
+            g.platform_control_token = dependencies.bind_platform_control()
+            return None
+
+        unit_id = int(getattr(user, "unit_id", 0) or 0)
+        if unit_id and g.tenant_context_token is None:
+            routing = dependencies.routing_for_unit(unit_id)
+            if dependencies.deployment_environment == "production" and not routing:
+                abort(503, "Operational database routing is unavailable.")
+            g.tenant_context_token = dependencies.bind_authenticated_unit(
+                unit_id,
+                routing.secret_name if routing else None,
+            )
+        return None
+
+    def reset_tenant_context(_error: BaseException | None = None) -> None:
+        token = getattr(g, "tenant_context_token", None)
+        g.tenant_context_token = None
+        if token is not None:
+            try:
+                dependencies.reset_authenticated_unit(token)
+            except RuntimeError:
+                # Flask test/request contexts may invoke teardown more than once.
+                pass
+        platform_token = getattr(g, "platform_control_token", None)
+        g.platform_control_token = None
+        if platform_token is not None:
+            try:
+                dependencies.reset_platform_control(platform_token)
+            except RuntimeError:
+                pass
+        dependencies.clear_context()
+
+    bind_tenant_context.__name__ = "_bind_tenant_context"
+    reset_tenant_context.__name__ = "_reset_tenant_context"
+    app.before_request(bind_tenant_context)
+    app.teardown_request(reset_tenant_context)
+    return bind_tenant_context, reset_tenant_context

--- a/docs/architecture/app-module-inventory.md
+++ b/docs/architecture/app-module-inventory.md
@@ -1,0 +1,150 @@
+# Application module inventory
+
+Baseline commit: `d7428da166e3943f94175e8ed65fc46e4abe1996`. Baseline `app.py`: **10,029 lines**. This inventory describes the compatibility boundary before incremental extraction. Automatic Flask `HEAD` and `OPTIONS` methods are omitted from the route contract because Flask derives them from explicit methods.
+
+## Responsibilities remaining in `app.py`
+
+| Responsibility | Current ownership and security boundary | Intended boundary |
+|---|---|---|
+| Application bootstrap and configuration | Flask creation, production config validation, extension wiring and blueprint registration | `atcroster/application.py` compatibility assembly |
+| Database initialisation and model aliases | Single SQLAlchemy instance, tenant-routed session, operational models and imported SaaS aliases | Existing extension plus explicit compatibility aliases; no duplicate models |
+| Tenant binding | Before/after request hooks, verified membership binding, ORM read/write tenant enforcement | `atcroster/tenancy/hooks.py` reusing `tenancy.py` context |
+| Authentication and sessions | Flask-Login loader, auth stamps, idle/absolute timeout and account/MFA invalidation | `atcroster/security/sessions.py` and existing auth blueprint |
+| CSRF | Session token creation and global default-deny unsafe-method hook | `atcroster/security/csrf.py` |
+| Headers and CSP | Nonce creation, CSP/HSTS/cache headers and metrics completion | `atcroster/security/headers.py` |
+| Error handling | 400/403/404/500 rendering, request IDs and security logging | `atcroster/errors/handlers.py` |
+| Public/legal | Favicon and privacy/cookie/terms/subprocessor pages | `atcroster/public/blueprint.py` |
+| Account administration | Unit accounts, invitations, recovery, role/MFA/session lifecycle | `atcroster/accounts/` service, policies and blueprint |
+| Platform administration | Tenant provisioning, platform MFA and worker status | `atcroster/platform/` reusing provisioning service |
+| Qualifications/compliance | Qualifications, medical/UE validity, warnings, reports and live-position eligibility | `atcroster/qualifications/` narrow status service |
+| Roster and publication | Roster rules, fatigue, publication transaction/snapshot and notification | Existing roster blueprint plus `atcroster/publication/` service |
+| Notifications | SMS/email delivery, notification records and audit | `atcroster/notifications/service.py` |
+| Audit helpers | Change, annotation, request and SMS audit creation | `atcroster/audit/service.py`; DB append-only controls remain central |
+| Reports and metrics | Operational metrics calculations and report entry routes | Existing report/operations blueprints and reporting service |
+| CLI and compatibility migrations | Seed/setup and legacy maintenance commands/functions | `atcroster/cli/commands.py`; Alembic remains authoritative |
+| Encryption | Versioned Fernet field encryption and startup key validation | `atcroster/security/encryption.py` service |
+| Background integration | Provisioning worker queue/health and external briefing storage | Existing services with explicit bootstrap dependencies |
+
+## Registered route compatibility inventory
+
+CSRF is enforced globally for every explicit unsafe method. Authentication and role entries state the governing boundary; individual service/policy checks remain authoritative. “JSON/redirect/response” means no statically discoverable template call in the registered view.
+
+| URL | Endpoint | Methods | Authentication | Role/permission | Tenant scope | CSRF | Template/response | Owner/dependencies |
+|---|---|---|---|---|---|---|---|---|
+| / | `index` | GET | Anonymous or token-bound | Public/token workflow policy | Verified active unit | Not applicable (safe method) | JSON/redirect/response | `app` + registered dependencies |
+| /__can | `__can` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | JSON/redirect/response | `app` + registered dependencies |
+| /admin | `admin` | GET, POST | Authenticated account | Admin/editor action policy | Verified active unit | Global default-deny | admin.html | `app` + registered dependencies |
+| /admin/change-log | `change_log_page` | GET | Authenticated account | Admin/editor action policy | Verified active unit | Not applicable (safe method) | change_log.html | `app` + registered dependencies |
+| /admin/fatigue-rules | `admin_fatigue_rules` | GET, POST | Authenticated account | Admin/editor action policy | Verified active unit | Global default-deny | admin_fatigue_rules.html | `app` + registered dependencies |
+| /admin/reference | `admin_reference` | GET, POST | Authenticated account | Admin/editor action policy | Verified active unit | Global default-deny | admin_reference.html | `app` + registered dependencies |
+| /admin/requests/<int:rid>/respond | `admin_request_respond` | POST | Authenticated account | Admin/editor action policy | Verified active unit | Global default-deny | JSON/redirect/response | `absence_requests_blueprint` + registered dependencies |
+| /admin/sms-audit | `admin_sms_audit` | GET | Authenticated account | Admin/editor action policy | Verified active unit | Not applicable (safe method) | admin_sms_audit.html | `app` + registered dependencies |
+| /admin/staff/<int:sid> | `admin_staff_edit` | GET, POST | Authenticated account | Admin/editor action policy | Verified active unit | Global default-deny | staff_edit.html | `app` + registered dependencies |
+| /admin/staff/<int:sid>/watch-move | `admin_watch_move` | POST | Authenticated account | Admin/editor action policy | Verified active unit | Global default-deny | JSON/redirect/response | `app` + registered dependencies |
+| /admin/staff/watch-move/<int:hid>/delete | `admin_watch_move_delete` | POST | Authenticated account | Admin/editor action policy | Verified active unit | Global default-deny | JSON/redirect/response | `app` + registered dependencies |
+| /admin/staff/watch-move/<int:hid>/edit | `admin_watch_move_edit` | POST | Authenticated account | Admin/editor action policy | Verified active unit | Global default-deny | JSON/redirect/response | `app` + registered dependencies |
+| /admin/toil/new | `admin_toil_new` | GET, POST | Authenticated account | Admin/editor action policy | Verified active unit | Global default-deny | admin_toil_new.html | `app` + registered dependencies |
+| /administration | `administration_home` | GET | Authenticated account | UnitAdmin/domain policy | Verified active unit | Not applicable (safe method) | administration_home.html | `app` + registered dependencies |
+| /administration/kiosk-accounts | `kiosk_accounts` | GET, POST | Authenticated account | UnitAdmin/domain policy | Verified active unit | Global default-deny | kiosk_accounts.html | `app` + registered dependencies |
+| /assign/<int:staff_id>/<ym>/<day> | `assign_cell` | POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `roster_blueprint` + registered dependencies |
+| /briefing/ | `briefing.home` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | briefing/home.html | `briefing_module` + registered dependencies |
+| /briefing/admin | `briefing.admin` | GET, POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | briefing/admin.html | `briefing_module` + registered dependencies |
+| /briefing/admin/<int:item_id>/publish | `briefing.publish` | POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `briefing_module` + registered dependencies |
+| /briefing/admin/<int:item_id>/withdraw | `briefing.withdraw` | POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `briefing_module` + registered dependencies |
+| /briefing/admin/assurance | `briefing.legacy_assurance` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | JSON/redirect/response | `briefing_module` + registered dependencies |
+| /briefing/admin/audit | `briefing.audit` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | briefing/audit.html | `briefing_module` + registered dependencies |
+| /briefing/admin/message-types/configure | `briefing.configure_message_types` | POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `briefing_module` + registered dependencies |
+| /briefing/admin/reports | `briefing.assurance` | GET, POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | briefing/assurance.html | `briefing_module` + registered dependencies |
+| /briefing/admin/reports/<int:run_id>/delete | `briefing.delete_assurance_report` | POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `briefing_module` + registered dependencies |
+| /briefing/admin/settings | `briefing.settings` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | briefing/settings.html | `briefing_module` + registered dependencies |
+| /briefing/archive | `briefing.archive` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | briefing/archive.html | `briefing_module` + registered dependencies |
+| /briefing/item/<int:item_id> | `briefing.view_item` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | briefing/item.html | `briefing_module` + registered dependencies |
+| /briefing/item/<int:item_id>/acknowledge | `briefing.acknowledge` | POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `briefing_module` + registered dependencies |
+| /briefing/item/<int:item_id>/archive | `briefing.archive_item` | POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `briefing_module` + registered dependencies |
+| /briefing/item/<int:item_id>/delete | `briefing.delete_item` | POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `briefing_module` + registered dependencies |
+| /briefing/item/<int:item_id>/document | `briefing.document` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | JSON/redirect/response | `briefing_module` + registered dependencies |
+| /briefing/item/<int:item_id>/heartbeat | `briefing.heartbeat` | POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `briefing_module` + registered dependencies |
+| /calendar/<int:sid>/<token>.ics | `calendar_feed` | GET | Anonymous or token-bound | Public/token workflow policy | Server-token resolved | Not applicable (safe method) | JSON/redirect/response | `app` + registered dependencies |
+| /competency/ | `competency_home` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | competency_home.html | `training_blueprint` + registered dependencies |
+| /competency/<int:sid> | `competency_profile` | GET, POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | competency_profile.html | `training_blueprint` + registered dependencies |
+| /compliance | `qualification_compliance` | GET, POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | qualification_compliance.html | `app` + registered dependencies |
+| /compliance-centre | `compliance_centre` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | JSON/redirect/response | `app` + registered dependencies |
+| /compliance-centre/export | `compliance_centre_export` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | JSON/redirect/response | `app` + registered dependencies |
+| /cookies | `cookie_notice` | GET | Anonymous or token-bound | Public/token workflow policy | Unbound/public | Not applicable (safe method) | cookies.html | `app` + registered dependencies |
+| /favicon.ico | `favicon` | GET | Anonymous or token-bound | Public/token workflow policy | Unbound/public | Not applicable (safe method) | static asset | `app` + registered dependencies |
+| /health/live | `health_live` | GET | Anonymous or token-bound | Public/token workflow policy | Unbound/public | Not applicable (safe method) | JSON/redirect/response | `production_operations` + registered dependencies |
+| /health/ready | `health_ready` | GET | Anonymous or token-bound | Public/token workflow policy | Unbound/public | Not applicable (safe method) | JSON/redirect/response | `production_operations` + registered dependencies |
+| /internal/health | `internal_health` | GET | Internal bearer token | Metrics token | Unbound/public | Not applicable (safe method) | JSON/redirect/response | `production_operations` + registered dependencies |
+| /internal/metrics | `internal_metrics` | GET | Internal bearer token | Metrics token | Unbound/public | Not applicable (safe method) | JSON/redirect/response | `production_operations` + registered dependencies |
+| /invite/<token> | `accept_invitation` | GET, POST | Anonymous or token-bound | Public/token workflow policy | Server-token resolved | Global default-deny | invitation_accept.html | `app` + registered dependencies |
+| /leave | `leave` | GET, POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | leave.html | `absence_requests_blueprint` + registered dependencies |
+| /live-positions/ | `live_position.admin_home` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | JSON/redirect/response | `live_position_blueprint` + registered dependencies |
+| /live-positions/admin/positions | `live_position.position_configuration` | GET, POST | Authenticated account | UnitAdmin/domain policy | Verified active unit | Global default-deny | live_position/position_configuration.html | `live_position_blueprint` + registered dependencies |
+| /live-positions/api/controllers | `live_position.controllers` | GET | Kiosk session or authorised user | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | JSON/redirect/response | `live_position_blueprint` + registered dependencies |
+| /live-positions/api/events | `live_position.live_events` | GET | Kiosk session or authorised user | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | JSON/redirect/response | `live_position_blueprint` + registered dependencies |
+| /live-positions/api/positions/<int:position_id>/close | `live_position.close_position` | POST | Kiosk session or authorised user | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `live_position_blueprint` + registered dependencies |
+| /live-positions/api/positions/<int:position_id>/handover | `live_position.handover` | POST | Kiosk session or authorised user | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `live_position_blueprint` + registered dependencies |
+| /live-positions/api/positions/<int:position_id>/logoff | `live_position.logoff` | POST | Kiosk session or authorised user | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `live_position_blueprint` + registered dependencies |
+| /live-positions/api/positions/<int:position_id>/logon | `live_position.logon` | POST | Kiosk session or authorised user | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `live_position_blueprint` + registered dependencies |
+| /live-positions/api/positions/<int:position_id>/open | `live_position.open_position` | POST | Kiosk session or authorised user | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `live_position_blueprint` + registered dependencies |
+| /live-positions/api/positions/<int:position_id>/participants | `live_position.add_participant` | POST | Kiosk session or authorised user | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `live_position_blueprint` + registered dependencies |
+| /live-positions/api/positions/<int:position_id>/participants/<int:participant_id>/logoff | `live_position.remove_participant` | POST | Kiosk session or authorised user | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `live_position_blueprint` + registered dependencies |
+| /live-positions/api/state | `live_position.live_state` | GET | Kiosk session or authorised user | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | JSON/redirect/response | `live_position_blueprint` + registered dependencies |
+| /live-positions/kiosk | `live_position.kiosk_hmi` | GET | Kiosk session or authorised user | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | live_position/kiosk.html | `live_position_blueprint` + registered dependencies |
+| /live-positions/reports/operational-activity | `live_position.operational_activity` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | live_position/operational_activity_report.html | `live_position_blueprint` + registered dependencies |
+| /login | `login` | GET, POST | Anonymous or token-bound | Public/token workflow policy | Unbound/public | Global default-deny | login.html | `auth_blueprint` + registered dependencies |
+| /login/mfa | `mfa_challenge` | GET, POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | mfa_challenge.html | `app` + registered dependencies |
+| /login/platform-mfa | `platform_mfa_challenge` | GET, POST | Platform identity + MFA | Endpoint/domain permission | Control DB/platform | Global default-deny | mfa_challenge.html | `app` + registered dependencies |
+| /login/platform-mfa/setup | `platform_mfa_setup` | GET, POST | Platform identity + MFA | Endpoint/domain permission | Control DB/platform | Global default-deny | mfa_setup.html | `app` + registered dependencies |
+| /logout | `logout` | POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `auth_blueprint` + registered dependencies |
+| /messages | `unit_messages` | GET, POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | messages.html | `app` + registered dependencies |
+| /metrics | `metrics` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | metrics.html | `reports_blueprint` + registered dependencies |
+| /metrics/export | `metrics_export` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | JSON/redirect/response | `reports_blueprint` + registered dependencies |
+| /modules | `module_home` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | module_home.html | `app` + registered dependencies |
+| /notifications/<int:notification_id>/delete | `notification_delete` | POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `app` + registered dependencies |
+| /notifications/<int:notification_id>/read | `notification_read` | POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `app` + registered dependencies |
+| /notifications/read | `notifications_read` | POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `app` + registered dependencies |
+| /operations/<ym> | `operations_assurance` | GET, POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | operations_assurance.html | `operations_blueprint` + registered dependencies |
+| /overtime | `overtime` | GET, POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | overtime.html | `app` + registered dependencies |
+| /password | `password_change` | GET, POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | password.html | `app` + registered dependencies |
+| /planning/coverage/<ym> | `coverage_heatmap` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | coverage_heatmap.html | `operations_blueprint` + registered dependencies |
+| /planning/scenarios | `scenarios_page` | GET, POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | scenarios.html | `operations_blueprint` + registered dependencies |
+| /platform/admin | `platform_admin` | GET, POST | Platform identity + MFA | SuperAdmin/platform policy | Control DB/platform | Global default-deny | platform_admin.html | `app` + registered dependencies |
+| /platform/worker-health | `platform_worker_health` | GET | Platform identity + MFA | SuperAdmin/platform policy | Control DB/platform | Not applicable (safe method) | JSON/redirect/response | `app` + registered dependencies |
+| /privacy | `privacy_notice` | GET | Anonymous or token-bound | Public/token workflow policy | Unbound/public | Not applicable (safe method) | privacy.html | `app` + registered dependencies |
+| /recover | `account_recovery` | GET, POST | Anonymous or token-bound | Public/token workflow policy | Unbound/public | Global default-deny | account_recovery.html | `app` + registered dependencies |
+| /recover/approve/<token> | `approve_account_recovery` | GET, POST | Anonymous or token-bound | Public/token workflow policy | Server-token resolved | Global default-deny | recovery_approve.html | `app` + registered dependencies |
+| /recover/reset/<token> | `complete_account_recovery` | GET, POST | Anonymous or token-bound | Public/token workflow policy | Server-token resolved | Global default-deny | recovery_reset.html | `app` + registered dependencies |
+| /reports | `reports_index` | GET, POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | reports_index.html | `reports_blueprint` + registered dependencies |
+| /reports/leave-year | `report_leave_year` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | report_leave_year.html | `reports_blueprint` + registered dependencies |
+| /reports/leave.csv | `report_leave_csv` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | JSON/redirect/response | `reports_blueprint` + registered dependencies |
+| /reports/leave/<ym> | `report_leave` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | report_leave.html | `reports_blueprint` + registered dependencies |
+| /reports/sickness | `report_sickness` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | report_sickness.html | `reports_blueprint` + registered dependencies |
+| /requests | `requests_page` | GET, POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | requests.html | `absence_requests_blueprint` + registered dependencies |
+| /roster/<ym> | `roster_month` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | roster_month.html | `roster_blueprint` + registered dependencies |
+| /roster/<ym>/export | `roster_export_csv` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | JSON/redirect/response | `roster_blueprint` + registered dependencies |
+| /roster/<ym>/print | `roster_print_view` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | JSON/redirect/response | `roster_blueprint` + registered dependencies |
+| /roster/<ym>/publish | `roster_month_publish` | POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `roster_blueprint` + registered dependencies |
+| /roster/<ym>/unpublish | `roster_month_unpublish` | POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `roster_blueprint` + registered dependencies |
+| /security/mfa | `mfa_setup` | GET, POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | mfa_setup.html | `app` + registered dependencies |
+| /staff/<int:sid> | `staff_profile` | GET, POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | staff_profile.html | `app` + registered dependencies |
+| /staff/<int:sid>/calendar-token | `calendar_token_create` | POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | JSON/redirect/response | `app` + registered dependencies |
+| /static/<path:filename> | `static` | GET | Anonymous or token-bound | Public/token workflow policy | Unbound/public | Not applicable (safe method) | JSON/redirect/response | `flask.app` + registered dependencies |
+| /subprocessors | `subprocessor_notice` | GET | Anonymous or token-bound | Public/token workflow policy | Unbound/public | Not applicable (safe method) | subprocessors.html | `app` + registered dependencies |
+| /terms | `terms_of_service` | GET | Anonymous or token-bound | Public/token workflow policy | Unbound/public | Not applicable (safe method) | terms.html | `app` + registered dependencies |
+| /training/ | `training_home` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | training_home.html | `training_blueprint` + registered dependencies |
+| /training/<int:sid> | `training_profile` | GET, POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | training_profile.html | `training_blueprint` + registered dependencies |
+| /training/admin | `training_admin` | GET, POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | training_admin.html | `training_blueprint` + registered dependencies |
+| /training/analytics | `training_analytics` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | training_analytics.html | `training_blueprint` + registered dependencies |
+| /unit/accounts | `unit_accounts` | GET, POST | Authenticated account | UnitAdmin/domain policy | Verified active unit | Global default-deny | unit_accounts.html | `app` + registered dependencies |
+| /unit/onboarding | `unit_onboarding` | GET, POST | Authenticated account | UnitAdmin/domain policy | Verified active unit | Global default-deny | unit_onboarding.html | `app` + registered dependencies |
+
+## Extraction constraints
+
+- `app`, `db`, `login_manager`, model classes and `wsgi:application` remain singletons/compatibility exports.
+- Blueprint endpoint names are contractual and covered by `tests/fixtures/route_map.json`.
+- Tenant context must be empty before public work and cleared after every response or exception.
+- Global unsafe-method CSRF and post-response security headers remain centrally registered until their explicit extraction commits.
+- No domain extraction may bypass existing policy helpers, tenant-scoped queries, audit writes or transaction boundaries.
+
+

--- a/docs/architecture/application-bootstrap.md
+++ b/docs/architecture/application-bootstrap.md
@@ -1,0 +1,41 @@
+# Application bootstrap
+
+## Current entry points
+
+`wsgi:application` remains the production entry point and is the same Flask
+object exported as `app.app`. `atcroster.create_app()` remains the only
+application factory. The refactor has not created a second SQLAlchemy,
+Flask-Login, cache, or metrics instance.
+
+`app.py` still assembles extensions, models, domain blueprints and legacy route
+registrations. Extracted framework concerns are registered explicitly:
+
+1. security headers and response completion;
+2. CSRF protection;
+3. public/legal routes;
+4. error handlers;
+5. authenticated session lifecycle; and
+6. tenant request binding and teardown.
+
+Compatibility aliases remain in `app.py` for `_security_headers`,
+`_validate_csrf`, `_enforce_csrf`, `_field_ciphers`, `_encrypt_field`,
+`_decrypt_field`, `_current_auth_stamp`, `_initialize_authenticated_session`,
+`_bind_tenant_context`, `_reset_tenant_context`, and the four error handlers.
+They prevent existing blueprints, tests and operational tools from importing a
+new internal location during this incremental phase.
+
+## Registration order
+
+Request metrics begin before CSRF and identity work. CSRF remains global and
+default-deny for unsafe browser methods. Flask-Login resolves the signed
+principal before session revocation and tenant binding. Principal-specific
+SuperAdmin, kiosk and MFA restrictions run after the verified context is bound.
+Tenant context is cleared again during teardown, including after exceptions.
+
+## Next bootstrap step
+
+Do not move extension creation until operational models and the tenant-routed
+SQLAlchemy session have a stable package boundary. After the account,
+qualification, publication and CLI domains are extracted, introduce
+`atcroster/application.py` as assembly code and retain `app.py` as the
+compatibility export for `app` and model aliases.

--- a/docs/architecture/refactor-progress.md
+++ b/docs/architecture/refactor-progress.md
@@ -1,0 +1,61 @@
+# Incremental `app.py` refactor progress
+
+## Baseline
+
+- Branch: `agent/modularise-app-incrementally`
+- Starting commit: `d7428da166e3943f94175e8ed65fc46e4abe1996`
+- Starting `app.py`: 10,029 lines
+- Baseline tests: 264 passed, 11 skipped
+- Baseline coverage: 71.50%
+- Route snapshot: 107 routes
+
+## Extracted domains
+
+| Domain | New owner |
+|---|---|
+| Route compatibility contract | `tests/fixtures/route_map.json` and `tests/test_route_map_contract.py` |
+| Security headers/CSP | `atcroster/security/headers.py` |
+| Error handlers | `atcroster/errors.py` |
+| Public/legal pages | `atcroster/public/blueprint.py` |
+| CSRF | `atcroster/security/csrf.py` |
+| Field encryption | `atcroster/security/encryption.py` |
+| Session lifecycle | `atcroster/security/sessions.py` |
+| Tenant request hooks | `atcroster/tenancy_hooks.py` |
+
+## Safe stopping boundary
+
+Framework and cross-cutting security concerns are extracted and independently
+tested. `app.py` is still substantially above the target because the next
+sections are multi-model business transactions. The first is `/unit/accounts`,
+which coordinates the control database, an airport database, invitations,
+capacity enforcement, audit/session revocation and compensating cleanup.
+Moving it as a bulk route would increase production risk, so this branch stops
+before that transaction and remains deployable at every commit.
+
+## Remaining domains, in recommended order
+
+1. Account service and policies, then account routes and recovery/MFA routes.
+2. Qualification status service and compliance blueprint, retaining the narrow
+   live-position eligibility interface.
+3. Roster publication transaction and immutable snapshot service.
+4. Standardised audit creation helpers with rollback tests.
+5. CLI command registration and CLI runner contract tests.
+6. Application assembly and extension/model compatibility aliases.
+7. Roster, fatigue, notification and remaining reporting business services.
+
+## Temporary compatibility and import state
+
+Compatibility aliases are listed in `application-bootstrap.md`. There are no
+wildcard imports, runtime monkey patches or duplicate model/extension objects.
+The dependency callbacks used by extracted hooks are deliberate late-bound
+edges to model-backed services still defined in `app.py`; they avoid circular
+imports while preserving startup order. A clean-process import test detects new
+circular-import failures.
+
+The main residual circular-dependency risk is the high number of model and
+helper globals still consumed when existing blueprints are registered near the
+end of `app.py`. In particular, `briefing_module` imports `db` and `utcnow`
+from `app`, so importing that module before the canonical `wsgi -> app` startup
+order fails. The clean-process test verifies every module in production startup
+order and records this direct-import limitation. Future domain extractions
+should replace these edges with small, domain-specific dependency objects.

--- a/docs/architecture/refactor-progress.md
+++ b/docs/architecture/refactor-progress.md
@@ -32,6 +32,24 @@ capacity enforcement, audit/session revocation and compensating cleanup.
 Moving it as a bulk route would increase production risk, so this branch stops
 before that transaction and remains deployable at every commit.
 
+At this boundary `app.py` is 9,670 lines (359 fewer than baseline). Five
+public route functions have moved, 29 test functions were added, and the final
+local suite reports 296 passed, 11 skipped and 72.02% coverage.
+
+## Verification at this boundary
+
+- Route snapshot: unchanged, 107 routes.
+- Ruff: passed for every tracked Python file.
+- Mypy: passed for the configured typed scope and all new package modules.
+- Bandit Medium/High gate: passed.
+- Compileall: passed.
+- Container build: passed.
+- Migration and backup unit/fixture tests: 22 passed.
+- PostgreSQL/Redis integration: 10 passed; the backup/restore integration case
+  reached `pg_dump` but could not run locally because the host client is version
+  14 while the isolated PostgreSQL server is version 16. Exact-commit CI must
+  verify that remaining case with its matching client tools.
+
 ## Remaining domains, in recommended order
 
 1. Account service and policies, then account routes and recovery/MFA routes.

--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -1,0 +1,27 @@
+# Security boundaries
+
+## Extracted controls
+
+| Control | Owner | Preserved behaviour |
+|---|---|---|
+| CSP and headers | `atcroster/security/headers.py` | Nonces, CSP directives, HSTS, authenticated no-store, request IDs and metrics completion |
+| CSRF | `atcroster/security/csrf.py` | Session token, form/header input, constant-time comparison and global unsafe-method enforcement |
+| Field encryption | `atcroster/security/encryption.py` | Current-key encryption, version-specific rotation, legacy unversioned decrypt and startup validation |
+| Sessions | `atcroster/security/sessions.py` | Idle/absolute expiry, auth stamps, password/role/membership/MFA revocation and secure initialization |
+| Errors | `atcroster/errors.py` | Safe 400/403/404/500 responses, request IDs and security-event logging |
+
+No route is exempt from browser CSRF protection. Plaintext field values are not
+cached or logged. Versioned encrypted fields use the first configured key for
+new ciphertext and matching older keys for rotation. Unversioned legacy
+ciphertext tries the configured ring without changing storage.
+
+Session stamps bind password hash, role, membership state and MFA state. A
+change invalidates already-issued browser sessions. A user rejected by the
+Flask-Login loader has the stale signed session cleared immediately.
+
+## Residual boundary
+
+Role/MFA/kiosk endpoint restrictions and the Flask-Login user loader remain in
+`app.py` because they depend on operational and control-plane models. Account
+recovery and MFA HTTP workflows also remain there. Their next extraction must
+retain central-versus-operational database ordering and session invalidation.

--- a/docs/architecture/tenant-request-lifecycle.md
+++ b/docs/architecture/tenant-request-lifecycle.md
@@ -1,0 +1,29 @@
+# Tenant request lifecycle
+
+The browser never supplies the authoritative airport ID. Flask-Login resolves
+an active `UnitMembership`, and only its server-verified `unit_id` is passed to
+`atcroster/tenancy_hooks.py`.
+
+For every request the hook:
+
+1. clears all context variables;
+2. creates the request ID and CSP nonce;
+3. rejects expired or auth-stamp-invalid sessions;
+4. binds a normal account to its verified airport and configured database
+   route; or
+5. binds a SuperAdmin to platform control, which explicitly forbids routine
+   operational database access.
+
+Anonymous and public routes stay unbound. In production, a verified airport
+without routing metadata fails closed with HTTP 503. The separate principal
+boundary in `app.py` continues to restrict SuperAdmin, kiosk and MFA setup
+routes after binding.
+
+Teardown resets the airport and platform-control tokens and forcibly clears the
+context variables. It runs for normal responses, redirects and exceptions.
+Background work must continue to use `operational_unit_context()` and therefore
+cannot inherit an HTTP request's stale tenant.
+
+The direct hook tests cover anonymous requests, verified airport binding,
+SuperAdmin isolation and cleanup after exceptions. Existing physical database
+tests cover airport-to-airport isolation.

--- a/tests/fixtures/route_map.json
+++ b/tests/fixtures/route_map.json
@@ -1,0 +1,786 @@
+[
+  {
+    "endpoint": "index",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/"
+  },
+  {
+    "endpoint": "__can",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/__can"
+  },
+  {
+    "endpoint": "admin",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/admin"
+  },
+  {
+    "endpoint": "change_log_page",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/admin/change-log"
+  },
+  {
+    "endpoint": "admin_fatigue_rules",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/admin/fatigue-rules"
+  },
+  {
+    "endpoint": "admin_reference",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/admin/reference"
+  },
+  {
+    "endpoint": "admin_request_respond",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/admin/requests/<int:rid>/respond"
+  },
+  {
+    "endpoint": "admin_sms_audit",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/admin/sms-audit"
+  },
+  {
+    "endpoint": "admin_staff_edit",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/admin/staff/<int:sid>"
+  },
+  {
+    "endpoint": "admin_watch_move",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/admin/staff/<int:sid>/watch-move"
+  },
+  {
+    "endpoint": "admin_watch_move_delete",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/admin/staff/watch-move/<int:hid>/delete"
+  },
+  {
+    "endpoint": "admin_watch_move_edit",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/admin/staff/watch-move/<int:hid>/edit"
+  },
+  {
+    "endpoint": "admin_toil_new",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/admin/toil/new"
+  },
+  {
+    "endpoint": "administration_home",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/administration"
+  },
+  {
+    "endpoint": "kiosk_accounts",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/administration/kiosk-accounts"
+  },
+  {
+    "endpoint": "assign_cell",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/assign/<int:staff_id>/<ym>/<day>"
+  },
+  {
+    "endpoint": "briefing.home",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/briefing/"
+  },
+  {
+    "endpoint": "briefing.admin",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/briefing/admin"
+  },
+  {
+    "endpoint": "briefing.publish",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/briefing/admin/<int:item_id>/publish"
+  },
+  {
+    "endpoint": "briefing.withdraw",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/briefing/admin/<int:item_id>/withdraw"
+  },
+  {
+    "endpoint": "briefing.legacy_assurance",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/briefing/admin/assurance"
+  },
+  {
+    "endpoint": "briefing.audit",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/briefing/admin/audit"
+  },
+  {
+    "endpoint": "briefing.configure_message_types",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/briefing/admin/message-types/configure"
+  },
+  {
+    "endpoint": "briefing.assurance",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/briefing/admin/reports"
+  },
+  {
+    "endpoint": "briefing.delete_assurance_report",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/briefing/admin/reports/<int:run_id>/delete"
+  },
+  {
+    "endpoint": "briefing.settings",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/briefing/admin/settings"
+  },
+  {
+    "endpoint": "briefing.archive",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/briefing/archive"
+  },
+  {
+    "endpoint": "briefing.view_item",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/briefing/item/<int:item_id>"
+  },
+  {
+    "endpoint": "briefing.acknowledge",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/briefing/item/<int:item_id>/acknowledge"
+  },
+  {
+    "endpoint": "briefing.archive_item",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/briefing/item/<int:item_id>/archive"
+  },
+  {
+    "endpoint": "briefing.delete_item",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/briefing/item/<int:item_id>/delete"
+  },
+  {
+    "endpoint": "briefing.document",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/briefing/item/<int:item_id>/document"
+  },
+  {
+    "endpoint": "briefing.heartbeat",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/briefing/item/<int:item_id>/heartbeat"
+  },
+  {
+    "endpoint": "calendar_feed",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/calendar/<int:sid>/<token>.ics"
+  },
+  {
+    "endpoint": "competency_home",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/competency/"
+  },
+  {
+    "endpoint": "competency_profile",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/competency/<int:sid>"
+  },
+  {
+    "endpoint": "qualification_compliance",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/compliance"
+  },
+  {
+    "endpoint": "compliance_centre",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/compliance-centre"
+  },
+  {
+    "endpoint": "compliance_centre_export",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/compliance-centre/export"
+  },
+  {
+    "endpoint": "cookie_notice",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/cookies"
+  },
+  {
+    "endpoint": "favicon",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/favicon.ico"
+  },
+  {
+    "endpoint": "health_live",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/health/live"
+  },
+  {
+    "endpoint": "health_ready",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/health/ready"
+  },
+  {
+    "endpoint": "internal_health",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/internal/health"
+  },
+  {
+    "endpoint": "internal_metrics",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/internal/metrics"
+  },
+  {
+    "endpoint": "accept_invitation",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/invite/<token>"
+  },
+  {
+    "endpoint": "leave",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/leave"
+  },
+  {
+    "endpoint": "live_position.admin_home",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/live-positions/"
+  },
+  {
+    "endpoint": "live_position.position_configuration",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/live-positions/admin/positions"
+  },
+  {
+    "endpoint": "live_position.controllers",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/live-positions/api/controllers"
+  },
+  {
+    "endpoint": "live_position.live_events",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/live-positions/api/events"
+  },
+  {
+    "endpoint": "live_position.close_position",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/live-positions/api/positions/<int:position_id>/close"
+  },
+  {
+    "endpoint": "live_position.handover",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/live-positions/api/positions/<int:position_id>/handover"
+  },
+  {
+    "endpoint": "live_position.logoff",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/live-positions/api/positions/<int:position_id>/logoff"
+  },
+  {
+    "endpoint": "live_position.logon",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/live-positions/api/positions/<int:position_id>/logon"
+  },
+  {
+    "endpoint": "live_position.open_position",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/live-positions/api/positions/<int:position_id>/open"
+  },
+  {
+    "endpoint": "live_position.add_participant",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/live-positions/api/positions/<int:position_id>/participants"
+  },
+  {
+    "endpoint": "live_position.remove_participant",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/live-positions/api/positions/<int:position_id>/participants/<int:participant_id>/logoff"
+  },
+  {
+    "endpoint": "live_position.live_state",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/live-positions/api/state"
+  },
+  {
+    "endpoint": "live_position.kiosk_hmi",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/live-positions/kiosk"
+  },
+  {
+    "endpoint": "live_position.operational_activity",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/live-positions/reports/operational-activity"
+  },
+  {
+    "endpoint": "login",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/login"
+  },
+  {
+    "endpoint": "mfa_challenge",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/login/mfa"
+  },
+  {
+    "endpoint": "platform_mfa_challenge",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/login/platform-mfa"
+  },
+  {
+    "endpoint": "platform_mfa_setup",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/login/platform-mfa/setup"
+  },
+  {
+    "endpoint": "logout",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/logout"
+  },
+  {
+    "endpoint": "unit_messages",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/messages"
+  },
+  {
+    "endpoint": "metrics",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/metrics"
+  },
+  {
+    "endpoint": "metrics_export",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/metrics/export"
+  },
+  {
+    "endpoint": "module_home",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/modules"
+  },
+  {
+    "endpoint": "notification_delete",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/notifications/<int:notification_id>/delete"
+  },
+  {
+    "endpoint": "notification_read",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/notifications/<int:notification_id>/read"
+  },
+  {
+    "endpoint": "notifications_read",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/notifications/read"
+  },
+  {
+    "endpoint": "operations_assurance",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/operations/<ym>"
+  },
+  {
+    "endpoint": "overtime",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/overtime"
+  },
+  {
+    "endpoint": "password_change",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/password"
+  },
+  {
+    "endpoint": "coverage_heatmap",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/planning/coverage/<ym>"
+  },
+  {
+    "endpoint": "scenarios_page",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/planning/scenarios"
+  },
+  {
+    "endpoint": "platform_admin",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/platform/admin"
+  },
+  {
+    "endpoint": "platform_worker_health",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/platform/worker-health"
+  },
+  {
+    "endpoint": "privacy_notice",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/privacy"
+  },
+  {
+    "endpoint": "account_recovery",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/recover"
+  },
+  {
+    "endpoint": "approve_account_recovery",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/recover/approve/<token>"
+  },
+  {
+    "endpoint": "complete_account_recovery",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/recover/reset/<token>"
+  },
+  {
+    "endpoint": "reports_index",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/reports"
+  },
+  {
+    "endpoint": "report_leave_year",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/reports/leave-year"
+  },
+  {
+    "endpoint": "report_leave_csv",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/reports/leave.csv"
+  },
+  {
+    "endpoint": "report_leave",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/reports/leave/<ym>"
+  },
+  {
+    "endpoint": "report_sickness",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/reports/sickness"
+  },
+  {
+    "endpoint": "requests_page",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/requests"
+  },
+  {
+    "endpoint": "roster_month",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/roster/<ym>"
+  },
+  {
+    "endpoint": "roster_export_csv",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/roster/<ym>/export"
+  },
+  {
+    "endpoint": "roster_print_view",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/roster/<ym>/print"
+  },
+  {
+    "endpoint": "roster_month_publish",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/roster/<ym>/publish"
+  },
+  {
+    "endpoint": "roster_month_unpublish",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/roster/<ym>/unpublish"
+  },
+  {
+    "endpoint": "mfa_setup",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/security/mfa"
+  },
+  {
+    "endpoint": "staff_profile",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/staff/<int:sid>"
+  },
+  {
+    "endpoint": "calendar_token_create",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/staff/<int:sid>/calendar-token"
+  },
+  {
+    "endpoint": "static",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/static/<path:filename>"
+  },
+  {
+    "endpoint": "subprocessor_notice",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/subprocessors"
+  },
+  {
+    "endpoint": "terms_of_service",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/terms"
+  },
+  {
+    "endpoint": "training_home",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/training/"
+  },
+  {
+    "endpoint": "training_profile",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/training/<int:sid>"
+  },
+  {
+    "endpoint": "training_admin",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/training/admin"
+  },
+  {
+    "endpoint": "training_analytics",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/training/analytics"
+  },
+  {
+    "endpoint": "unit_accounts",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/unit/accounts"
+  },
+  {
+    "endpoint": "unit_onboarding",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/unit/onboarding"
+  }
+]
+

--- a/tests/test_csrf_security.py
+++ b/tests/test_csrf_security.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from flask import Flask
+
+import app as application_module
+from atcroster.security.csrf import UNSAFE_METHODS, register_csrf_protection
+
+
+def csrf_application() -> Flask:
+    application = Flask(__name__)
+    application.secret_key = "isolated-csrf-tests"
+    register_csrf_protection(application)
+
+    @application.get("/token")
+    def token():
+        return application.jinja_env.globals["csrf_token"]()
+
+    @application.post("/form")
+    def form_mutation():
+        return "accepted"
+
+    @application.patch("/header")
+    def header_mutation():
+        return "accepted"
+
+    return application
+
+
+def test_token_is_stable_within_session_and_form_token_is_accepted():
+    client = csrf_application().test_client()
+    token = client.get("/token").get_data(as_text=True)
+    assert token
+    assert client.get("/token").get_data(as_text=True) == token
+    assert client.post("/form", data={"_csrf_token": token}).status_code == 200
+
+
+def test_header_token_is_accepted_and_missing_or_invalid_tokens_are_rejected():
+    client = csrf_application().test_client()
+    token = client.get("/token").get_data(as_text=True)
+    assert client.patch(
+        "/header", headers={"X-CSRF-Token": token}
+    ).status_code == 200
+    assert client.post("/form").status_code == 400
+    assert client.post("/form", data={"_csrf_token": "wrong"}).status_code == 400
+
+
+def test_every_registered_unsafe_browser_route_uses_the_global_hook():
+    unsafe_endpoints = {
+        rule.endpoint
+        for rule in application_module.app.url_map.iter_rules()
+        if set(rule.methods or ()) & UNSAFE_METHODS
+    }
+    hooks = application_module.app.before_request_funcs.get(None, ())
+
+    assert unsafe_endpoints
+    assert application_module._enforce_csrf in hooks
+    assert not hasattr(application_module._enforce_csrf, "exempt_endpoints")

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from flask import Flask, abort, g
+from flask_login import LoginManager, UserMixin, login_user
+from jinja2 import DictLoader
+from werkzeug.exceptions import BadRequest
+
+from atcroster.errors import ErrorHandlerDependencies, register_error_handlers
+
+
+class PlatformUser(UserMixin):
+    id = 17
+    unit_id = None
+    role = "superadmin"
+
+
+def error_application() -> tuple[Flask, list[tuple[str, dict[str, object]]]]:
+    application = Flask(__name__)
+    application.secret_key = "isolated-error-handler-tests"
+    application.config.update(TESTING=True, PROPAGATE_EXCEPTIONS=False)
+    application.jinja_loader = DictLoader(
+        {
+            "error.html": (
+                "{{ status_code }}|{{ error_title }}|{{ error_message }}|"
+                "{{ request_id }}|{{ home_url }}|{{ home_label }}"
+            )
+        }
+    )
+    manager = LoginManager(application)
+    platform_user = PlatformUser()
+
+    @manager.user_loader
+    def load_user(user_id):
+        return platform_user if user_id == str(platform_user.id) else None
+
+    @application.before_request
+    def request_context():
+        g.request_id = "request-errors"
+
+    @application.get("/", endpoint="index")
+    def index():
+        return "index"
+
+    @application.get("/platform/admin", endpoint="platform_admin")
+    def platform_admin():
+        return "platform"
+
+    @application.get("/briefing", endpoint="briefing.home")
+    def briefing_home():
+        return "briefing"
+
+    @application.get("/training", endpoint="training_home")
+    def training_home():
+        return "training"
+
+    @application.get("/competency", endpoint="competency_home")
+    def competency_home():
+        return "competency"
+
+    @application.get("/csrf")
+    def csrf_failure():
+        raise BadRequest("Invalid CSRF token.")
+
+    @application.get("/generic-bad")
+    def generic_bad_request():
+        abort(400)
+
+    @application.get("/denied")
+    def denied():
+        abort(403)
+
+    @application.get("/platform-denied")
+    def platform_denied():
+        login_user(platform_user)
+        abort(403)
+
+    @application.get("/explode")
+    def explode():
+        raise RuntimeError("expected test failure")
+
+    events: list[tuple[str, dict[str, object]]] = []
+    register_error_handlers(
+        application,
+        ErrorHandlerDependencies(
+            security_event=lambda event, **facts: events.append((event, facts))
+        ),
+    )
+    return application, events
+
+
+def test_csrf_400_preserves_message_request_id_and_security_event():
+    application, events = error_application()
+    response = application.test_client().get("/csrf")
+    assert response.status_code == 400
+    assert b"This page or form has expired" in response.data
+    assert b"request-errors" in response.data
+    assert events == [("csrf_rejected", {"route": "csrf_failure"})]
+
+
+def test_generic_400_preserves_safe_user_message():
+    application, _events = error_application()
+    response = application.test_client().get("/generic-bad")
+    assert response.status_code == 400
+    assert b"The request was not valid" in response.data
+
+
+def test_403_records_event_and_preserves_platform_admin_navigation():
+    application, events = error_application()
+    response = application.test_client().get("/platform-denied")
+    assert response.status_code == 403
+    assert b"Platform administrators cannot access airport" in response.data
+    assert b"/platform/admin" in response.data
+    assert events == [
+        (
+            "forbidden_role_action",
+            {
+                "route": "platform_denied",
+                "unit_id": None,
+                "actor_id": 17,
+            },
+        )
+    ]
+
+
+def test_404_preserves_module_navigation_and_request_id():
+    application, _events = error_application()
+    response = application.test_client().get("/briefing/missing")
+    assert response.status_code == 404
+    assert b"That page or record was not found" in response.data
+    assert b"/briefing" in response.data
+    assert b"Return to briefing" in response.data
+    assert b"request-errors" in response.data
+
+
+def test_500_preserves_request_id_and_logs_failure(caplog):
+    application, _events = error_application()
+    response = application.test_client().get("/explode")
+    assert response.status_code == 500
+    assert b"request-errors" in response.data
+    assert "unhandled_request_error request_id=request-errors" in caplog.text

--- a/tests/test_field_encryption.py
+++ b/tests/test_field_encryption.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+from cryptography.fernet import Fernet
+
+from atcroster.security.encryption import FieldEncryptionService
+
+
+def test_current_key_encrypts_with_version_and_decrypts():
+    key = Fernet.generate_key().decode()
+    service = FieldEncryptionService(f"v2:{key}")
+
+    encrypted = service.encrypt("sensitive-value")
+
+    assert encrypted.startswith("v2.")
+    assert service.decrypt(encrypted) == "sensitive-value"
+    assert "sensitive-value" not in encrypted
+
+
+def test_previous_key_decrypts_during_rotation():
+    current_key = Fernet.generate_key().decode()
+    previous_key = Fernet.generate_key().decode()
+    previous_cipher = Fernet(previous_key.encode())
+    old_value = "v1." + previous_cipher.encrypt(b"old-secret").decode()
+    service = FieldEncryptionService(f"v2:{current_key},v1:{previous_key}")
+
+    assert service.decrypt(old_value) == "old-secret"
+    assert service.encrypt("new-secret").startswith("v2.")
+
+
+def test_legacy_unversioned_ciphertext_tries_each_configured_key():
+    current_key = Fernet.generate_key().decode()
+    previous_key = Fernet.generate_key().decode()
+    legacy_value = Fernet(previous_key.encode()).encrypt(b"legacy-secret").decode()
+    service = FieldEncryptionService(f"v2:{current_key},v1:{previous_key}")
+
+    assert service.decrypt(legacy_value) == "legacy-secret"
+
+
+@pytest.mark.parametrize(
+    ("serialized_keys", "message"),
+    [
+        ("missing-separator", "Invalid field-encryption key version"),
+        ("invalid version!:material", "Invalid field-encryption key version"),
+        ("v1:not-a-fernet-key", "Invalid field-encryption key material"),
+        ("", "Invalid field-encryption key version"),
+    ],
+)
+def test_invalid_key_configuration_is_rejected(serialized_keys, message):
+    with pytest.raises(RuntimeError, match=message):
+        FieldEncryptionService(serialized_keys)
+
+
+def test_invalid_ciphertext_and_missing_version_are_rejected():
+    key = Fernet.generate_key().decode()
+    service = FieldEncryptionService(f"v2:{key}")
+
+    with pytest.raises(ValueError, match="cannot be decrypted"):
+        service.decrypt("v2.invalid-ciphertext")
+    with pytest.raises(ValueError, match="cannot be decrypted"):
+        service.decrypt("v1.invalid-ciphertext")

--- a/tests/test_import_sanity.py
+++ b/tests/test_import_sanity.py
@@ -1,0 +1,48 @@
+"""Detect circular imports and import-time bootstrap regressions."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_application_modules_import_in_clean_process():
+    root_modules = sorted(
+        path.stem
+        for path in ROOT.glob("*.py")
+        if path.stem not in {"app", "wsgi"}
+    )
+    import_script = f"""
+import importlib
+import pkgutil
+import atcroster
+
+modules = {root_modules!r}
+modules.extend(
+    info.name for info in pkgutil.walk_packages(
+        atcroster.__path__, prefix='atcroster.'
+    )
+)
+app = importlib.import_module('app')
+for name in sorted(set(modules)):
+    importlib.import_module(name)
+wsgi = importlib.import_module('wsgi')
+assert wsgi.application is app.app
+"""
+    environment = os.environ.copy()
+    environment["ATCROSTER_SKIP_BOOTSTRAP"] = "1"
+    result = subprocess.run(
+        [sys.executable, "-c", import_script],
+        cwd=ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_public_blueprint.py
+++ b/tests/test_public_blueprint.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from flask import Flask
+from jinja2 import DictLoader
+
+from atcroster.public import public_blueprint
+from atcroster.public.blueprint import legal_context
+
+
+def public_application(tmp_path) -> Flask:
+    static_folder = tmp_path / "static"
+    static_folder.mkdir()
+    (static_folder / "favicon.svg").write_text("<svg></svg>", encoding="utf-8")
+    application = Flask(__name__, static_folder=str(static_folder))
+    application.jinja_loader = DictLoader(
+        {
+            "privacy.html": "privacy|{{ legal_entity }}|{{ privacy_email }}",
+            "cookies.html": "cookies|{{ policy_date }}",
+            "terms.html": "terms|{{ legal_address }}",
+            "subprocessors.html": "subprocessors|{{ company_number }}",
+        }
+    )
+    application.register_blueprint(public_blueprint)
+    return application
+
+
+def test_public_blueprint_preserves_legacy_routes_and_endpoints(tmp_path):
+    application = public_application(tmp_path)
+    routes = {
+        rule.rule: (rule.endpoint, sorted(rule.methods - {"HEAD", "OPTIONS"}))
+        for rule in application.url_map.iter_rules()
+        if rule.rule != "/static/<path:filename>"
+    }
+    assert routes == {
+        "/favicon.ico": ("favicon", ["GET"]),
+        "/privacy": ("privacy_notice", ["GET"]),
+        "/cookies": ("cookie_notice", ["GET"]),
+        "/terms": ("terms_of_service", ["GET"]),
+        "/subprocessors": ("subprocessor_notice", ["GET"]),
+    }
+
+
+def test_public_pages_render_and_favicon_is_served(tmp_path, monkeypatch):
+    monkeypatch.setenv("ATCROSTER_LEGAL_ENTITY", "Example Aviation")
+    monkeypatch.setenv("ATCROSTER_PRIVACY_EMAIL", "privacy@example.test")
+    application = public_application(tmp_path)
+    client = application.test_client()
+
+    assert b"privacy|Example Aviation|privacy@example.test" in client.get(
+        "/privacy"
+    ).data
+    assert client.get("/cookies").status_code == 200
+    assert client.get("/terms").status_code == 200
+    assert client.get("/subprocessors").status_code == 200
+    favicon_response = client.get("/favicon.ico")
+    assert favicon_response.status_code == 200
+    assert favicon_response.mimetype == "image/svg+xml"
+
+
+def test_legal_context_preserves_support_email_fallback(monkeypatch):
+    monkeypatch.delenv("ATCROSTER_PRIVACY_EMAIL", raising=False)
+    monkeypatch.setenv("ATCROSTER_SUPPORT_EMAIL", "support@example.test")
+    assert legal_context()["privacy_email"] == "support@example.test"

--- a/tests/test_route_map_contract.py
+++ b/tests/test_route_map_contract.py
@@ -1,0 +1,34 @@
+"""Compatibility contract for every registered Flask route."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import app
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "route_map.json"
+IGNORED_AUTOMATIC_METHODS = {"HEAD", "OPTIONS"}
+
+
+def current_route_map() -> list[dict[str, object]]:
+    """Return stable route facts, excluding Flask's automatic methods."""
+    routes = [
+        {
+            "endpoint": rule.endpoint,
+            "methods": sorted(set(rule.methods or ()) - IGNORED_AUTOMATIC_METHODS),
+            "rule": rule.rule,
+        }
+        for rule in app.app.url_map.iter_rules()
+    ]
+    return sorted(
+        routes,
+        key=lambda route: (route["rule"], route["endpoint"], route["methods"]),
+    )
+
+
+def test_route_map_matches_compatibility_snapshot():
+    expected = json.loads(FIXTURE.read_text())
+    assert current_route_map() == expected
+

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from flask import Flask, g
+from flask_login import LoginManager
+
+from atcroster.security.headers import (
+    SecurityHeaderDependencies,
+    content_security_policy,
+    register_security_headers,
+)
+
+
+def test_content_security_policy_preserves_nonce_sources_and_directives():
+    policy = content_security_policy("nonce-value", production=False)
+    assert policy == (
+        "default-src 'self'; base-uri 'self'; form-action 'self'; "
+        "frame-ancestors 'none'; object-src 'none'; img-src 'self' data:; "
+        "font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; "
+        "style-src 'self' 'nonce-nonce-value' https://fonts.googleapis.com "
+        "https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; "
+        "style-src-attr 'none'; script-src 'self' 'nonce-nonce-value' "
+        "https://cdn.jsdelivr.net; connect-src 'self'; worker-src 'self'; "
+        "manifest-src 'self'"
+    )
+    assert "'unsafe-inline'" not in policy
+
+
+def test_production_policy_only_adds_upgrade_insecure_requests():
+    development = content_security_policy("same", production=False)
+    production = content_security_policy("same", production=True)
+    assert production == development + "; upgrade-insecure-requests"
+
+
+def test_registered_headers_preserve_nonce_hsts_and_metrics_completion():
+    application = Flask(__name__)
+    application.secret_key = "direct-header-test"
+    login_manager = LoginManager(application)
+
+    @login_manager.user_loader
+    def load_user(_user_id):
+        return None
+    completed: list[dict[str, object]] = []
+
+    @application.before_request
+    def request_context():
+        g.csp_nonce = "direct-test"
+        g.request_id = "request-test"
+        g.metrics_started_at = 4.0
+
+    @application.get("/probe")
+    def probe():
+        return "ok"
+
+    def finish(_metrics, started_at, **facts):
+        completed.append({"started_at": started_at, **facts})
+        return 0.125
+
+    register_security_headers(
+        application,
+        SecurityHeaderDependencies(
+            deployment_environment="production",
+            metrics=object(),
+            finish_request=finish,
+        ),
+    )
+
+    response = application.test_client().get("/probe")
+    assert response.headers["X-Request-ID"] == "request-test"
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+    assert response.headers["X-Frame-Options"] == "DENY"
+    assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+    assert response.headers["Permissions-Policy"] == (
+        "camera=(), microphone=(), geolocation=()"
+    )
+    assert "script-src 'self' 'nonce-direct-test'" in response.headers[
+        "Content-Security-Policy"
+    ]
+    assert response.headers["Strict-Transport-Security"] == (
+        "max-age=31536000; includeSubDomains"
+    )
+    assert completed == [
+        {
+            "started_at": 4.0,
+            "route": "probe",
+            "method": "GET",
+            "status": 200,
+        }
+    ]

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from flask import Flask
+from flask_login import LoginManager, UserMixin, current_user, login_user
+
+from atcroster.security.sessions import (
+    SessionLifecycle,
+    SessionLifecycleDependencies,
+)
+
+
+@dataclass
+class Credential:
+    enabled: bool = True
+    reset_required: bool = False
+    encrypted_secret: str = "encrypted-secret"
+    enrolled_at: datetime = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+class BrowserUser(UserMixin):
+    id = 7
+    password_hash = "password-hash"
+    role = "admin"
+    membership_status = "active"
+
+
+def session_application(monkeypatch, *, idle_minutes="30", absolute_minutes="720"):
+    application = Flask(__name__)
+    application.secret_key = "isolated-session-tests"
+    manager = LoginManager(application)
+    user = BrowserUser()
+    credential = Credential()
+    clock = {"now": datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)}
+    events = []
+    lifecycle = SessionLifecycle(
+        SessionLifecycleDependencies(
+            now=lambda: clock["now"],
+            credential_for_user=lambda _user: credential,
+            security_event=lambda event, **facts: events.append((event, facts)),
+        )
+    )
+    monkeypatch.setenv("ATCROSTER_SESSION_IDLE_MINUTES", idle_minutes)
+    monkeypatch.setenv("ATCROSTER_SESSION_ABSOLUTE_MINUTES", absolute_minutes)
+
+    @manager.user_loader
+    def load_user(user_id):
+        return user if user_id == str(user.id) else None
+
+    @application.before_request
+    def enforce_session():
+        return lifecycle.enforce_request(current_user)
+
+    @application.get("/login", endpoint="login")
+    def login():
+        login_user(user)
+        lifecycle.initialize(user)
+        return "logged-in"
+
+    @application.get("/private")
+    def private():
+        return "private"
+
+    return application, user, credential, clock, events, lifecycle
+
+
+def test_initialize_sets_revocation_stamp_and_session_times(monkeypatch):
+    application, user, _credential, clock, _events, lifecycle = session_application(
+        monkeypatch
+    )
+    client = application.test_client()
+    client.get("/login")
+    with client.session_transaction() as browser_session:
+        assert browser_session["_auth_stamp"] == lifecycle.auth_stamp(user)
+        assert browser_session["_last_seen_epoch"] == int(clock["now"].timestamp())
+        assert browser_session["_session_started_at"] == clock["now"].isoformat()
+        assert browser_session["_session_nonce"]
+
+
+def test_idle_timeout_revokes_session(monkeypatch):
+    application, _user, _credential, clock, events, _lifecycle = session_application(
+        monkeypatch, idle_minutes="30"
+    )
+    client = application.test_client()
+    client.get("/login")
+    clock["now"] += timedelta(minutes=31)
+    response = client.get("/private")
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/login")
+    assert events[0][0] == "session_expired"
+    assert events[0][1]["reason"] == "idle"
+
+
+def test_absolute_timeout_wins_over_recent_activity(monkeypatch):
+    application, _user, _credential, clock, events, _lifecycle = session_application(
+        monkeypatch, absolute_minutes="60"
+    )
+    client = application.test_client()
+    client.get("/login")
+    clock["now"] += timedelta(minutes=61)
+    with client.session_transaction() as browser_session:
+        browser_session["_last_seen_epoch"] = int(clock["now"].timestamp())
+    assert client.get("/private").status_code == 302
+    assert events[0][1]["reason"] == "absolute"
+
+
+def test_role_or_mfa_change_forces_revocation(monkeypatch):
+    application, user, credential, _clock, events, _lifecycle = session_application(
+        monkeypatch
+    )
+    role_client = application.test_client()
+    role_client.get("/login")
+    user.role = "user"
+    assert role_client.get("/private").status_code == 302
+    assert events[-1][0] == "session_forced_invalidation"
+
+    user.role = "admin"
+    mfa_client = application.test_client()
+    mfa_client.get("/login")
+    credential.encrypted_secret = "replacement-secret"
+    assert mfa_client.get("/private").status_code == 302
+    assert events[-1][0] == "session_forced_invalidation"

--- a/tests/test_tenant_hooks.py
+++ b/tests/test_tenant_hooks.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from flask import Flask, g
+
+from atcroster.tenancy_hooks import TenantHookDependencies, register_tenant_hooks
+
+
+@dataclass
+class BrowserUser:
+    is_authenticated: bool
+    role: str = "user"
+    unit_id: int | None = None
+
+
+@dataclass
+class Route:
+    secret_name: str
+
+
+def tenant_application(user: BrowserUser, *, production=False, explode=False):
+    application = Flask(__name__)
+    calls = []
+
+    def record(name, result=None):
+        def callback(*args):
+            calls.append((name, args))
+            return result
+
+        return callback
+
+    register_tenant_hooks(
+        application,
+        TenantHookDependencies(
+            deployment_environment="production" if production else "test",
+            current_user=lambda: user,
+            enforce_session=lambda _user: None,
+            routing_for_unit=lambda unit_id: Route(f"UNIT_{unit_id}_DATABASE_URL"),
+            clear_context=record("clear"),
+            bind_authenticated_unit=record("bind_unit", "unit-token"),
+            reset_authenticated_unit=record("reset_unit"),
+            bind_platform_control=record("bind_platform", "platform-token"),
+            reset_platform_control=record("reset_platform"),
+        ),
+    )
+
+    @application.get("/")
+    def index():
+        if explode:
+            raise RuntimeError("expected request failure")
+        return {
+            "unit_token": getattr(g, "tenant_context_token", None),
+            "platform_token": getattr(g, "platform_control_token", None),
+        }
+
+    return application, calls
+
+
+def test_anonymous_requests_remain_unbound_and_clear_context_twice():
+    application, calls = tenant_application(BrowserUser(False))
+    assert application.test_client().get("/").status_code == 200
+    assert [name for name, _args in calls] == ["clear", "clear"]
+
+
+def test_verified_unit_is_bound_from_user_and_reset_after_request():
+    application, calls = tenant_application(BrowserUser(True, unit_id=12))
+    response = application.test_client().get("/")
+    assert response.json == {"platform_token": None, "unit_token": "unit-token"}
+    assert ("bind_unit", (12, "UNIT_12_DATABASE_URL")) in calls
+    assert ("reset_unit", ("unit-token",)) in calls
+
+
+def test_superadmin_binds_only_platform_control():
+    application, calls = tenant_application(BrowserUser(True, "superadmin", 99))
+    response = application.test_client().get("/")
+    assert response.json == {
+        "platform_token": "platform-token",
+        "unit_token": None,
+    }
+    assert not any(name == "bind_unit" for name, _args in calls)
+    assert ("reset_platform", ("platform-token",)) in calls
+
+
+def test_tenant_context_is_reset_after_exception():
+    application, calls = tenant_application(BrowserUser(True, unit_id=3), explode=True)
+    application.config.update(TESTING=True, PROPAGATE_EXCEPTIONS=False)
+    assert application.test_client().get("/").status_code == 500
+    assert ("reset_unit", ("unit-token",)) in calls
+    assert [name for name, _args in calls][-1] == "clear"


### PR DESCRIPTION
## What changed

- snapshots all 107 Flask routes and endpoint methods
- extracts CSP/security headers, error handlers, and public/legal routes
- extracts default-deny CSRF, versioned field encryption, and session lifecycle services
- extracts verified tenant request binding and teardown hooks
- adds clean-startup import coverage and architecture/security/tenancy progress documentation

## Why

`app.py` began at 10,029 lines and mixed framework security controls with domain transactions. This moves the safest cross-cutting boundaries first, keeps every commit deployable, and deliberately stops before the high-risk multi-database account administration transaction.

## Compatibility

The route snapshot is unchanged. Endpoint names, templates, CSRF behaviour, tenant binding, session revocation, `wsgi:application`, migrations, and startup remain compatible.

## Validation

- 296 passed, 11 skipped; 72.02% coverage
- Ruff, configured mypy scope, Bandit Medium/High, and compileall passed
- Docker image build passed
- migration/backup unit and fixture tests: 22 passed
- PostgreSQL/Redis integration: 10 passed; local restore integration was blocked only by host pg_dump 14 versus PostgreSQL 16 and must be confirmed by exact-commit CI

## Safe boundary

`app.py` is now 9,670 lines. The remaining account, qualification, publication, audit, CLI, and bootstrap extractions are documented in `docs/architecture/refactor-progress.md` and should be reviewed as later incremental PRs.