### PR TITLE
Keep today highlight behind pinned names

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -872,7 +872,8 @@ th.sticky.left{left:0; z-index:3; background:var(--head);}
 }
 
 .roster td.col-name{
-  z-index:4;
+  /* Stay above the today-column overlay (layer 5) while horizontally pinned. */
+  z-index:7;
   background:var(--card);
   box-shadow:4px 0 8px rgba(0,0,0,.18);
 }

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -602,6 +602,8 @@ def test_roster_has_persistent_zoom_presets(client):
     assert b"padding:.65rem 0" in stylesheet.data
     assert b"table.roster { zoom:var(--ui-scale); }" in stylesheet.data
     assert b"transform: scale(var(--ui-scale))" not in stylesheet.data
+    assert b"today-column overlay (layer 5)" in stylesheet.data
+    assert b"z-index:7" in stylesheet.data
 
 
 def test_favicon_is_served(client):


### PR DESCRIPTION
## What changed
- raise the pinned ATCO-name cells above the today-column overlay
- retain the yellow today band across visible roster shift cells
- add a regression assertion for the stacking layer

## Why
The yellow today outline was rendering over the pinned ATCO-name column during horizontal scrolling.

## Validation
- `python -m pytest -q tests/test_routes.py -k roster_has_persistent_zoom_presets`
- `python -m pytest -q tests`