### PR TITLE
Pulse overstaffed roster counts

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1222,6 +1222,23 @@ tfoot td{background:var(--card); font-weight:bold; color:var(--text);}
 .rag.green{color:#2ecc71;}
 .rag.amber{color:#f1c40f;}
 .rag.red{color:#e74c3c;}
+.rag-count--over{
+  animation:roster-count-over-pulse 1.6s ease-in-out infinite;
+  font-weight:800;
+}
+@keyframes roster-count-over-pulse{
+  0%,100%{color:inherit; text-shadow:none;}
+  50%{color:#53aaff; text-shadow:0 0 7px rgba(83,170,255,.95);}
+}
+@media (prefers-reduced-motion:reduce){
+  .rag-count--over{
+    animation:none;
+    text-decoration:underline;
+    text-decoration-color:#53aaff;
+    text-decoration-thickness:2px;
+    text-underline-offset:2px;
+  }
+}
 
 .ot-green{ background:#1b5e20 !important; color:#fff !important; font-weight:700; }
 .ot-amber{ background:#f9a825 !important; color:#000 !important; font-weight:700; }

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -313,10 +313,10 @@
         {% set total = m + dday + a + (n if night_active[d] else 0) %}
         <td class="totcell{% if d == today %} is-today{% endif %}">
           <div class="daily-total"><strong>Total {{ total }}</strong></div>
-          <div class="rag {{ rag[d]['M'] }}">M {{ m }}/{{ req_by_day[d]['M'] }}</div>
-          <div class="rag {{ rag[d]['D'] }}">D {{ dday }}/{{ req_by_day[d]['D'] }}</div>
-          <div class="rag {{ rag[d]['A'] }}">A {{ a }}/{{ req_by_day[d]['A'] }}</div>
-          {% if night_active[d] %}<div class="rag {{ rag[d]['N'] }}">N {{ n }}/{{ req_by_day[d]['N'] }}</div>{% endif %}
+          <div class="rag {{ rag[d]['M'] }}">M <span class="rag-count{% if m > req_by_day[d]['M'] %} rag-count--over{% endif %}">{{ m }}</span>/{{ req_by_day[d]['M'] }}</div>
+          <div class="rag {{ rag[d]['D'] }}">D <span class="rag-count{% if dday > req_by_day[d]['D'] %} rag-count--over{% endif %}">{{ dday }}</span>/{{ req_by_day[d]['D'] }}</div>
+          <div class="rag {{ rag[d]['A'] }}">A <span class="rag-count{% if a > req_by_day[d]['A'] %} rag-count--over{% endif %}">{{ a }}</span>/{{ req_by_day[d]['A'] }}</div>
+          {% if night_active[d] %}<div class="rag {{ rag[d]['N'] }}">N <span class="rag-count{% if n > req_by_day[d]['N'] %} rag-count--over{% endif %}">{{ n }}</span>/{{ req_by_day[d]['N'] }}</div>{% endif %}
         </td>
       {% endfor %}
     </tr>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -629,6 +629,10 @@ def test_roster_publication_is_managed_from_monthly_roster(client):
     assert b"Draft roster" in draft.data
     assert b"Publish roster" in draft.data
     assert b'class="daily-total"><strong>Total ' in draft.data
+    assert b'class="rag-count' in draft.data
+    stylesheet = client.get("/static/styles.css")
+    assert b".rag-count--over" in stylesheet.data
+    assert b"@keyframes roster-count-over-pulse" in stylesheet.data
     token = csrf(client)
     published = client.post(
         "/roster/2025-04/publish",


### PR DESCRIPTION
## What changed
- pulse the actual roster count blue when staffing exceeds the requirement
- retain the existing green, amber, and red status colours
- provide a static blue underline when reduced motion is preferred
- cover the roster markup and stylesheet hooks in route tests

## Why
Overstaffed shifts should attract attention without replacing the existing staffing-status colour.

## Validation
- `python -m pytest -q tests`