### PR TITLE
Add flexible roster pattern foundation

### DIFF
--- a/app.py
+++ b/app.py
@@ -82,6 +82,7 @@ from fatigue_compliance import (
     compliance_month,
     create_fatigue_compliance_blueprint,
 )
+from work_pattern_service import WorkPatternDependencies, WorkPatternService
 from access_policy import (
     has_permission,
     is_admin,
@@ -260,7 +261,9 @@ OPERATIONAL_TABLE_NAMES = frozenset({
     "position_participant_role", "position_status_event",
     "position_session", "position_session_participant",
     "controller_kiosk_credential", "position_session_audit",
-    "toil_transaction",
+    "toil_transaction", "work_pattern", "work_pattern_day",
+    "work_pattern_day_allowed_shift", "staff_pattern_assignment",
+    "staff_rule",
 })
 
 
@@ -1165,7 +1168,10 @@ class ShiftType(db.Model):
     is_active = db.Column(db.Boolean, nullable=False, default=True)
     is_requestable = db.Column(db.Boolean, nullable=False, default=False)
     required_qualification = db.Column(db.String(40), nullable=False, default="")
-    __table_args__ = (db.UniqueConstraint("unit_id", "code", name="uq_shift_unit_code"),)
+    __table_args__ = (
+        db.UniqueConstraint("unit_id", "code", name="uq_shift_unit_code"),
+        db.UniqueConstraint("unit_id", "id", name="uq_shift_unit_id"),
+    )
 
 
 class Requirement(db.Model):
@@ -1394,6 +1400,11 @@ BreakPlan = SaaS.BreakPlan
 AchievedDuty = SaaS.AchievedDuty
 FatigueReport = SaaS.FatigueReport
 ToilTransaction = SaaS.ToilTransaction
+WorkPattern = SaaS.WorkPattern
+WorkPatternDay = SaaS.WorkPatternDay
+WorkPatternDayAllowedShift = SaaS.WorkPatternDayAllowedShift
+StaffPatternAssignment = SaaS.StaffPatternAssignment
+StaffRule = SaaS.StaffRule
 RosterRuleVersion = SaaS.RosterRuleVersion
 MfaCredential = SaaS.MfaCredential
 
@@ -1425,7 +1436,8 @@ TENANT_OPERATIONAL_MODELS = (
     BriefingAudit,
     BriefingAssuranceRun,
     TrainingLevel, TrainingObjective, TrainingSession, TrainingScore,
-    ToilTransaction,
+    ToilTransaction, WorkPattern, WorkPatternDay,
+    WorkPatternDayAllowedShift, StaffPatternAssignment, StaffRule,
 )
 
 APPEND_ONLY_AUDIT_MODELS = (
@@ -8806,6 +8818,23 @@ from operations_blueprint import OperationsDependencies, create_operations_bluep
 from live_position_blueprint import (
     LivePositionDependencies, create_live_position_blueprint,
 )
+
+work_pattern_service = WorkPatternService(WorkPatternDependencies(
+    Staff=Staff,
+    ShiftType=ShiftType,
+    Leave=Leave,
+    Assignment=Assignment,
+    WorkPattern=WorkPattern,
+    WorkPatternDay=WorkPatternDay,
+    WorkPatternDayAllowedShift=WorkPatternDayAllowedShift,
+    StaffPatternAssignment=StaffPatternAssignment,
+    StaffRule=StaffRule,
+    shift_group=lambda shift: shift_counter_group(shift.code, shift.unit_id),
+))
+get_pattern_day_for_staff = work_pattern_service.get_pattern_day_for_staff
+get_effective_staff_rules = work_pattern_service.get_effective_staff_rules
+is_staff_eligible_for_shift = work_pattern_service.is_staff_eligible_for_shift
+calculate_soft_rule_penalty = work_pattern_service.calculate_soft_rule_penalty
 
 app.register_blueprint(create_live_position_blueprint(LivePositionDependencies(
     db=db, Unit=Unit, OperationalPosition=OperationalPosition,

--- a/docs/flexible_roster_design.md
+++ b/docs/flexible_roster_design.md
@@ -1,0 +1,54 @@
+# Flexible roster engine design
+
+## Stage 1 foundation
+
+The normalised pattern engine is an additive operational-domain capability.
+Existing unit, watch and staff CSV patterns remain unchanged and continue to
+drive roster generation until an integration stage explicitly opts a workflow
+into the new resolver. Creating the new tables therefore cannot rewrite an
+assignment, change a published snapshot or alter historical roster output.
+
+All pattern and staff-rule rows are airport scoped. Composite foreign keys bind
+staff, shift, pattern and pattern-day references to the same airport. The tables
+are migrated only in operational databases; the control database stores no
+staff restrictions or working-pattern details.
+
+## Pattern-day calculation
+
+`StaffPatternAssignment` is effective dated. The applicable row is the latest
+assignment whose inclusive date range contains the requested date. Its cycle
+index is calculated as:
+
+```text
+(anchor_day_index + requested_date - anchor_date) modulo cycle_length_days
+```
+
+This supports dates before and after the anchor and prevents later pattern
+changes from altering earlier resolutions. Overlapping assignments are rejected
+by the service before persistence. PostgreSQL exclusion constraints are not used
+because the project supports SQLite for development and tests; the same service
+validation must be used by every write interface.
+
+Every pattern day uses a controlled day-type value. Allowed shift sets are rows
+in `WorkPatternDayAllowedShift`, not free text. `weekdays_mask` on a staff rule
+is a seven-bit integer where bit zero is Monday and bit six is Sunday.
+
+## Hard and soft rules
+
+Hard rules return an ineligible result with stable reason codes and human-readable
+explanations. Soft rules never make an otherwise legal assignment eligible or
+ineligible; they add their configured penalty and structured explanation. Leave
+is treated as a hard blocker. Existing fatigue, medical, qualification and
+endorsement checks remain authoritative and will be composed with this service
+in the roster-validation stage rather than duplicated here.
+
+Count and minutes rules use `rolling_period_days`. `maximum_count` stores either
+the maximum duty count or maximum minutes according to `rule_type`. This shared
+typed representation avoids adding a new staff column for each future rule.
+
+## Compatibility and next integration boundary
+
+The first consumer will be the roster-validation service. CSV migration, pattern
+administration, fairness calculations and automatic proposals are separate
+stages. No optimiser may write live assignments directly; generated duties will
+remain proposal records until an authorised user accepts them.

--- a/migrations/fresh_schema.py
+++ b/migrations/fresh_schema.py
@@ -393,6 +393,7 @@ def create_fresh_schema():
         sa.Column('leave_carryover_days', sa.Integer()),
         sa.UniqueConstraint('username'),
         sa.UniqueConstraint('unit_id', 'staff_no', name='uq_staff_unit_number'),
+        sa.UniqueConstraint('unit_id', 'id', name='uq_staff_unit_id'),
         sa.UniqueConstraint('calendar_token'),
     )
     op.create_index('ix_staff_unit_id', 'staff', ['unit_id'], unique=False)

--- a/migrations/fresh_schema.py
+++ b/migrations/fresh_schema.py
@@ -311,6 +311,7 @@ def create_fresh_schema():
         sa.Column('is_requestable', sa.Boolean(), nullable=False),
         sa.Column('required_qualification', sa.String(40), nullable=False),
         sa.UniqueConstraint('unit_id', 'code', name='uq_shift_unit_code'),
+        sa.UniqueConstraint('unit_id', 'id', name='uq_shift_unit_id'),
     )
     op.create_index('ix_shift_type_unit_id', 'shift_type', ['unit_id'], unique=False)
     op.create_table('super_admin_audit',
@@ -609,3 +610,109 @@ def create_fresh_schema():
     )
     op.create_index('ix_request_audit_request_id', 'request_audit', ['request_id'], unique=False)
     op.create_index('ix_request_audit_unit_id', 'request_audit', ['unit_id'], unique=False)
+    op.create_table('work_pattern',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('unit_id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.String(120), nullable=False),
+        sa.Column('description', sa.Text(), nullable=False),
+        sa.Column('cycle_length_days', sa.Integer(), nullable=False),
+        sa.Column('contracted_minutes_per_cycle', sa.Integer(), nullable=False),
+        sa.Column('is_active', sa.Boolean(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.UniqueConstraint('unit_id', 'name', name='uq_work_pattern_unit_name'),
+        sa.UniqueConstraint('unit_id', 'id', name='uq_work_pattern_unit_id'),
+        sa.CheckConstraint('cycle_length_days > 0', name='ck_work_pattern_cycle_positive'),
+        sa.CheckConstraint('contracted_minutes_per_cycle >= 0', name='ck_work_pattern_minutes_nonnegative'),
+    )
+    op.create_index('ix_work_pattern_unit_id', 'work_pattern', ['unit_id'], unique=False)
+    op.create_table('work_pattern_day',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('unit_id', sa.Integer(), nullable=False),
+        sa.Column('work_pattern_id', sa.Integer(), nullable=False),
+        sa.Column('day_index', sa.Integer(), nullable=False),
+        sa.Column('day_type', sa.String(32), nullable=False),
+        sa.Column('fixed_shift_type_id', sa.Integer()),
+        sa.Column('required_work', sa.Boolean(), nullable=False),
+        sa.Column('notes', sa.String(500), nullable=False),
+        sa.ForeignKeyConstraint(['unit_id', 'work_pattern_id'], ['work_pattern.unit_id', 'work_pattern.id'], name='fk_work_pattern_day_pattern_unit', ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['unit_id', 'fixed_shift_type_id'], ['shift_type.unit_id', 'shift_type.id'], name='fk_work_pattern_day_shift_unit'),
+        sa.UniqueConstraint('unit_id', 'work_pattern_id', 'day_index', name='uq_work_pattern_day_index'),
+        sa.UniqueConstraint('unit_id', 'id', name='uq_work_pattern_day_unit_id'),
+        sa.CheckConstraint('day_index >= 0', name='ck_work_pattern_day_index_nonnegative'),
+        sa.CheckConstraint("day_type IN ('FIXED_SHIFT','WORK_ANY','WORK_ALLOWED_SET','OFF','OPTIONAL_WORK','PROTECTED_NON_OPERATIONAL')", name='ck_work_pattern_day_type'),
+        sa.CheckConstraint("(day_type = 'FIXED_SHIFT' AND fixed_shift_type_id IS NOT NULL) OR (day_type <> 'FIXED_SHIFT' AND fixed_shift_type_id IS NULL)", name='ck_work_pattern_day_fixed_shift'),
+    )
+    op.create_index('ix_work_pattern_day_unit_id', 'work_pattern_day', ['unit_id'], unique=False)
+    op.create_index('ix_work_pattern_day_work_pattern_id', 'work_pattern_day', ['work_pattern_id'], unique=False)
+    op.create_table('work_pattern_day_allowed_shift',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('unit_id', sa.Integer(), nullable=False),
+        sa.Column('work_pattern_day_id', sa.Integer(), nullable=False),
+        sa.Column('shift_type_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['unit_id', 'work_pattern_day_id'], ['work_pattern_day.unit_id', 'work_pattern_day.id'], name='fk_pattern_allowed_day_unit', ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['unit_id', 'shift_type_id'], ['shift_type.unit_id', 'shift_type.id'], name='fk_pattern_allowed_shift_unit'),
+        sa.UniqueConstraint('unit_id', 'work_pattern_day_id', 'shift_type_id', name='uq_pattern_day_allowed_shift'),
+    )
+    op.create_index('ix_pattern_allowed_unit_id', 'work_pattern_day_allowed_shift', ['unit_id'], unique=False)
+    op.create_index('ix_pattern_allowed_day_id', 'work_pattern_day_allowed_shift', ['work_pattern_day_id'], unique=False)
+    op.create_index('ix_pattern_allowed_shift_id', 'work_pattern_day_allowed_shift', ['shift_type_id'], unique=False)
+    op.create_table('staff_pattern_assignment',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('unit_id', sa.Integer(), nullable=False),
+        sa.Column('staff_id', sa.Integer(), nullable=False),
+        sa.Column('work_pattern_id', sa.Integer(), nullable=False),
+        sa.Column('effective_from', sa.Date(), nullable=False),
+        sa.Column('effective_to', sa.Date()),
+        sa.Column('anchor_date', sa.Date(), nullable=False),
+        sa.Column('anchor_day_index', sa.Integer(), nullable=False),
+        sa.Column('contracted_minutes_override', sa.Integer()),
+        sa.Column('notes', sa.String(500), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['unit_id', 'staff_id'], ['staff.unit_id', 'staff.id'], name='fk_staff_pattern_person_unit', ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['unit_id', 'work_pattern_id'], ['work_pattern.unit_id', 'work_pattern.id'], name='fk_staff_pattern_pattern_unit'),
+        sa.CheckConstraint('effective_to IS NULL OR effective_to >= effective_from', name='ck_staff_pattern_effective_range'),
+        sa.CheckConstraint('anchor_day_index >= 0', name='ck_staff_pattern_anchor_index'),
+        sa.CheckConstraint('contracted_minutes_override IS NULL OR contracted_minutes_override >= 0', name='ck_staff_pattern_minutes_nonnegative'),
+    )
+    op.create_index('ix_staff_pattern_unit_id', 'staff_pattern_assignment', ['unit_id'], unique=False)
+    op.create_index('ix_staff_pattern_staff_id', 'staff_pattern_assignment', ['staff_id'], unique=False)
+    op.create_index('ix_staff_pattern_pattern_id', 'staff_pattern_assignment', ['work_pattern_id'], unique=False)
+    op.create_index('ix_staff_pattern_effective_from', 'staff_pattern_assignment', ['effective_from'], unique=False)
+    op.create_index('ix_staff_pattern_effective_to', 'staff_pattern_assignment', ['effective_to'], unique=False)
+    op.create_table('staff_rule',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('unit_id', sa.Integer(), nullable=False),
+        sa.Column('staff_id', sa.Integer(), nullable=False),
+        sa.Column('rule_type', sa.String(40), nullable=False),
+        sa.Column('hardness', sa.String(8), nullable=False),
+        sa.Column('effective_from', sa.Date(), nullable=False),
+        sa.Column('effective_to', sa.Date()),
+        sa.Column('shift_type_id', sa.Integer()),
+        sa.Column('shift_group', sa.String(20)),
+        sa.Column('maximum_count', sa.Integer()),
+        sa.Column('rolling_period_days', sa.Integer()),
+        sa.Column('weekdays_mask', sa.Integer()),
+        sa.Column('penalty_weight', sa.Integer(), nullable=False),
+        sa.Column('reason', sa.String(500), nullable=False),
+        sa.Column('authorised_by_user_id', sa.Integer()),
+        sa.Column('is_active', sa.Boolean(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['unit_id', 'staff_id'], ['staff.unit_id', 'staff.id'], name='fk_staff_rule_person_unit', ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['unit_id', 'shift_type_id'], ['shift_type.unit_id', 'shift_type.id'], name='fk_staff_rule_shift_unit'),
+        sa.ForeignKeyConstraint(['unit_id', 'authorised_by_user_id'], ['staff.unit_id', 'staff.id'], name='fk_staff_rule_authoriser_unit'),
+        sa.CheckConstraint("hardness IN ('HARD','SOFT')", name='ck_staff_rule_hardness'),
+        sa.CheckConstraint("rule_type IN ('NO_NIGHT','AVOID_NIGHT','NO_EARLY','AVOID_EARLY','ALLOWED_SHIFT','DISALLOWED_SHIFT','MAX_NIGHTS_PER_CYCLE','MAX_SHIFTS_PER_CYCLE','AVAILABLE_WEEKDAYS','UNAVAILABLE_WEEKDAYS','MAX_CONTRACTED_MINUTES','PREFERRED_SHIFT','PREFERRED_DAY_OFF')", name='ck_staff_rule_type'),
+        sa.CheckConstraint('effective_to IS NULL OR effective_to >= effective_from', name='ck_staff_rule_effective_range'),
+        sa.CheckConstraint('maximum_count IS NULL OR maximum_count >= 0', name='ck_staff_rule_maximum_nonnegative'),
+        sa.CheckConstraint('rolling_period_days IS NULL OR rolling_period_days > 0', name='ck_staff_rule_period_positive'),
+        sa.CheckConstraint('weekdays_mask IS NULL OR (weekdays_mask >= 0 AND weekdays_mask <= 127)', name='ck_staff_rule_weekdays_mask'),
+        sa.CheckConstraint('penalty_weight >= 0', name='ck_staff_rule_penalty'),
+    )
+    op.create_index('ix_staff_rule_unit_id', 'staff_rule', ['unit_id'], unique=False)
+    op.create_index('ix_staff_rule_staff_id', 'staff_rule', ['staff_id'], unique=False)
+    op.create_index('ix_staff_rule_rule_type', 'staff_rule', ['rule_type'], unique=False)
+    op.create_index('ix_staff_rule_effective_from', 'staff_rule', ['effective_from'], unique=False)
+    op.create_index('ix_staff_rule_effective_to', 'staff_rule', ['effective_to'], unique=False)

--- a/migrations/versions/20260802_38_flexible_pattern_foundation.py
+++ b/migrations/versions/20260802_38_flexible_pattern_foundation.py
@@ -1,0 +1,228 @@
+"""Add flexible work patterns and effective-dated staff rules.
+
+Revision ID: 20260802_38
+Revises: 20260801_37
+"""
+
+import os
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260802_38"
+down_revision = "20260801_37"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = set(inspector.get_table_names())
+    # Some supported legacy fixtures contain only a subset of the roster
+    # schema. They remain migratable and are not suitable for pattern records
+    # until the prerequisite operational tables exist.
+    if not {"staff", "shift_type"}.issubset(tables):
+        return
+    shift_uniques = {
+        tuple(item.get("column_names") or ())
+        for item in inspector.get_unique_constraints("shift_type")
+    }
+    if ("unit_id", "id") not in shift_uniques:
+        with op.batch_alter_table("shift_type") as batch:
+            batch.create_unique_constraint("uq_shift_unit_id", ["unit_id", "id"])
+
+    # Revision 01 creates the current fresh schema in one pass. Consequently,
+    # a brand-new database already contains these tables by the time Alembic
+    # reaches this revision, whereas an upgraded database still needs them.
+    # Keep this revision safe for both paths.
+    pattern_tables = {
+        "work_pattern",
+        "work_pattern_day",
+        "work_pattern_day_allowed_shift",
+        "staff_pattern_assignment",
+        "staff_rule",
+    }
+    if pattern_tables.issubset(tables):
+        return
+
+    op.create_table(
+        "work_pattern",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("unit_id", sa.Integer(), nullable=False, index=True),
+        sa.Column("name", sa.String(120), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("cycle_length_days", sa.Integer(), nullable=False),
+        sa.Column(
+            "contracted_minutes_per_cycle", sa.Integer(),
+            nullable=False, server_default="0",
+        ),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.UniqueConstraint("unit_id", "name", name="uq_work_pattern_unit_name"),
+        sa.UniqueConstraint("unit_id", "id", name="uq_work_pattern_unit_id"),
+        sa.CheckConstraint("cycle_length_days > 0", name="ck_work_pattern_cycle_positive"),
+        sa.CheckConstraint(
+            "contracted_minutes_per_cycle >= 0",
+            name="ck_work_pattern_minutes_nonnegative",
+        ),
+    )
+    op.create_table(
+        "work_pattern_day",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("unit_id", sa.Integer(), nullable=False, index=True),
+        sa.Column("work_pattern_id", sa.Integer(), nullable=False, index=True),
+        sa.Column("day_index", sa.Integer(), nullable=False),
+        sa.Column("day_type", sa.String(32), nullable=False),
+        sa.Column("fixed_shift_type_id", sa.Integer()),
+        sa.Column("required_work", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("notes", sa.String(500), nullable=False, server_default=""),
+        sa.ForeignKeyConstraint(
+            ["unit_id", "work_pattern_id"],
+            ["work_pattern.unit_id", "work_pattern.id"],
+            name="fk_work_pattern_day_pattern_unit", ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["unit_id", "fixed_shift_type_id"],
+            ["shift_type.unit_id", "shift_type.id"],
+            name="fk_work_pattern_day_shift_unit",
+        ),
+        sa.UniqueConstraint(
+            "unit_id", "work_pattern_id", "day_index",
+            name="uq_work_pattern_day_index",
+        ),
+        sa.UniqueConstraint("unit_id", "id", name="uq_work_pattern_day_unit_id"),
+        sa.CheckConstraint("day_index >= 0", name="ck_work_pattern_day_index_nonnegative"),
+        sa.CheckConstraint(
+            "day_type IN ('FIXED_SHIFT','WORK_ANY','WORK_ALLOWED_SET','OFF',"
+            "'OPTIONAL_WORK','PROTECTED_NON_OPERATIONAL')",
+            name="ck_work_pattern_day_type",
+        ),
+        sa.CheckConstraint(
+            "(day_type = 'FIXED_SHIFT' AND fixed_shift_type_id IS NOT NULL) OR "
+            "(day_type <> 'FIXED_SHIFT' AND fixed_shift_type_id IS NULL)",
+            name="ck_work_pattern_day_fixed_shift",
+        ),
+    )
+    op.create_table(
+        "work_pattern_day_allowed_shift",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("unit_id", sa.Integer(), nullable=False, index=True),
+        sa.Column("work_pattern_day_id", sa.Integer(), nullable=False, index=True),
+        sa.Column("shift_type_id", sa.Integer(), nullable=False, index=True),
+        sa.ForeignKeyConstraint(
+            ["unit_id", "work_pattern_day_id"],
+            ["work_pattern_day.unit_id", "work_pattern_day.id"],
+            name="fk_pattern_allowed_day_unit", ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["unit_id", "shift_type_id"],
+            ["shift_type.unit_id", "shift_type.id"],
+            name="fk_pattern_allowed_shift_unit",
+        ),
+        sa.UniqueConstraint(
+            "unit_id", "work_pattern_day_id", "shift_type_id",
+            name="uq_pattern_day_allowed_shift",
+        ),
+    )
+    op.create_table(
+        "staff_pattern_assignment",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("unit_id", sa.Integer(), nullable=False, index=True),
+        sa.Column("staff_id", sa.Integer(), nullable=False, index=True),
+        sa.Column("work_pattern_id", sa.Integer(), nullable=False, index=True),
+        sa.Column("effective_from", sa.Date(), nullable=False, index=True),
+        sa.Column("effective_to", sa.Date(), index=True),
+        sa.Column("anchor_date", sa.Date(), nullable=False),
+        sa.Column("anchor_day_index", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("contracted_minutes_override", sa.Integer()),
+        sa.Column("notes", sa.String(500), nullable=False, server_default=""),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["unit_id", "staff_id"], ["staff.unit_id", "staff.id"],
+            name="fk_staff_pattern_person_unit", ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["unit_id", "work_pattern_id"],
+            ["work_pattern.unit_id", "work_pattern.id"],
+            name="fk_staff_pattern_pattern_unit",
+        ),
+        sa.CheckConstraint(
+            "effective_to IS NULL OR effective_to >= effective_from",
+            name="ck_staff_pattern_effective_range",
+        ),
+        sa.CheckConstraint("anchor_day_index >= 0", name="ck_staff_pattern_anchor_index"),
+        sa.CheckConstraint(
+            "contracted_minutes_override IS NULL OR contracted_minutes_override >= 0",
+            name="ck_staff_pattern_minutes_nonnegative",
+        ),
+    )
+    op.create_table(
+        "staff_rule",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("unit_id", sa.Integer(), nullable=False, index=True),
+        sa.Column("staff_id", sa.Integer(), nullable=False, index=True),
+        sa.Column("rule_type", sa.String(40), nullable=False, index=True),
+        sa.Column("hardness", sa.String(8), nullable=False),
+        sa.Column("effective_from", sa.Date(), nullable=False, index=True),
+        sa.Column("effective_to", sa.Date(), index=True),
+        sa.Column("shift_type_id", sa.Integer()),
+        sa.Column("shift_group", sa.String(20)),
+        sa.Column("maximum_count", sa.Integer()),
+        sa.Column("rolling_period_days", sa.Integer()),
+        sa.Column("weekdays_mask", sa.Integer()),
+        sa.Column("penalty_weight", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("reason", sa.String(500), nullable=False, server_default=""),
+        sa.Column("authorised_by_user_id", sa.Integer()),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["unit_id", "staff_id"], ["staff.unit_id", "staff.id"],
+            name="fk_staff_rule_person_unit", ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["unit_id", "shift_type_id"], ["shift_type.unit_id", "shift_type.id"],
+            name="fk_staff_rule_shift_unit",
+        ),
+        sa.ForeignKeyConstraint(
+            ["unit_id", "authorised_by_user_id"], ["staff.unit_id", "staff.id"],
+            name="fk_staff_rule_authoriser_unit",
+        ),
+        sa.CheckConstraint("hardness IN ('HARD','SOFT')", name="ck_staff_rule_hardness"),
+        sa.CheckConstraint(
+            "rule_type IN ('NO_NIGHT','AVOID_NIGHT','NO_EARLY','AVOID_EARLY',"
+            "'ALLOWED_SHIFT','DISALLOWED_SHIFT','MAX_NIGHTS_PER_CYCLE',"
+            "'MAX_SHIFTS_PER_CYCLE','AVAILABLE_WEEKDAYS','UNAVAILABLE_WEEKDAYS',"
+            "'MAX_CONTRACTED_MINUTES','PREFERRED_SHIFT','PREFERRED_DAY_OFF')",
+            name="ck_staff_rule_type",
+        ),
+        sa.CheckConstraint(
+            "effective_to IS NULL OR effective_to >= effective_from",
+            name="ck_staff_rule_effective_range",
+        ),
+        sa.CheckConstraint("maximum_count IS NULL OR maximum_count >= 0", name="ck_staff_rule_maximum_nonnegative"),
+        sa.CheckConstraint("rolling_period_days IS NULL OR rolling_period_days > 0", name="ck_staff_rule_period_positive"),
+        sa.CheckConstraint("weekdays_mask IS NULL OR (weekdays_mask >= 0 AND weekdays_mask <= 127)", name="ck_staff_rule_weekdays_mask"),
+        sa.CheckConstraint("penalty_weight >= 0", name="ck_staff_rule_penalty"),
+    )
+
+
+def downgrade() -> None:
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
+    tables = set(sa.inspect(op.get_bind()).get_table_names())
+    for table_name in (
+        "staff_rule",
+        "staff_pattern_assignment",
+        "work_pattern_day_allowed_shift",
+        "work_pattern_day",
+        "work_pattern",
+    ):
+        if table_name in tables:
+            op.drop_table(table_name)

--- a/saas_models.py
+++ b/saas_models.py
@@ -652,6 +652,186 @@ def register_saas_models(db, utcnow):
             ),
         )
 
+    class WorkPattern(db.Model):
+        __tablename__ = "work_pattern"
+        id = db.Column(db.Integer, primary_key=True)
+        unit_id = db.Column(db.Integer, db.ForeignKey("unit.id"), nullable=False, index=True)
+        name = db.Column(db.String(120), nullable=False)
+        description = db.Column(db.Text, nullable=False, default="")
+        cycle_length_days = db.Column(db.Integer, nullable=False)
+        contracted_minutes_per_cycle = db.Column(db.Integer, nullable=False, default=0)
+        is_active = db.Column(db.Boolean, nullable=False, default=True)
+        created_at = db.Column(db.DateTime, nullable=False, default=utcnow)
+        updated_at = db.Column(db.DateTime, nullable=False, default=utcnow, onupdate=utcnow)
+        __table_args__ = (
+            db.UniqueConstraint("unit_id", "name", name="uq_work_pattern_unit_name"),
+            db.UniqueConstraint("unit_id", "id", name="uq_work_pattern_unit_id"),
+            db.CheckConstraint("cycle_length_days > 0", name="ck_work_pattern_cycle_positive"),
+            db.CheckConstraint(
+                "contracted_minutes_per_cycle >= 0",
+                name="ck_work_pattern_minutes_nonnegative",
+            ),
+        )
+
+    class WorkPatternDay(db.Model):
+        __tablename__ = "work_pattern_day"
+        id = db.Column(db.Integer, primary_key=True)
+        unit_id = db.Column(db.Integer, nullable=False, index=True)
+        work_pattern_id = db.Column(db.Integer, nullable=False, index=True)
+        day_index = db.Column(db.Integer, nullable=False)
+        day_type = db.Column(db.String(32), nullable=False)
+        fixed_shift_type_id = db.Column(db.Integer)
+        required_work = db.Column(db.Boolean, nullable=False, default=False)
+        notes = db.Column(db.String(500), nullable=False, default="")
+        __table_args__ = (
+            db.ForeignKeyConstraint(
+                ["unit_id", "work_pattern_id"],
+                ["work_pattern.unit_id", "work_pattern.id"],
+                name="fk_work_pattern_day_pattern_unit", ondelete="CASCADE",
+            ),
+            db.ForeignKeyConstraint(
+                ["unit_id", "fixed_shift_type_id"],
+                ["shift_type.unit_id", "shift_type.id"],
+                name="fk_work_pattern_day_shift_unit",
+            ),
+            db.UniqueConstraint(
+                "unit_id", "work_pattern_id", "day_index",
+                name="uq_work_pattern_day_index",
+            ),
+            db.UniqueConstraint("unit_id", "id", name="uq_work_pattern_day_unit_id"),
+            db.CheckConstraint("day_index >= 0", name="ck_work_pattern_day_index_nonnegative"),
+            db.CheckConstraint(
+                "day_type IN ('FIXED_SHIFT','WORK_ANY','WORK_ALLOWED_SET','OFF',"
+                "'OPTIONAL_WORK','PROTECTED_NON_OPERATIONAL')",
+                name="ck_work_pattern_day_type",
+            ),
+            db.CheckConstraint(
+                "(day_type = 'FIXED_SHIFT' AND fixed_shift_type_id IS NOT NULL) OR "
+                "(day_type <> 'FIXED_SHIFT' AND fixed_shift_type_id IS NULL)",
+                name="ck_work_pattern_day_fixed_shift",
+            ),
+        )
+
+    class WorkPatternDayAllowedShift(db.Model):
+        __tablename__ = "work_pattern_day_allowed_shift"
+        id = db.Column(db.Integer, primary_key=True)
+        unit_id = db.Column(db.Integer, nullable=False, index=True)
+        work_pattern_day_id = db.Column(db.Integer, nullable=False, index=True)
+        shift_type_id = db.Column(db.Integer, nullable=False, index=True)
+        __table_args__ = (
+            db.ForeignKeyConstraint(
+                ["unit_id", "work_pattern_day_id"],
+                ["work_pattern_day.unit_id", "work_pattern_day.id"],
+                name="fk_pattern_allowed_day_unit", ondelete="CASCADE",
+            ),
+            db.ForeignKeyConstraint(
+                ["unit_id", "shift_type_id"],
+                ["shift_type.unit_id", "shift_type.id"],
+                name="fk_pattern_allowed_shift_unit",
+            ),
+            db.UniqueConstraint(
+                "unit_id", "work_pattern_day_id", "shift_type_id",
+                name="uq_pattern_day_allowed_shift",
+            ),
+        )
+
+    class StaffPatternAssignment(db.Model):
+        __tablename__ = "staff_pattern_assignment"
+        id = db.Column(db.Integer, primary_key=True)
+        unit_id = db.Column(db.Integer, nullable=False, index=True)
+        staff_id = db.Column(db.Integer, nullable=False, index=True)
+        work_pattern_id = db.Column(db.Integer, nullable=False, index=True)
+        effective_from = db.Column(db.Date, nullable=False, index=True)
+        effective_to = db.Column(db.Date, index=True)
+        anchor_date = db.Column(db.Date, nullable=False)
+        anchor_day_index = db.Column(db.Integer, nullable=False, default=0)
+        contracted_minutes_override = db.Column(db.Integer)
+        notes = db.Column(db.String(500), nullable=False, default="")
+        created_at = db.Column(db.DateTime, nullable=False, default=utcnow)
+        updated_at = db.Column(db.DateTime, nullable=False, default=utcnow, onupdate=utcnow)
+        __table_args__ = (
+            db.ForeignKeyConstraint(
+                ["unit_id", "staff_id"], ["staff.unit_id", "staff.id"],
+                name="fk_staff_pattern_person_unit", ondelete="CASCADE",
+            ),
+            db.ForeignKeyConstraint(
+                ["unit_id", "work_pattern_id"],
+                ["work_pattern.unit_id", "work_pattern.id"],
+                name="fk_staff_pattern_pattern_unit",
+            ),
+            db.CheckConstraint(
+                "effective_to IS NULL OR effective_to >= effective_from",
+                name="ck_staff_pattern_effective_range",
+            ),
+            db.CheckConstraint("anchor_day_index >= 0", name="ck_staff_pattern_anchor_index"),
+            db.CheckConstraint(
+                "contracted_minutes_override IS NULL OR contracted_minutes_override >= 0",
+                name="ck_staff_pattern_minutes_nonnegative",
+            ),
+        )
+
+    class StaffRule(db.Model):
+        __tablename__ = "staff_rule"
+        id = db.Column(db.Integer, primary_key=True)
+        unit_id = db.Column(db.Integer, nullable=False, index=True)
+        staff_id = db.Column(db.Integer, nullable=False, index=True)
+        rule_type = db.Column(db.String(40), nullable=False, index=True)
+        hardness = db.Column(db.String(8), nullable=False)
+        effective_from = db.Column(db.Date, nullable=False, index=True)
+        effective_to = db.Column(db.Date, index=True)
+        shift_type_id = db.Column(db.Integer)
+        shift_group = db.Column(db.String(20))
+        maximum_count = db.Column(db.Integer)
+        rolling_period_days = db.Column(db.Integer)
+        weekdays_mask = db.Column(db.Integer)
+        penalty_weight = db.Column(db.Integer, nullable=False, default=1)
+        reason = db.Column(db.String(500), nullable=False, default="")
+        authorised_by_user_id = db.Column(db.Integer)
+        is_active = db.Column(db.Boolean, nullable=False, default=True)
+        created_at = db.Column(db.DateTime, nullable=False, default=utcnow)
+        updated_at = db.Column(db.DateTime, nullable=False, default=utcnow, onupdate=utcnow)
+        __table_args__ = (
+            db.ForeignKeyConstraint(
+                ["unit_id", "staff_id"], ["staff.unit_id", "staff.id"],
+                name="fk_staff_rule_person_unit", ondelete="CASCADE",
+            ),
+            db.ForeignKeyConstraint(
+                ["unit_id", "shift_type_id"],
+                ["shift_type.unit_id", "shift_type.id"],
+                name="fk_staff_rule_shift_unit",
+            ),
+            db.ForeignKeyConstraint(
+                ["unit_id", "authorised_by_user_id"],
+                ["staff.unit_id", "staff.id"],
+                name="fk_staff_rule_authoriser_unit",
+            ),
+            db.CheckConstraint("hardness IN ('HARD','SOFT')", name="ck_staff_rule_hardness"),
+            db.CheckConstraint(
+                "rule_type IN ('NO_NIGHT','AVOID_NIGHT','NO_EARLY','AVOID_EARLY',"
+                "'ALLOWED_SHIFT','DISALLOWED_SHIFT','MAX_NIGHTS_PER_CYCLE',"
+                "'MAX_SHIFTS_PER_CYCLE','AVAILABLE_WEEKDAYS','UNAVAILABLE_WEEKDAYS',"
+                "'MAX_CONTRACTED_MINUTES','PREFERRED_SHIFT','PREFERRED_DAY_OFF')",
+                name="ck_staff_rule_type",
+            ),
+            db.CheckConstraint(
+                "effective_to IS NULL OR effective_to >= effective_from",
+                name="ck_staff_rule_effective_range",
+            ),
+            db.CheckConstraint(
+                "maximum_count IS NULL OR maximum_count >= 0",
+                name="ck_staff_rule_maximum_nonnegative",
+            ),
+            db.CheckConstraint(
+                "rolling_period_days IS NULL OR rolling_period_days > 0",
+                name="ck_staff_rule_period_positive",
+            ),
+            db.CheckConstraint(
+                "weekdays_mask IS NULL OR (weekdays_mask >= 0 AND weekdays_mask <= 127)",
+                name="ck_staff_rule_weekdays_mask",
+            ),
+            db.CheckConstraint("penalty_weight >= 0", name="ck_staff_rule_penalty"),
+        )
+
     class RosterRuleVersion(db.Model):
         __tablename__ = "roster_rule_version"
         id = db.Column(db.Integer, primary_key=True)

--- a/tests/test_legacy_migration_fixtures.py
+++ b/tests/test_legacy_migration_fixtures.py
@@ -120,11 +120,19 @@ def test_legacy_fixture_upgrades_to_head_without_data_loss(fixture_name, tmp_pat
     assert result.returncode == 0, result.stdout + result.stderr
     with engine.connect() as connection:
         inspector = inspect(connection)
+        if "staff" in inspector.get_table_names() and "shift_type" in inspector.get_table_names():
+            assert {
+                "work_pattern",
+                "work_pattern_day",
+                "work_pattern_day_allowed_shift",
+                "staff_pattern_assignment",
+                "staff_rule",
+            } <= set(inspector.get_table_names())
         assert (
             connection.execute(
                 text("SELECT version_num FROM alembic_version")
             ).scalar_one()
-            == "20260801_37"
+            == "20260802_38"
         )
         for table, count in before.items():
             assert (

--- a/tests/test_postgresql_multidatabase.py
+++ b/tests/test_postgresql_multidatabase.py
@@ -97,9 +97,9 @@ def test_postgresql_control_and_two_airport_databases_are_isolated(
     dispose_operational_engines()
     for url in (CONTROL_URL, AIRPORT_A_URL, AIRPORT_B_URL):
         _reset_postgres(url)
-    assert upgrade_database(CONTROL_URL, "control") == "20260801_37"
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260801_37"
-    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260801_37"
+    assert upgrade_database(CONTROL_URL, "control") == "20260802_38"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260802_38"
+    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260802_38"
     secret_a = "ATCROSTER_UNIT_1_DATABASE_URL"
     secret_b = "ATCROSTER_UNIT_2_DATABASE_URL"
     monkeypatch.setenv(secret_a, AIRPORT_A_URL)
@@ -281,7 +281,7 @@ def test_postgresql_control_and_two_airport_databases_are_isolated(
 def test_generated_postgresql_backup_restores_and_preserves_key_records(tmp_path):
     _reset_postgres(AIRPORT_A_URL)
     _reset_postgres(RESTORE_URL)
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260801_37"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260802_38"
     source = create_engine(AIRPORT_A_URL)
     with source.begin() as connection:
         connection.execute(
@@ -298,7 +298,7 @@ def test_generated_postgresql_backup_restores_and_preserves_key_records(tmp_path
         AIRPORT_A_URL, tmp_path, "airport-test", "operational"
     )
     result = restore_backup(archive, metadata, RESTORE_URL)
-    assert result.alembic_revision == "20260801_37"
+    assert result.alembic_revision == "20260802_38"
     restored = create_engine(RESTORE_URL)
     try:
         with restored.connect() as connection:
@@ -331,7 +331,7 @@ def _insert_staff(connection, unit_id, username):
 
 def test_postgresql_rejects_cross_unit_operational_relationships():
     _reset_postgres(AIRPORT_A_URL)
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260801_37"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260802_38"
     engine = create_engine(AIRPORT_A_URL)
     try:
         with engine.begin() as connection:
@@ -381,7 +381,7 @@ def test_tenant_integrity_migration_refuses_inconsistent_legacy_data():
 
 def test_postgresql_concurrent_toil_retry_changes_balance_once(monkeypatch):
     _reset_postgres(AIRPORT_A_URL)
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260801_37"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260802_38"
     engine = create_engine(AIRPORT_A_URL)
     with engine.begin() as connection:
         person_id = _insert_staff(connection, 1, "toil-concurrency")
@@ -451,7 +451,7 @@ def test_postgresql_concurrent_toil_retry_changes_balance_once(monkeypatch):
 
 def test_postgresql_runtime_role_cannot_mutate_audit_evidence():
     _reset_postgres(AIRPORT_B_URL)
-    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260801_37"
+    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260802_38"
     role = f"atcroster_runtime_{os.getpid()}"
     password = "runtime-integration-only"
     owner_dsn = str(
@@ -511,7 +511,7 @@ def test_postgresql_runtime_role_cannot_mutate_audit_evidence():
 
 def test_postgresql_two_roster_editors_reject_the_stale_cell_version():
     _reset_postgres(AIRPORT_A_URL)
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260801_37"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260802_38"
     engine = create_engine(AIRPORT_A_URL)
     with engine.begin() as connection:
         person_id = _insert_staff(connection, 1, "roster-race")
@@ -562,7 +562,7 @@ def test_postgresql_two_roster_editors_reject_the_stale_cell_version():
 
 def test_postgresql_two_managers_create_one_request_transition_and_side_effects():
     _reset_postgres(AIRPORT_A_URL)
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260801_37"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260802_38"
     engine = create_engine(AIRPORT_A_URL)
     with engine.begin() as connection:
         person_id = _insert_staff(connection, 1, "request-race")
@@ -641,7 +641,7 @@ def test_postgresql_two_managers_create_one_request_transition_and_side_effects(
 
 def test_postgresql_publication_and_roster_mutations_share_a_coherent_month_lock():
     _reset_postgres(AIRPORT_A_URL)
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260801_37"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260802_38"
     dsn = (
         make_url(AIRPORT_A_URL)
         .set(drivername="postgresql")
@@ -767,7 +767,7 @@ def test_postgresql_live_position_logon_retry_tenant_scope_and_handover_races(
     monkeypatch,
 ):
     _reset_postgres(AIRPORT_A_URL)
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260801_37"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260802_38"
     secret_name = "ATCROSTER_TEST_LIVE_CONCURRENCY_DATABASE_URL"
     monkeypatch.setenv(secret_name, AIRPORT_A_URL)
     dispose_operational_engines()

--- a/tests/test_work_pattern_service.py
+++ b/tests/test_work_pattern_service.py
@@ -1,0 +1,294 @@
+from datetime import date, time
+
+import pytest
+
+import app
+from work_pattern_service import WorkPatternDependencies, WorkPatternService
+
+
+@pytest.fixture()
+def pattern_service():
+    with app.app.app_context():
+        app.db.create_all()
+        unit = app.Unit.query.filter_by(code="WPAT").first()
+        if not unit:
+            unit = app.Unit(
+                code="WPAT", name="Pattern Test Airport", onboarding_step=100
+            )
+            app.db.session.add(unit)
+            app.db.session.flush()
+        shifts = {}
+        for code, start, end in (
+            ("M", time(6), time(14)),
+            ("D", time(8), time(16)),
+            ("A", time(14), time(22)),
+            ("N", time(22), time(6)),
+        ):
+            shift = app.ShiftType.query.filter_by(unit_id=unit.id, code=code).first()
+            if not shift:
+                shift = app.ShiftType(
+                    unit_id=unit.id, code=code, name=code,
+                    start_time=start, end_time=end, is_working=True,
+                )
+                app.db.session.add(shift)
+                app.db.session.flush()
+            shifts[code] = shift
+        person = app.Staff.query.filter_by(
+            unit_id=unit.id, staff_no="WP-001"
+        ).first()
+        if not person:
+            person = app.Staff(
+                unit_id=unit.id,
+                username="work_pattern_test_person",
+                password_hash="unused",
+                name="Pattern Test Person",
+                staff_no="WP-001",
+                role="user",
+            )
+            app.db.session.add(person)
+            app.db.session.flush()
+        app.db.session.commit()
+
+        service = WorkPatternService(WorkPatternDependencies(
+            Staff=app.Staff,
+            ShiftType=app.ShiftType,
+            Leave=app.Leave,
+            Assignment=app.Assignment,
+            WorkPattern=app.WorkPattern,
+            WorkPatternDay=app.WorkPatternDay,
+            WorkPatternDayAllowedShift=app.WorkPatternDayAllowedShift,
+            StaffPatternAssignment=app.StaffPatternAssignment,
+            StaffRule=app.StaffRule,
+            shift_group=lambda shift: shift.code[0],
+        ))
+        yield service, unit, person, shifts
+
+        app.StaffRule.query.filter_by(unit_id=unit.id).delete()
+        app.StaffPatternAssignment.query.filter_by(unit_id=unit.id).delete()
+        allowed_day_ids = [
+            row.id for row in app.WorkPatternDay.query.filter_by(unit_id=unit.id)
+        ]
+        if allowed_day_ids:
+            app.WorkPatternDayAllowedShift.query.filter(
+                app.WorkPatternDayAllowedShift.work_pattern_day_id.in_(allowed_day_ids)
+            ).delete(synchronize_session=False)
+        app.WorkPatternDay.query.filter_by(unit_id=unit.id).delete()
+        app.WorkPattern.query.filter_by(unit_id=unit.id).delete()
+        app.Leave.query.filter_by(unit_id=unit.id).delete()
+        app.Assignment.query.filter_by(unit_id=unit.id).delete()
+        app.db.session.commit()
+
+
+def _add_pattern(
+    unit, shifts, name: str, day_specs: list[tuple[str, str | None]],
+):
+    pattern = app.WorkPattern(
+        unit_id=unit.id,
+        name=name,
+        cycle_length_days=len(day_specs),
+        contracted_minutes_per_cycle=sum(
+            480 for day_type, _ in day_specs if day_type != "OFF"
+        ),
+    )
+    app.db.session.add(pattern)
+    app.db.session.flush()
+    rows = []
+    for index, (day_type, shift_code) in enumerate(day_specs):
+        row = app.WorkPatternDay(
+            unit_id=unit.id,
+            work_pattern_id=pattern.id,
+            day_index=index,
+            day_type=day_type,
+            fixed_shift_type_id=(
+                shifts[shift_code].id if day_type == "FIXED_SHIFT" else None
+            ),
+            required_work=day_type not in {"OFF", "OPTIONAL_WORK"},
+        )
+        app.db.session.add(row)
+        app.db.session.flush()
+        if day_type == "WORK_ALLOWED_SET" and shift_code:
+            for code in shift_code.split(","):
+                app.db.session.add(app.WorkPatternDayAllowedShift(
+                    unit_id=unit.id,
+                    work_pattern_day_id=row.id,
+                    shift_type_id=shifts[code].id,
+                ))
+        rows.append(row)
+    app.db.session.commit()
+    return pattern, rows
+
+
+def _assign(person, pattern, effective_from, anchor_date, effective_to=None):
+    row = app.StaffPatternAssignment(
+        unit_id=person.unit_id,
+        staff_id=person.id,
+        work_pattern_id=pattern.id,
+        effective_from=effective_from,
+        effective_to=effective_to,
+        anchor_date=anchor_date,
+        anchor_day_index=0,
+    )
+    app.db.session.add(row)
+    app.db.session.commit()
+    return row
+
+
+def test_six_on_four_off_resolves_anchor_and_wraparound(pattern_service):
+    service, unit, person, shifts = pattern_service
+    pattern, _ = _add_pattern(unit, shifts, "6 on 4 off", [
+        ("FIXED_SHIFT", "M"), ("FIXED_SHIFT", "M"),
+        ("FIXED_SHIFT", "A"), ("FIXED_SHIFT", "A"),
+        ("FIXED_SHIFT", "N"), ("FIXED_SHIFT", "N"),
+        ("OFF", None), ("OFF", None), ("OFF", None), ("OFF", None),
+    ])
+    anchor = date(2026, 1, 1)
+    _assign(person, pattern, anchor, anchor)
+
+    assert service.get_pattern_day_for_staff(person.id, anchor).cycle_index == 0
+    assert service.get_pattern_day_for_staff(
+        person.id, date(2026, 1, 11)
+    ).cycle_index == 0
+    assert service.get_pattern_day_for_staff(
+        person.id, date(2026, 1, 7)
+    ).pattern_day.day_type == "OFF"
+
+
+def test_historical_assignment_and_dated_pattern_change(pattern_service):
+    service, unit, person, shifts = pattern_service
+    old, _ = _add_pattern(unit, shifts, "Historical days", [
+        ("FIXED_SHIFT", "M"), ("OFF", None),
+    ])
+    new, _ = _add_pattern(unit, shifts, "Future days", [
+        ("FIXED_SHIFT", "A"), ("OFF", None),
+    ])
+    _assign(person, old, date(2026, 1, 1), date(2026, 1, 1), date(2026, 1, 31))
+    _assign(person, new, date(2026, 2, 1), date(2026, 2, 1))
+
+    january = service.get_pattern_day_for_staff(person.id, date(2026, 1, 1))
+    february = service.get_pattern_day_for_staff(person.id, date(2026, 2, 1))
+    assert january.pattern.id == old.id
+    assert january.pattern_day.fixed_shift_type_id == shifts["M"].id
+    assert february.pattern.id == new.id
+    assert february.pattern_day.fixed_shift_type_id == shifts["A"].id
+
+    old.is_active = False
+    app.db.session.commit()
+    assert service.get_pattern_day_for_staff(
+        person.id, date(2026, 1, 1)
+    ).pattern.id == old.id
+
+
+def test_four_on_six_off_allowed_set_and_off_day(pattern_service):
+    service, unit, person, shifts = pattern_service
+    pattern, _ = _add_pattern(unit, shifts, "4 on 6 off", [
+        ("WORK_ALLOWED_SET", "M,D"), ("WORK_ALLOWED_SET", "M,D"),
+        ("FIXED_SHIFT", "A"), ("FIXED_SHIFT", "A"),
+        ("OFF", None), ("OFF", None), ("OFF", None), ("OFF", None),
+        ("OFF", None), ("OFF", None),
+    ])
+    anchor = date(2026, 3, 1)
+    _assign(person, pattern, anchor, anchor)
+
+    assert service.is_staff_eligible_for_shift(
+        person.id, anchor, shifts["D"].id
+    ).eligible
+    wrong = service.is_staff_eligible_for_shift(
+        person.id, anchor, shifts["A"].id
+    )
+    assert not wrong.eligible
+    assert wrong.reason_code == "PATTERN_SHIFT_NOT_ALLOWED"
+    off = service.is_staff_eligible_for_shift(
+        person.id, date(2026, 3, 5), shifts["M"].id
+    )
+    assert not off.eligible
+    assert off.reason_code == "PATTERN_NON_WORKING_DAY"
+
+
+def test_hard_no_night_blocks_and_soft_avoid_night_penalises(pattern_service):
+    service, unit, person, shifts = pattern_service
+    on_date = date(2026, 4, 1)
+    hard = app.StaffRule(
+        unit_id=unit.id, staff_id=person.id, rule_type="NO_NIGHT",
+        hardness="HARD", effective_from=on_date, reason="Medical restriction",
+    )
+    app.db.session.add(hard)
+    app.db.session.commit()
+    result = service.is_staff_eligible_for_shift(person.id, on_date, shifts["N"].id)
+    assert not result.eligible
+    assert result.reason_code == "NO_NIGHT_RULE"
+
+    app.db.session.delete(hard)
+    app.db.session.add(app.StaffRule(
+        unit_id=unit.id, staff_id=person.id, rule_type="AVOID_NIGHT",
+        hardness="SOFT", effective_from=on_date, penalty_weight=17,
+    ))
+    app.db.session.commit()
+    preferred = service.is_staff_eligible_for_shift(
+        person.id, on_date, shifts["N"].id
+    )
+    assert preferred.eligible
+    assert preferred.soft_penalty == 17
+    assert preferred.reasons[0].code == "SOFT_AVOID_NIGHT"
+
+
+def test_expired_and_future_rules_do_not_apply_early(pattern_service):
+    service, unit, person, shifts = pattern_service
+    app.db.session.add_all([
+        app.StaffRule(
+            unit_id=unit.id, staff_id=person.id, rule_type="NO_NIGHT",
+            hardness="HARD", effective_from=date(2025, 1, 1),
+            effective_to=date(2025, 12, 31),
+        ),
+        app.StaffRule(
+            unit_id=unit.id, staff_id=person.id, rule_type="NO_NIGHT",
+            hardness="HARD", effective_from=date(2027, 1, 1),
+        ),
+    ])
+    app.db.session.commit()
+    result = service.is_staff_eligible_for_shift(
+        person.id, date(2026, 6, 1), shifts["N"].id
+    )
+    assert result.eligible
+
+
+def test_approved_leave_and_allowed_shift_rule_are_hard_constraints(pattern_service):
+    service, unit, person, shifts = pattern_service
+    on_date = date(2026, 7, 1)
+    app.db.session.add(app.StaffRule(
+        unit_id=unit.id, staff_id=person.id, rule_type="ALLOWED_SHIFT",
+        hardness="HARD", effective_from=on_date, shift_type_id=shifts["M"].id,
+    ))
+    app.db.session.commit()
+    disallowed = service.is_staff_eligible_for_shift(
+        person.id, on_date, shifts["A"].id
+    )
+    assert not disallowed.eligible
+    assert disallowed.reason_code == "SHIFT_NOT_ALLOWED_RULE"
+
+    app.db.session.add(app.Leave(
+        unit_id=unit.id, staff_id=person.id, leave_type="AL",
+        start=on_date, end=on_date,
+    ))
+    app.db.session.commit()
+    leave = service.is_staff_eligible_for_shift(
+        person.id, on_date, shifts["M"].id
+    )
+    assert not leave.eligible
+    assert leave.reason_code == "APPROVED_LEAVE"
+
+
+def test_overlapping_effective_pattern_ranges_are_rejected(pattern_service):
+    service, unit, person, shifts = pattern_service
+    pattern, _ = _add_pattern(unit, shifts, "Overlap test", [
+        ("FIXED_SHIFT", "M"), ("OFF", None),
+    ])
+    _assign(
+        person, pattern, date(2026, 1, 1), date(2026, 1, 1), date(2026, 6, 30)
+    )
+    candidate = app.StaffPatternAssignment(
+        unit_id=unit.id, staff_id=person.id, work_pattern_id=pattern.id,
+        effective_from=date(2026, 6, 1), anchor_date=date(2026, 6, 1),
+        anchor_day_index=0,
+    )
+    with pytest.raises(ValueError, match="overlaps"):
+        service.validate_staff_pattern_assignment(candidate)

--- a/work_pattern_service.py
+++ b/work_pattern_service.py
@@ -1,0 +1,427 @@
+"""Effective-dated working patterns and staff eligibility rules.
+
+The service is deliberately independent of Flask routes. Existing CSV patterns
+remain the compatibility fallback when ``resolve_pattern_day`` returns ``None``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, time, timedelta
+from typing import Any, Callable, Iterable
+
+
+PATTERN_DAY_TYPES = frozenset({
+    "FIXED_SHIFT", "WORK_ANY", "WORK_ALLOWED_SET", "OFF",
+    "OPTIONAL_WORK", "PROTECTED_NON_OPERATIONAL",
+})
+STAFF_RULE_TYPES = frozenset({
+    "NO_NIGHT", "AVOID_NIGHT", "NO_EARLY", "AVOID_EARLY",
+    "ALLOWED_SHIFT", "DISALLOWED_SHIFT", "MAX_NIGHTS_PER_CYCLE",
+    "MAX_SHIFTS_PER_CYCLE", "AVAILABLE_WEEKDAYS",
+    "UNAVAILABLE_WEEKDAYS", "MAX_CONTRACTED_MINUTES", "PREFERRED_SHIFT",
+    "PREFERRED_DAY_OFF",
+})
+
+
+@dataclass(frozen=True)
+class PatternResolution:
+    assignment: Any
+    pattern: Any
+    cycle_index: int
+    pattern_day: Any
+    allowed_shift_type_ids: frozenset[int] = field(default_factory=frozenset)
+
+
+@dataclass(frozen=True)
+class EligibilityReason:
+    code: str
+    explanation: str
+    rule_id: int | None = None
+
+
+@dataclass(frozen=True)
+class EligibilityResult:
+    eligible: bool
+    reason_code: str
+    explanation: str
+    reasons: tuple[EligibilityReason, ...] = ()
+    soft_penalty: int = 0
+
+
+@dataclass(frozen=True)
+class WorkPatternDependencies:
+    Staff: Any
+    ShiftType: Any
+    Leave: Any
+    Assignment: Any
+    WorkPattern: Any
+    WorkPatternDay: Any
+    WorkPatternDayAllowedShift: Any
+    StaffPatternAssignment: Any
+    StaffRule: Any
+    shift_group: Callable[[Any], str]
+    early_start_before: time = time(6, 30)
+
+
+class WorkPatternService:
+    def __init__(self, dependencies: WorkPatternDependencies) -> None:
+        self.dependencies = dependencies
+
+    def validate_pattern(self, pattern: Any, days: Iterable[Any]) -> None:
+        if int(pattern.cycle_length_days or 0) <= 0:
+            raise ValueError("Pattern cycle length must be greater than zero.")
+        if int(pattern.contracted_minutes_per_cycle or 0) < 0:
+            raise ValueError("Contracted cycle minutes cannot be negative.")
+        day_rows = list(days)
+        indexes = {int(row.day_index) for row in day_rows}
+        expected = set(range(int(pattern.cycle_length_days)))
+        if indexes != expected or len(day_rows) != len(expected):
+            raise ValueError("A pattern must define every cycle day exactly once.")
+        for row in day_rows:
+            if row.day_type not in PATTERN_DAY_TYPES:
+                raise ValueError(f"Unsupported pattern day type: {row.day_type}.")
+            if row.day_type == "FIXED_SHIFT" and not row.fixed_shift_type_id:
+                raise ValueError("A fixed-shift day must reference a shift type.")
+            if row.day_type != "FIXED_SHIFT" and row.fixed_shift_type_id:
+                raise ValueError("Only a fixed-shift day may reference a fixed shift.")
+
+    def validate_staff_pattern_assignment(self, candidate: Any) -> None:
+        pattern = self.dependencies.WorkPattern.query.filter_by(
+            id=candidate.work_pattern_id,
+            unit_id=candidate.unit_id,
+        ).first()
+        if not pattern:
+            raise ValueError("The selected pattern is unavailable in this airport.")
+        if not 0 <= int(candidate.anchor_day_index) < int(pattern.cycle_length_days):
+            raise ValueError("Anchor cycle day falls outside the selected pattern.")
+        if candidate.effective_to and candidate.effective_to < candidate.effective_from:
+            raise ValueError("Pattern end date cannot be before its start date.")
+        query = self.dependencies.StaffPatternAssignment.query.filter_by(
+            unit_id=candidate.unit_id, staff_id=candidate.staff_id
+        )
+        if getattr(candidate, "id", None):
+            query = query.filter(
+                self.dependencies.StaffPatternAssignment.id != candidate.id
+            )
+        for existing in query.all():
+            if _date_ranges_overlap(
+                candidate.effective_from,
+                candidate.effective_to,
+                existing.effective_from,
+                existing.effective_to,
+            ):
+                raise ValueError(
+                    "This pattern assignment overlaps an existing effective period."
+                )
+
+    def validate_staff_rule(self, rule: Any) -> None:
+        if rule.rule_type not in STAFF_RULE_TYPES:
+            raise ValueError("Choose a supported staff rule type.")
+        if rule.hardness not in {"HARD", "SOFT"}:
+            raise ValueError("Rule hardness must be HARD or SOFT.")
+        if rule.effective_to and rule.effective_to < rule.effective_from:
+            raise ValueError("Rule end date cannot be before its start date.")
+        if int(rule.penalty_weight or 0) < 0:
+            raise ValueError("Rule penalty cannot be negative.")
+        if rule.rule_type in {
+            "ALLOWED_SHIFT", "DISALLOWED_SHIFT", "PREFERRED_SHIFT",
+        } and not (rule.shift_type_id or rule.shift_group):
+            raise ValueError("This rule must target a shift or shift group.")
+        if rule.rule_type in {
+            "AVAILABLE_WEEKDAYS", "UNAVAILABLE_WEEKDAYS", "PREFERRED_DAY_OFF",
+        } and rule.weekdays_mask is None:
+            raise ValueError("This rule must select at least one weekday.")
+        if rule.weekdays_mask is not None and not 0 <= int(rule.weekdays_mask) <= 127:
+            raise ValueError("Weekday selection is invalid.")
+        if rule.rule_type in {
+            "MAX_NIGHTS_PER_CYCLE", "MAX_SHIFTS_PER_CYCLE",
+            "MAX_CONTRACTED_MINUTES",
+        }:
+            if rule.maximum_count is None or int(rule.maximum_count) < 0:
+                raise ValueError("This rule requires a non-negative maximum.")
+            if not rule.rolling_period_days or int(rule.rolling_period_days) <= 0:
+                raise ValueError("This rule requires a positive rolling period.")
+
+    def get_pattern_day_for_staff(
+        self, staff_id: int, on_date: date
+    ) -> PatternResolution | None:
+        staff = self.dependencies.Staff.query.filter_by(id=staff_id).first()
+        if not staff:
+            return None
+        assignment = (
+            self.dependencies.StaffPatternAssignment.query.filter(
+                self.dependencies.StaffPatternAssignment.unit_id == staff.unit_id,
+                self.dependencies.StaffPatternAssignment.staff_id == staff.id,
+                self.dependencies.StaffPatternAssignment.effective_from <= on_date,
+                (
+                    self.dependencies.StaffPatternAssignment.effective_to.is_(None)
+                    | (self.dependencies.StaffPatternAssignment.effective_to >= on_date)
+                ),
+            )
+            .order_by(
+                self.dependencies.StaffPatternAssignment.effective_from.desc(),
+                self.dependencies.StaffPatternAssignment.id.desc(),
+            )
+            .first()
+        )
+        if not assignment:
+            return None
+        pattern = self.dependencies.WorkPattern.query.filter_by(
+            id=assignment.work_pattern_id,
+            unit_id=staff.unit_id,
+        ).first()
+        if not pattern or int(pattern.cycle_length_days or 0) <= 0:
+            return None
+        cycle_index = (
+            int(assignment.anchor_day_index)
+            + (on_date - assignment.anchor_date).days
+        ) % int(pattern.cycle_length_days)
+        pattern_day = self.dependencies.WorkPatternDay.query.filter_by(
+            unit_id=staff.unit_id,
+            work_pattern_id=pattern.id,
+            day_index=cycle_index,
+        ).first()
+        if not pattern_day:
+            return None
+        allowed = frozenset(
+            int(row.shift_type_id)
+            for row in self.dependencies.WorkPatternDayAllowedShift.query.filter_by(
+                unit_id=staff.unit_id, work_pattern_day_id=pattern_day.id
+            ).all()
+        )
+        return PatternResolution(
+            assignment=assignment,
+            pattern=pattern,
+            cycle_index=cycle_index,
+            pattern_day=pattern_day,
+            allowed_shift_type_ids=allowed,
+        )
+
+    def get_effective_staff_rules(self, staff_id: int, on_date: date) -> tuple[Any, ...]:
+        return tuple(
+            self.dependencies.StaffRule.query.filter(
+                self.dependencies.StaffRule.staff_id == staff_id,
+                self.dependencies.StaffRule.is_active.is_(True),
+                self.dependencies.StaffRule.effective_from <= on_date,
+                (
+                    self.dependencies.StaffRule.effective_to.is_(None)
+                    | (self.dependencies.StaffRule.effective_to >= on_date)
+                ),
+            ).order_by(self.dependencies.StaffRule.id).all()
+        )
+
+    def is_staff_eligible_for_shift(
+        self, staff_id: int, on_date: date, shift_type_id: int
+    ) -> EligibilityResult:
+        staff = self.dependencies.Staff.query.filter_by(id=staff_id).first()
+        shift = self.dependencies.ShiftType.query.filter_by(
+            id=shift_type_id, is_active=True
+        ).first()
+        if not staff or not shift or shift.unit_id != staff.unit_id:
+            return _blocked(
+                "SHIFT_UNAVAILABLE",
+                "The staff member or shift is unavailable in this airport.",
+            )
+        leave = self.dependencies.Leave.query.filter(
+            self.dependencies.Leave.staff_id == staff.id,
+            self.dependencies.Leave.start <= on_date,
+            self.dependencies.Leave.end >= on_date,
+        ).first()
+        if leave:
+            return _blocked("APPROVED_LEAVE", "Employee is on approved leave.")
+
+        resolution = self.get_pattern_day_for_staff(staff.id, on_date)
+        if resolution:
+            pattern_reason = self._pattern_eligibility(resolution, shift)
+            if pattern_reason:
+                return _blocked(pattern_reason.code, pattern_reason.explanation)
+
+        group = self.dependencies.shift_group(shift).upper()
+        is_night = group == "N"
+        is_early = bool(shift.start_time and shift.start_time < self.dependencies.early_start_before)
+        rules = self.get_effective_staff_rules(staff.id, on_date)
+        hard_reasons: list[EligibilityReason] = []
+        allowed_rules = [
+            rule for rule in rules
+            if rule.hardness == "HARD" and rule.rule_type == "ALLOWED_SHIFT"
+        ]
+        if allowed_rules and not any(
+            _rule_targets_shift(rule, shift, group) for rule in allowed_rules
+        ):
+            hard_reasons.append(_rule_reason(
+                allowed_rules[0],
+                "SHIFT_NOT_ALLOWED_RULE",
+                "This shift is outside the employee's allowed shifts.",
+            ))
+        for rule in rules:
+            if rule.hardness != "HARD":
+                continue
+            reason = self._hard_rule_reason(rule, shift, group, is_night, is_early, on_date)
+            if reason:
+                hard_reasons.append(reason)
+        if hard_reasons:
+            first = hard_reasons[0]
+            return EligibilityResult(
+                eligible=False,
+                reason_code=first.code,
+                explanation=first.explanation,
+                reasons=tuple(hard_reasons),
+            )
+        penalty, soft_reasons = self._soft_rule_penalty(
+            rules, shift, group, is_night, is_early, on_date
+        )
+        return EligibilityResult(
+            eligible=True,
+            reason_code="ELIGIBLE",
+            explanation="Employee is eligible for this shift.",
+            reasons=tuple(soft_reasons),
+            soft_penalty=penalty,
+        )
+
+    def calculate_soft_rule_penalty(
+        self, staff_id: int, on_date: date, shift_type_id: int
+    ) -> int:
+        result = self.is_staff_eligible_for_shift(staff_id, on_date, shift_type_id)
+        return result.soft_penalty if result.eligible else 0
+
+    def _pattern_eligibility(self, resolution: PatternResolution, shift: Any) -> EligibilityReason | None:
+        day = resolution.pattern_day
+        if day.day_type in {"OFF", "PROTECTED_NON_OPERATIONAL"}:
+            return EligibilityReason(
+                "PATTERN_NON_WORKING_DAY",
+                "This date is a protected non-working day in the active pattern.",
+            )
+        if day.day_type == "FIXED_SHIFT" and day.fixed_shift_type_id != shift.id:
+            return EligibilityReason(
+                "PATTERN_FIXED_SHIFT_MISMATCH",
+                "The active pattern requires a different fixed shift on this date.",
+            )
+        if (
+            day.day_type == "WORK_ALLOWED_SET"
+            and shift.id not in resolution.allowed_shift_type_ids
+        ):
+            return EligibilityReason(
+                "PATTERN_SHIFT_NOT_ALLOWED",
+                "This shift is not in the allowed set for the active pattern day.",
+            )
+        return None
+
+    def _hard_rule_reason(
+        self, rule: Any, shift: Any, group: str, is_night: bool,
+        is_early: bool, on_date: date,
+    ) -> EligibilityReason | None:
+        applies = _rule_targets_shift(rule, shift, group)
+        if rule.rule_type == "NO_NIGHT" and is_night:
+            return _rule_reason(rule, "NO_NIGHT_RULE", "Employee has an active hard restriction preventing night duties.")
+        if rule.rule_type == "NO_EARLY" and is_early:
+            return _rule_reason(rule, "NO_EARLY_RULE", "Employee has an active hard restriction preventing early duties.")
+        if rule.rule_type == "DISALLOWED_SHIFT" and applies:
+            return _rule_reason(rule, "DISALLOWED_SHIFT_RULE", "This shift is explicitly disallowed for the employee.")
+        weekday_allowed = _weekday_in_mask(on_date.weekday(), rule.weekdays_mask)
+        if rule.rule_type == "AVAILABLE_WEEKDAYS" and not weekday_allowed:
+            return _rule_reason(rule, "WEEKDAY_NOT_AVAILABLE", "Employee is not available on this weekday.")
+        if rule.rule_type == "UNAVAILABLE_WEEKDAYS" and weekday_allowed:
+            return _rule_reason(rule, "WEEKDAY_UNAVAILABLE", "Employee is unavailable on this weekday.")
+        if rule.rule_type in {"MAX_NIGHTS_PER_CYCLE", "MAX_SHIFTS_PER_CYCLE"}:
+            if rule.rule_type == "MAX_NIGHTS_PER_CYCLE" and not is_night:
+                return None
+            if self._assignment_count(rule, on_date, nights_only=rule.rule_type == "MAX_NIGHTS_PER_CYCLE") >= int(rule.maximum_count or 0):
+                return _rule_reason(rule, rule.rule_type, "Employee has reached the configured maximum duty count.")
+        if rule.rule_type == "MAX_CONTRACTED_MINUTES":
+            if self._assigned_minutes(rule, on_date) + _shift_minutes(shift) > int(rule.maximum_count or 0):
+                return _rule_reason(rule, "MAX_CONTRACTED_MINUTES", "This shift would exceed the employee's configured maximum minutes.")
+        return None
+
+    def _soft_rule_penalty(
+        self, rules: tuple[Any, ...], shift: Any, group: str,
+        is_night: bool, is_early: bool, on_date: date,
+    ) -> tuple[int, list[EligibilityReason]]:
+        penalty = 0
+        reasons: list[EligibilityReason] = []
+        for rule in rules:
+            if rule.hardness != "SOFT":
+                continue
+            breached = (
+                (rule.rule_type == "AVOID_NIGHT" and is_night)
+                or (rule.rule_type == "AVOID_EARLY" and is_early)
+                or (rule.rule_type == "PREFERRED_SHIFT" and not _rule_targets_shift(rule, shift, group))
+                or (rule.rule_type == "PREFERRED_DAY_OFF" and _weekday_in_mask(on_date.weekday(), rule.weekdays_mask))
+            )
+            if breached:
+                weight = max(0, int(rule.penalty_weight or 0))
+                penalty += weight
+                reasons.append(_rule_reason(
+                    rule, f"SOFT_{rule.rule_type}",
+                    "Assignment breaches an active staff preference.",
+                ))
+        return penalty, reasons
+
+    def _assignment_count(self, rule: Any, on_date: date, *, nights_only: bool) -> int:
+        start = on_date - timedelta(days=max(1, int(rule.rolling_period_days or 1)) - 1)
+        rows = self.dependencies.Assignment.query.filter(
+            self.dependencies.Assignment.staff_id == rule.staff_id,
+            self.dependencies.Assignment.day >= start,
+            self.dependencies.Assignment.day <= on_date,
+        ).all()
+        shifts = self.dependencies.ShiftType.query.filter_by(
+            unit_id=rule.unit_id, is_working=True
+        ).all()
+        codes = {
+            shift.code for shift in shifts
+            if not nights_only
+            or self.dependencies.shift_group(shift).upper() == "N"
+        }
+        return sum(1 for row in rows if row.code in codes)
+
+    def _assigned_minutes(self, rule: Any, on_date: date) -> int:
+        start = on_date - timedelta(days=max(1, int(rule.rolling_period_days or 1)) - 1)
+        rows = self.dependencies.Assignment.query.filter(
+            self.dependencies.Assignment.staff_id == rule.staff_id,
+            self.dependencies.Assignment.day >= start,
+            self.dependencies.Assignment.day <= on_date,
+        ).all()
+        shifts = {
+            row.code: row for row in self.dependencies.ShiftType.query.filter_by(
+                unit_id=rule.unit_id
+            ).all()
+        }
+        return sum(_shift_minutes(shifts.get(row.code)) for row in rows)
+
+
+def _date_ranges_overlap(
+    first_start: date, first_end: date | None,
+    second_start: date, second_end: date | None,
+) -> bool:
+    return first_start <= (second_end or date.max) and second_start <= (first_end or date.max)
+
+
+def _blocked(code: str, explanation: str) -> EligibilityResult:
+    reason = EligibilityReason(code, explanation)
+    return EligibilityResult(False, code, explanation, (reason,))
+
+
+def _rule_reason(rule: Any, code: str, explanation: str) -> EligibilityReason:
+    return EligibilityReason(code, explanation, getattr(rule, "id", None))
+
+
+def _rule_targets_shift(rule: Any, shift: Any, group: str) -> bool:
+    if rule.shift_type_id is not None:
+        return int(rule.shift_type_id) == int(shift.id)
+    if rule.shift_group:
+        return str(rule.shift_group).upper() == group.upper()
+    return False
+
+
+def _weekday_in_mask(weekday: int, mask: int | None) -> bool:
+    return mask is not None and bool(int(mask) & (1 << weekday))
+
+
+def _shift_minutes(shift: Any | None) -> int:
+    if not shift or not shift.start_time or not shift.end_time:
+        return 0
+    start = shift.start_time.hour * 60 + shift.start_time.minute
+    end = shift.end_time.hour * 60 + shift.end_time.minute
+    if end <= start:
+        end += 24 * 60
+    return end - start


### PR DESCRIPTION
## What changed

- add tenant-scoped, normalised work-pattern and pattern-day models
- add effective-dated staff pattern assignments and hard/soft staff rules
- add a typed service for pattern resolution, eligibility checks, and soft-rule penalties
- add a safe operational migration and fresh-schema support for SQLite and PostgreSQL
- preserve the existing CSV-pattern path and current roster generation behaviour
- document the foundation and its future optimiser boundary

## Why

This establishes the first backwards-compatible foundation for flexible full-time and part-time roster patterns. It supports dated restrictions and eligibility decisions without changing published rosters or introducing automatic allocation yet.

## Impact

There is no planner-facing interface in this step and no existing staff are automatically migrated. Operational databases gain the new normalised tables; control databases advance the Alembic revision without receiving operational tables.

## Validation

- `305 passed, 11 skipped`
- Python compilation passed
- Ruff checks passed
- `git diff --check` passed
- clean operational SQLite upgrade, downgrade to revision 37, and re-upgrade to revision 38 passed
