### PR TITLE
Extract fatigue compliance boundary

### DIFF
--- a/app.py
+++ b/app.py
@@ -75,6 +75,13 @@ from absence_requests import (
     request_month_is_locked,
     safe_admin_month,
 )
+from fatigue_compliance import (
+    FatigueComplianceDependencies,
+    FatigueRuleConfigDependencies,
+    FatigueRuleConfigService,
+    compliance_month,
+    create_fatigue_compliance_blueprint,
+)
 from access_policy import (
     has_permission,
     is_admin,
@@ -2447,8 +2454,6 @@ def _is_working_day_code(code: str) -> bool:
 # -------------------- Fatigue helpers (SRATCOH D18–D43; On-Call ignored) --------------------
 
 from fatigue_engine import (
-    CUSTOM_FATIGUE_RULE_TYPES,
-    SYSTEM_FATIGUE_RULES,
     _analyze_segments,
     _configured_time,
     _custom_fatigue_flags,
@@ -2461,97 +2466,15 @@ from fatigue_engine import (
 )
 
 
-def _fatigue_rule_config(unit_id: int | None = None) -> dict:
-    resolved_unit_id = int(unit_id or _current_unit_id() or 1)
-    system = {
-        item["code"]: {
-            **item,
-            "parameters": {
-                key: dict(parameter)
-                for key, parameter in item["parameters"].items()
-            },
-            "enabled": True,
-        }
-        for item in SYSTEM_FATIGUE_RULES
-    }
-    custom = []
-    definitions = {
-        "early_start_before": "06:30",
-        "night_period_start": "01:30",
-        "night_period_end": "05:30",
-    }
-    row = RosterSetting.query.filter_by(
-        unit_id=resolved_unit_id, key="fatigue_rule_config"
-    ).first()
-    if row and row.value:
-        try:
-            saved = json.loads(row.value)
-            for key in definitions:
-                candidate = str((saved.get("definitions") or {}).get(key) or "")
-                try:
-                    datetime.strptime(candidate, "%H:%M")
-                    definitions[key] = candidate
-                except ValueError:
-                    pass
-            for code, overrides in (saved.get("system") or {}).items():
-                if code in system and isinstance(overrides, dict):
-                    system[code].update({
-                        "name": str(overrides.get("name") or system[code]["name"])[:120],
-                        "severity": (
-                            overrides.get("severity")
-                            if overrides.get("severity") in {"warning", "critical"}
-                            else system[code]["severity"]
-                        ),
-                        "enabled": bool(overrides.get("enabled", True)),
-                    })
-                    saved_parameters = overrides.get("parameters") or {}
-                    for key, parameter in system[code]["parameters"].items():
-                        try:
-                            value = float(saved_parameters.get(
-                                key, parameter["value"]
-                            ))
-                            if value > 0:
-                                parameter["value"] = value
-                        except (TypeError, ValueError):
-                            pass
-            for rule in saved.get("custom") or []:
-                if (
-                    isinstance(rule, dict)
-                    and rule.get("rule_type") in CUSTOM_FATIGUE_RULE_TYPES
-                ):
-                    custom.append(rule)
-        except (TypeError, ValueError, json.JSONDecodeError):
-            pass
-    return {"system": system, "custom": custom, "definitions": definitions}
-
-
-def _save_fatigue_rule_config(config: dict) -> None:
-    unit_id = _current_unit_id()
-    row = RosterSetting.query.filter_by(
-        unit_id=unit_id, key="fatigue_rule_config"
-    ).first()
-    if not row:
-        row = RosterSetting(
-            unit_id=unit_id, key="fatigue_rule_config"
-        )
-        db.session.add(row)
-    row.value = json.dumps({
-        "system": {
-            code: {
-                "name": item["name"],
-                "severity": item["severity"],
-                "enabled": item["enabled"],
-                "parameters": {
-                    key: parameter["value"]
-                    for key, parameter in item["parameters"].items()
-                },
-            }
-            for code, item in config["system"].items()
-        },
-        "custom": config["custom"],
-        "definitions": config["definitions"],
-    }, sort_keys=True)
-    db.session.commit()
+_fatigue_rule_config_service = FatigueRuleConfigService(
+    FatigueRuleConfigDependencies(
+        db=db,
+        RosterSetting=RosterSetting,
+        current_unit_id=_current_unit_id,
+    )
+)
+_fatigue_rule_config = _fatigue_rule_config_service.load
+_save_fatigue_rule_config = _fatigue_rule_config_service.save
 
 
 
@@ -2746,15 +2669,7 @@ def would_create_new_fatigue_issues(
     return new_flags
 
 
-def _compliance_month(ym: str | None) -> tuple[int, int]:
-    today = date.today()
-    value = (ym or f"{today.year:04d}-{today.month:02d}").strip()
-    if not re.fullmatch(r"\d{4}-\d{2}", value):
-        abort(400, "Month must use YYYY-MM.")
-    year, month = map(int, value.split("-"))
-    if month not in range(1, 13):
-        abort(400, "Invalid month.")
-    return year, month
+_compliance_month = compliance_month
 
 
 def _compliance_findings(year: int, month: int) -> dict:
@@ -2819,148 +2734,6 @@ def _compliance_findings(year: int, month: int) -> dict:
         "rule_counts": rule_counts.most_common(),
     }
 
-
-@app.route("/compliance-centre")
-@login_required
-def compliance_centre():
-    """Retired standalone view; roster cells remain the monitoring surface."""
-    if not is_admin_user(current_user):
-        abort(403)
-    year, month = _compliance_month(request.args.get("ym"))
-    return redirect(
-        url_for("roster_month", ym=f"{year:04d}-{month:02d}")
-    )
-
-
-@app.route("/admin/fatigue-rules", methods=["GET", "POST"])
-@login_required
-def admin_fatigue_rules():
-    if not is_admin_user(current_user):
-        abort(403)
-    config = _fatigue_rule_config()
-    if request.method == "POST":
-        _validate_csrf()
-        action = request.form.get("action") or ""
-        try:
-            if action == "update_definitions":
-                definitions = {}
-                for key in (
-                    "early_start_before",
-                    "night_period_start",
-                    "night_period_end",
-                ):
-                    value = (request.form.get(key) or "").strip()
-                    datetime.strptime(value, "%H:%M")
-                    definitions[key] = value
-                if definitions["night_period_start"] == definitions["night_period_end"]:
-                    raise ValueError("The night-duty period must have a duration.")
-                config["definitions"] = definitions
-                _save_fatigue_rule_config(config)
-                flash("Duty time definitions updated for this airport.", "ok")
-            elif action == "update_system":
-                code = (request.form.get("code") or "").upper()
-                if code not in config["system"]:
-                    abort(404)
-                item = config["system"][code]
-                item["name"] = (
-                    request.form.get("name") or item["name"]
-                ).strip()[:120]
-                item["severity"] = (
-                    request.form.get("severity")
-                    if request.form.get("severity") in {"warning", "critical"}
-                    else item["severity"]
-                )
-                item["enabled"] = request.form.get("enabled") == "on"
-                for key, parameter_item in item["parameters"].items():
-                    value = float(request.form.get(
-                        f"parameter_{key}", parameter_item["value"]
-                    ))
-                    if not 0 < value <= 10000:
-                        raise ValueError(
-                            f"{parameter_item['label']} must be greater "
-                            "than zero."
-                        )
-                    parameter_item["value"] = value
-                _save_fatigue_rule_config(config)
-                flash(f"{code} fatigue rule updated.", "ok")
-            elif action in {"add_custom", "update_custom"}:
-                rule_type = request.form.get("rule_type") or ""
-                if rule_type not in CUSTOM_FATIGUE_RULE_TYPES:
-                    raise ValueError("Choose a supported rule check.")
-                name = (request.form.get("name") or "").strip()
-                if len(name) < 3:
-                    raise ValueError("Give the rule a clear name.")
-                threshold = float(request.form.get("threshold") or 0)
-                if threshold <= 0:
-                    raise ValueError("The limit must be greater than zero.")
-                type_meta = CUSTOM_FATIGUE_RULE_TYPES[rule_type]
-                window_days = int(
-                    request.form.get("window_days")
-                    or type_meta.get("default_window", 1)
-                )
-                if not 1 <= window_days <= 365:
-                    raise ValueError("The review period must be 1–365 days.")
-                severity = request.form.get("severity")
-                if severity not in {"warning", "critical"}:
-                    severity = "warning"
-                code = (request.form.get("code") or "").upper()
-                existing = next((
-                    item for item in config["custom"]
-                    if item.get("code") == code
-                ), None)
-                if action == "update_custom" and not existing:
-                    abort(404)
-                if not existing:
-                    existing = {
-                        "code": f"USR-{secrets.token_hex(3).upper()}"
-                    }
-                    config["custom"].append(existing)
-                existing.update({
-                    "name": name[:120],
-                    "rule_type": rule_type,
-                    "threshold": threshold,
-                    "window_days": window_days,
-                    "severity": severity,
-                    "enabled": request.form.get("enabled") == "on",
-                })
-                _save_fatigue_rule_config(config)
-                flash(f"{existing['code']} fatigue rule saved.", "ok")
-            elif action == "delete_custom":
-                code = (request.form.get("code") or "").upper()
-                before = len(config["custom"])
-                config["custom"] = [
-                    item for item in config["custom"]
-                    if item.get("code") != code
-                ]
-                if len(config["custom"]) == before:
-                    abort(404)
-                _save_fatigue_rule_config(config)
-                flash(f"{code} custom fatigue rule removed.", "ok")
-            else:
-                abort(400)
-        except (TypeError, ValueError) as exc:
-            flash(str(exc), "error")
-        return redirect(url_for("admin_fatigue_rules"))
-    return render_template(
-        "admin_fatigue_rules.html",
-        system_rules=list(config["system"].values()),
-        custom_rules=config["custom"],
-        definitions=config["definitions"],
-        rule_types=CUSTOM_FATIGUE_RULE_TYPES,
-        current_unit=db.session.get(Unit, _current_unit_id()),
-    )
-
-
-@app.route("/compliance-centre/export")
-@login_required
-def compliance_centre_export():
-    """Retired with the standalone Compliance Centre."""
-    if not is_admin_user(current_user):
-        abort(403)
-    year, month = _compliance_month(request.args.get("ym"))
-    return redirect(
-        url_for("roster_month", ym=f"{year:04d}-{month:02d}")
-    )
 
 # -------------------- Migrations / seeding --------------------
 
@@ -9198,6 +8971,17 @@ app.register_blueprint(create_training_blueprint(TrainingDependencies(
     sync_qualification_to_roster_profile=_sync_qualification_to_roster_profile,
     TrainingObjective=TrainingObjective,
 )))
+app.register_blueprint(create_fatigue_compliance_blueprint(
+    FatigueComplianceDependencies(
+        db=db,
+        Unit=Unit,
+        is_admin_user=is_admin_user,
+        current_unit_id=_current_unit_id,
+        validate_csrf=_validate_csrf,
+        load_rule_config=_fatigue_rule_config,
+        save_rule_config=_save_fatigue_rule_config,
+    )
+))
 app.register_blueprint(create_operations_blueprint(OperationsDependencies(
     db=db,
     OperationalPosition=OperationalPosition,

--- a/docs/architecture/app-module-inventory.md
+++ b/docs/architecture/app-module-inventory.md
@@ -3,9 +3,12 @@
 Baseline commit: `d7428da166e3943f94175e8ed65fc46e4abe1996`. Baseline `app.py`: **10,029 lines**. This inventory describes the compatibility boundary before incremental extraction. Automatic Flask `HEAD` and `OPTIONS` methods are omitted from the route contract because Flask derives them from explicit methods.
 
 Current modularisation milestone: the pure SRATCOH fatigue rules and analysis
-engine live in `fatigue_engine.py`. Compatibility aliases remain available from
-`app` for existing callers. At commit baseline `6eb9a36`, this extraction reduces
-`app.py` from 9,675 to 9,263 lines without changing its route map.
+engine live in `fatigue_engine.py`; airport-scoped fatigue rule persistence and
+the legacy compliance/fatigue administration routes live in
+`fatigue_compliance.py`. Compatibility aliases and the original unprefixed Flask
+endpoint names remain available for existing callers. From baseline `6eb9a36`,
+these extractions reduce `app.py` from 9,675 to 9,047 lines without changing its
+route map.
 
 ## Responsibilities remaining in `app.py`
 
@@ -40,7 +43,7 @@ CSRF is enforced globally for every explicit unsafe method. Authentication and r
 | /__can | `__can` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | JSON/redirect/response | `app` + registered dependencies |
 | /admin | `admin` | GET, POST | Authenticated account | Admin/editor action policy | Verified active unit | Global default-deny | admin.html | `app` + registered dependencies |
 | /admin/change-log | `change_log_page` | GET | Authenticated account | Admin/editor action policy | Verified active unit | Not applicable (safe method) | change_log.html | `app` + registered dependencies |
-| /admin/fatigue-rules | `admin_fatigue_rules` | GET, POST | Authenticated account | Admin/editor action policy | Verified active unit | Global default-deny | admin_fatigue_rules.html | `app` + registered dependencies |
+| /admin/fatigue-rules | `admin_fatigue_rules` | GET, POST | Authenticated account | Admin/editor action policy | Verified active unit | Global default-deny | admin_fatigue_rules.html | `fatigue_compliance` + registered dependencies |
 | /admin/reference | `admin_reference` | GET, POST | Authenticated account | Admin/editor action policy | Verified active unit | Global default-deny | admin_reference.html | `app` + registered dependencies |
 | /admin/requests/<int:rid>/respond | `admin_request_respond` | POST | Authenticated account | Admin/editor action policy | Verified active unit | Global default-deny | JSON/redirect/response | `absence_requests_blueprint` + registered dependencies |
 | /admin/sms-audit | `admin_sms_audit` | GET | Authenticated account | Admin/editor action policy | Verified active unit | Not applicable (safe method) | admin_sms_audit.html | `app` + registered dependencies |
@@ -73,8 +76,8 @@ CSRF is enforced globally for every explicit unsafe method. Authentication and r
 | /competency/ | `competency_home` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | competency_home.html | `training_blueprint` + registered dependencies |
 | /competency/<int:sid> | `competency_profile` | GET, POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | competency_profile.html | `training_blueprint` + registered dependencies |
 | /compliance | `qualification_compliance` | GET, POST | Authenticated account | Endpoint/domain permission | Verified active unit | Global default-deny | qualification_compliance.html | `app` + registered dependencies |
-| /compliance-centre | `compliance_centre` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | JSON/redirect/response | `app` + registered dependencies |
-| /compliance-centre/export | `compliance_centre_export` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | JSON/redirect/response | `app` + registered dependencies |
+| /compliance-centre | `compliance_centre` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | JSON/redirect/response | `fatigue_compliance` + registered dependencies |
+| /compliance-centre/export | `compliance_centre_export` | GET | Authenticated account | Endpoint/domain permission | Verified active unit | Not applicable (safe method) | JSON/redirect/response | `fatigue_compliance` + registered dependencies |
 | /cookies | `cookie_notice` | GET | Anonymous or token-bound | Public/token workflow policy | Unbound/public | Not applicable (safe method) | cookies.html | `app` + registered dependencies |
 | /favicon.ico | `favicon` | GET | Anonymous or token-bound | Public/token workflow policy | Unbound/public | Not applicable (safe method) | static asset | `app` + registered dependencies |
 | /health/live | `health_live` | GET | Anonymous or token-bound | Public/token workflow policy | Unbound/public | Not applicable (safe method) | JSON/redirect/response | `production_operations` + registered dependencies |
@@ -151,4 +154,3 @@ CSRF is enforced globally for every explicit unsafe method. Authentication and r
 - Tenant context must be empty before public work and cleared after every response or exception.
 - Global unsafe-method CSRF and post-response security headers remain centrally registered until their explicit extraction commits.
 - No domain extraction may bypass existing policy helpers, tenant-scoped queries, audit writes or transaction boundaries.
-

--- a/fatigue_compliance.py
+++ b/fatigue_compliance.py
@@ -1,0 +1,328 @@
+"""Fatigue rule persistence and compliance administration routes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+import json
+import re
+import secrets
+from typing import Any, Callable
+
+from flask import Blueprint, abort, flash, redirect, render_template, request, url_for
+from flask_login import current_user, login_required
+
+from fatigue_engine import CUSTOM_FATIGUE_RULE_TYPES, SYSTEM_FATIGUE_RULES
+
+
+@dataclass(frozen=True)
+class FatigueRuleConfigDependencies:
+    db: Any
+    RosterSetting: Any
+    current_unit_id: Callable[[], int]
+
+
+class FatigueRuleConfigService:
+    """Load and persist airport-scoped fatigue rule configuration."""
+
+    def __init__(self, dependencies: FatigueRuleConfigDependencies) -> None:
+        self.dependencies = dependencies
+
+    def load(self, unit_id: int | None = None) -> dict:
+        resolved_unit_id = int(
+            unit_id or self.dependencies.current_unit_id() or 1
+        )
+        system = {
+            item["code"]: {
+                **item,
+                "parameters": {
+                    key: dict(parameter)
+                    for key, parameter in item["parameters"].items()
+                },
+                "enabled": True,
+            }
+            for item in SYSTEM_FATIGUE_RULES
+        }
+        custom = []
+        definitions = {
+            "early_start_before": "06:30",
+            "night_period_start": "01:30",
+            "night_period_end": "05:30",
+        }
+        row = self.dependencies.RosterSetting.query.filter_by(
+            unit_id=resolved_unit_id, key="fatigue_rule_config"
+        ).first()
+        if row and row.value:
+            try:
+                saved = json.loads(row.value)
+                for key in definitions:
+                    candidate = str(
+                        (saved.get("definitions") or {}).get(key) or ""
+                    )
+                    try:
+                        datetime.strptime(candidate, "%H:%M")
+                        definitions[key] = candidate
+                    except ValueError:
+                        pass
+                for code, overrides in (saved.get("system") or {}).items():
+                    if code in system and isinstance(overrides, dict):
+                        system[code].update({
+                            "name": str(
+                                overrides.get("name") or system[code]["name"]
+                            )[:120],
+                            "severity": (
+                                overrides.get("severity")
+                                if overrides.get("severity")
+                                in {"warning", "critical"}
+                                else system[code]["severity"]
+                            ),
+                            "enabled": bool(overrides.get("enabled", True)),
+                        })
+                        saved_parameters = overrides.get("parameters") or {}
+                        for key, parameter in system[code]["parameters"].items():
+                            try:
+                                value = float(
+                                    saved_parameters.get(key, parameter["value"])
+                                )
+                                if value > 0:
+                                    parameter["value"] = value
+                            except (TypeError, ValueError):
+                                pass
+                for rule in saved.get("custom") or []:
+                    if (
+                        isinstance(rule, dict)
+                        and rule.get("rule_type") in CUSTOM_FATIGUE_RULE_TYPES
+                    ):
+                        custom.append(rule)
+            except (TypeError, ValueError, json.JSONDecodeError):
+                pass
+        return {
+            "system": system,
+            "custom": custom,
+            "definitions": definitions,
+        }
+
+    def save(self, config: dict) -> None:
+        unit_id = self.dependencies.current_unit_id()
+        row = self.dependencies.RosterSetting.query.filter_by(
+            unit_id=unit_id, key="fatigue_rule_config"
+        ).first()
+        if not row:
+            row = self.dependencies.RosterSetting(
+                unit_id=unit_id, key="fatigue_rule_config"
+            )
+            self.dependencies.db.session.add(row)
+        row.value = json.dumps({
+            "system": {
+                code: {
+                    "name": item["name"],
+                    "severity": item["severity"],
+                    "enabled": item["enabled"],
+                    "parameters": {
+                        key: parameter["value"]
+                        for key, parameter in item["parameters"].items()
+                    },
+                }
+                for code, item in config["system"].items()
+            },
+            "custom": config["custom"],
+            "definitions": config["definitions"],
+        }, sort_keys=True)
+        self.dependencies.db.session.commit()
+
+
+def compliance_month(ym: str | None) -> tuple[int, int]:
+    today = date.today()
+    value = (ym or f"{today.year:04d}-{today.month:02d}").strip()
+    if not re.fullmatch(r"\d{4}-\d{2}", value):
+        abort(400, "Month must use YYYY-MM.")
+    year, month = map(int, value.split("-"))
+    if month not in range(1, 13):
+        abort(400, "Invalid month.")
+    return year, month
+
+
+@dataclass(frozen=True)
+class FatigueComplianceDependencies:
+    db: Any
+    Unit: Any
+    is_admin_user: Callable
+    current_unit_id: Callable[[], int]
+    validate_csrf: Callable[[], None]
+    load_rule_config: Callable[..., dict]
+    save_rule_config: Callable[[dict], None]
+
+
+def create_fatigue_compliance_blueprint(
+    dependencies: FatigueComplianceDependencies,
+) -> Blueprint:
+    """Create legacy-named compliance routes without changing their URLs."""
+
+    blueprint = Blueprint("fatigue_compliance", __name__)
+
+    @login_required
+    def compliance_centre():
+        """Retired standalone view; roster cells remain the monitoring surface."""
+        if not dependencies.is_admin_user(current_user):
+            abort(403)
+        year, month = compliance_month(request.args.get("ym"))
+        return redirect(url_for("roster_month", ym=f"{year:04d}-{month:02d}"))
+
+    @login_required
+    def admin_fatigue_rules():
+        if not dependencies.is_admin_user(current_user):
+            abort(403)
+        config = dependencies.load_rule_config()
+        if request.method == "POST":
+            dependencies.validate_csrf()
+            action = request.form.get("action") or ""
+            try:
+                if action == "update_definitions":
+                    definitions = {}
+                    for key in (
+                        "early_start_before",
+                        "night_period_start",
+                        "night_period_end",
+                    ):
+                        value = (request.form.get(key) or "").strip()
+                        datetime.strptime(value, "%H:%M")
+                        definitions[key] = value
+                    if (
+                        definitions["night_period_start"]
+                        == definitions["night_period_end"]
+                    ):
+                        raise ValueError(
+                            "The night-duty period must have a duration."
+                        )
+                    config["definitions"] = definitions
+                    dependencies.save_rule_config(config)
+                    flash(
+                        "Duty time definitions updated for this airport.", "ok"
+                    )
+                elif action == "update_system":
+                    code = (request.form.get("code") or "").upper()
+                    if code not in config["system"]:
+                        abort(404)
+                    item = config["system"][code]
+                    item["name"] = (
+                        request.form.get("name") or item["name"]
+                    ).strip()[:120]
+                    item["severity"] = (
+                        request.form.get("severity")
+                        if request.form.get("severity")
+                        in {"warning", "critical"}
+                        else item["severity"]
+                    )
+                    item["enabled"] = request.form.get("enabled") == "on"
+                    for key, parameter_item in item["parameters"].items():
+                        value = float(request.form.get(
+                            f"parameter_{key}", parameter_item["value"]
+                        ))
+                        if not 0 < value <= 10000:
+                            raise ValueError(
+                                f"{parameter_item['label']} must be greater "
+                                "than zero."
+                            )
+                        parameter_item["value"] = value
+                    dependencies.save_rule_config(config)
+                    flash(f"{code} fatigue rule updated.", "ok")
+                elif action in {"add_custom", "update_custom"}:
+                    rule_type = request.form.get("rule_type") or ""
+                    if rule_type not in CUSTOM_FATIGUE_RULE_TYPES:
+                        raise ValueError("Choose a supported rule check.")
+                    name = (request.form.get("name") or "").strip()
+                    if len(name) < 3:
+                        raise ValueError("Give the rule a clear name.")
+                    threshold = float(request.form.get("threshold") or 0)
+                    if threshold <= 0:
+                        raise ValueError("The limit must be greater than zero.")
+                    type_meta = CUSTOM_FATIGUE_RULE_TYPES[rule_type]
+                    window_days = int(
+                        request.form.get("window_days")
+                        or type_meta.get("default_window", 1)
+                    )
+                    if not 1 <= window_days <= 365:
+                        raise ValueError("The review period must be 1–365 days.")
+                    severity = request.form.get("severity")
+                    if severity not in {"warning", "critical"}:
+                        severity = "warning"
+                    code = (request.form.get("code") or "").upper()
+                    existing = next((
+                        item for item in config["custom"]
+                        if item.get("code") == code
+                    ), None)
+                    if action == "update_custom" and not existing:
+                        abort(404)
+                    if not existing:
+                        existing = {
+                            "code": f"USR-{secrets.token_hex(3).upper()}"
+                        }
+                        config["custom"].append(existing)
+                    existing.update({
+                        "name": name[:120],
+                        "rule_type": rule_type,
+                        "threshold": threshold,
+                        "window_days": window_days,
+                        "severity": severity,
+                        "enabled": request.form.get("enabled") == "on",
+                    })
+                    dependencies.save_rule_config(config)
+                    flash(f"{existing['code']} fatigue rule saved.", "ok")
+                elif action == "delete_custom":
+                    code = (request.form.get("code") or "").upper()
+                    before = len(config["custom"])
+                    config["custom"] = [
+                        item for item in config["custom"]
+                        if item.get("code") != code
+                    ]
+                    if len(config["custom"]) == before:
+                        abort(404)
+                    dependencies.save_rule_config(config)
+                    flash(f"{code} custom fatigue rule removed.", "ok")
+                else:
+                    abort(400)
+            except (TypeError, ValueError) as exc:
+                flash(str(exc), "error")
+            return redirect(url_for("admin_fatigue_rules"))
+        return render_template(
+            "admin_fatigue_rules.html",
+            system_rules=list(config["system"].values()),
+            custom_rules=config["custom"],
+            definitions=config["definitions"],
+            rule_types=CUSTOM_FATIGUE_RULE_TYPES,
+            current_unit=dependencies.db.session.get(
+                dependencies.Unit, dependencies.current_unit_id()
+            ),
+        )
+
+    @login_required
+    def compliance_centre_export():
+        """Retired with the standalone Compliance Centre."""
+        if not dependencies.is_admin_user(current_user):
+            abort(403)
+        year, month = compliance_month(request.args.get("ym"))
+        return redirect(url_for("roster_month", ym=f"{year:04d}-{month:02d}"))
+
+    @blueprint.record_once
+    def register_routes(state):
+        routes = (
+            ("/compliance-centre", "compliance_centre", compliance_centre, ["GET"]),
+            (
+                "/admin/fatigue-rules",
+                "admin_fatigue_rules",
+                admin_fatigue_rules,
+                ["GET", "POST"],
+            ),
+            (
+                "/compliance-centre/export",
+                "compliance_centre_export",
+                compliance_centre_export,
+                ["GET"],
+            ),
+        )
+        for rule, endpoint, view_func, methods in routes:
+            state.app.add_url_rule(
+                rule, endpoint=endpoint, view_func=view_func, methods=methods
+            )
+
+    return blueprint

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -23,6 +23,7 @@ if os.path.exists(TEST_DB_PATH):
 os.environ["DATABASE_URL"] = f"sqlite:///{TEST_DB_PATH}"
 
 import app
+import fatigue_compliance
 import fatigue_engine
 from app import (
     AnnotationAudit,
@@ -1481,6 +1482,11 @@ def test_d24_requires_a_complete_observation_window(client):
             observation_start=start - timedelta(days=30),
         )
     assert app._analyze_segments is fatigue_engine._analyze_segments
+    assert app._compliance_month is fatigue_compliance.compliance_month
+    assert (
+        app._fatigue_rule_config
+        == app._fatigue_rule_config_service.load
+    )
     assert not any(
         message.startswith("D24:")
         for messages in without_history.values()


### PR DESCRIPTION
## What changed

- moved airport-scoped fatigue rule configuration loading and persistence from `app.py` into `fatigue_compliance.py`
- moved the fatigue administration and retired compliance redirect routes into an explicitly wired blueprint
- retained the original unprefixed Flask endpoint names, URLs, methods, permission checks, tenant selection, CSRF validation, templates, flashes, redirects, and transaction boundary
- added compatibility assertions and updated the architecture ownership inventory

## Why

This is the next incremental step in reducing the monolithic application module without changing production behaviour. It reduces `app.py` from 9,263 to 9,047 lines in this slice, and from 9,675 to 9,047 lines across the two fatigue extractions.

## Impact

There is no intended user-facing or schema change. Fatigue configuration remains scoped to the authenticated airport and all existing links continue to use the same endpoint names.

## Validation

- Python compilation passed
- Ruff passed for the new module
- focused routes and route-map contract: 93 passed
- full suite: 298 passed, 11 skipped
- `git diff --check` passed
