### PR TITLE
Route LPM allowances to airport databases

### DIFF
--- a/app.py
+++ b/app.py
@@ -242,6 +242,7 @@ OPERATIONAL_TABLE_NAMES = frozenset({
     "person_qualification", "person_qualification_history",
     "roster_publication", "roster_acknowledgement", "scenario",
     "operational_position", "operational_position_group",
+    "operational_position_time_allowance",
     "position_endorsement", "position_requirement",
     "break_plan", "achieved_duty", "fatigue_report",
     "roster_rule_version", "mfa_credential",

--- a/tests/test_physical_database_isolation.py
+++ b/tests/test_physical_database_isolation.py
@@ -32,6 +32,10 @@ def _operational_tables():
     ]
 
 
+def test_position_time_allowances_are_routed_to_operational_databases():
+    assert "operational_position_time_allowance" in app.OPERATIONAL_TABLE_NAMES
+
+
 def _seed_operational_unit(
     unit_id, secret_name, username, marker, create_schema=True
 ):


### PR DESCRIPTION
## What changed

- Classify `operational_position_time_allowance` as an operational table.
- Add a regression assertion to the physical database isolation suite.

## Root cause

The allowance model was omitted from `OPERATIONAL_TABLE_NAMES`, so Flask-SQLAlchemy sent its queries to the central control database instead of the authenticated airport database. This made Glasgow LPM state and SSE requests fail even though the table existed in Glasgow.

## Impact

Live Position Monitoring reads the time allowance matrix from the correct airport database and can render position state for Unit 2.

## Validation

- Focused physical-isolation and live-position tests: 15 passed.
- Changed test lint and diff checks passed.
