### PR TITLE
Fix kiosk live stream tenant context

### DIFF
--- a/app.py
+++ b/app.py
@@ -104,7 +104,9 @@ from atcroster.security.sessions import (
 )
 from atcroster.tenancy_hooks import TenantHookDependencies, register_tenant_hooks
 from tenancy import (
+    authenticated_database_route_optional,
     authenticated_unit_id,
+    authenticated_unit_context,
     bind_authenticated_unit,
     bind_platform_control,
     clear_request_context,
@@ -9457,6 +9459,8 @@ app.register_blueprint(create_live_position_blueprint(LivePositionDependencies(
     utcnow=utcnow, is_admin_user=is_admin_user,
     live_position_enabled=live_position_enabled,
     competency_enabled=competency_enabled,
+    authenticated_database_route_optional=authenticated_database_route_optional,
+    authenticated_unit_context=authenticated_unit_context,
 )))
 
 app.register_blueprint(create_auth_blueprint(AuthDependencies(

--- a/live_position_blueprint.py
+++ b/live_position_blueprint.py
@@ -51,6 +51,8 @@ class LivePositionDependencies:
     is_admin_user: Callable[[Any], bool]
     live_position_enabled: Callable[[int], bool]
     competency_enabled: Callable[[int], bool]
+    authenticated_database_route_optional: Callable[[], Any]
+    authenticated_unit_context: Callable[[int, str | None], Any]
 
 
 def _minutes_between(start: datetime, end: datetime) -> int:
@@ -1181,15 +1183,24 @@ def create_live_position_blueprint(
     @login_required
     def live_events():
         _require_kiosk()
+        unit_id = _unit_id()
+        database_route = dependencies.authenticated_database_route_optional()
 
         @stream_with_context
         def events():
             # Database state is authoritative. A short heartbeat makes this
             # work consistently across multiple web processes; the browser's
             # normal polling remains the fallback when SSE is unavailable.
-            for _index in range(120):
-                yield f"event: state\ndata: {json.dumps(_state_payload())}\n\n"
-                time.sleep(5)
+            # Flask tears down the original request before iterating a streamed
+            # response, so restore only the already-authenticated tenant route
+            # for the lifetime of the stream.
+            with dependencies.authenticated_unit_context(
+                unit_id,
+                database_route.secret_name if database_route is not None else None,
+            ):
+                for _index in range(120):
+                    yield f"event: state\ndata: {json.dumps(_state_payload())}\n\n"
+                    time.sleep(5)
 
         return Response(
             events(),

--- a/tenancy.py
+++ b/tenancy.py
@@ -118,6 +118,15 @@ def authenticated_database_route() -> DatabaseRoute:
     return route
 
 
+def authenticated_database_route_optional() -> DatabaseRoute | None:
+    """Return the trusted route when one is configured for this unit."""
+    unit_id = authenticated_unit_id()
+    route = _route_context.get()
+    if route is not None and route.unit_id != unit_id:
+        raise PermissionError("Operational database route is inconsistent")
+    return route
+
+
 _context_router = OperationalDatabaseRouter(
     lambda unit_id: authenticated_database_route()
 )
@@ -158,6 +167,16 @@ def operational_unit_context(
     token = bind_authenticated_unit(unit_id, secret_name)
     try:
         yield operational_engine_for_authenticated_unit()
+    finally:
+        reset_authenticated_unit(token)
+
+
+@contextmanager
+def authenticated_unit_context(unit_id: int, secret_name: str | None = None):
+    """Restore a previously authenticated tenant across a deferred boundary."""
+    token = bind_authenticated_unit(unit_id, secret_name)
+    try:
+        yield
     finally:
         reset_authenticated_unit(token)
 

--- a/tests/test_live_position_monitoring.py
+++ b/tests/test_live_position_monitoring.py
@@ -284,6 +284,21 @@ def test_live_state_includes_configured_display_group(live_position_data):
     assert state["group_order"] == 10
 
 
+def test_live_event_stream_retains_authenticated_tenant_context(live_position_data):
+    client = app.app.test_client()
+    _login_kiosk(client)
+
+    response = client.get("/live-positions/api/events", buffered=False)
+    try:
+        first_event = next(response.response)
+    finally:
+        response.close()
+
+    assert response.status_code == 200
+    assert first_event.startswith(b"event: state\ndata: ")
+    assert b'"group_name": "Tower"' in first_event
+
+
 def _login_kiosk(client):
     client.get("/login")
     with client.session_transaction() as session:


### PR DESCRIPTION
## What changed

- Preserve the authenticated operational database route while the live-position SSE response is streamed.
- Add a narrow deferred tenant context helper with route consistency validation.
- Add a regression test that consumes the first streamed state event after request teardown.

## Root cause

Flask tears down the original request context before Waitress iterates the streaming response. The tenancy teardown correctly cleared the airport context, but the SSE generator then queried operational state without restoring the already-authenticated route.

## Impact

Dedicated position-monitor kiosks can keep their live update connection open without tenant-context crashes. Tenant isolation remains enforced because the stream reuses only the route captured from the authenticated request.

## Validation

- `297 passed, 11 skipped`
- Ruff checks passed for all changed Python files.
