### PR TITLE
Add flexible pattern administration

### DIFF
--- a/app.py
+++ b/app.py
@@ -8818,6 +8818,12 @@ from operations_blueprint import OperationsDependencies, create_operations_bluep
 from live_position_blueprint import (
     LivePositionDependencies, create_live_position_blueprint,
 )
+from work_pattern_admin_service import (
+    WorkPatternAdminDependencies, WorkPatternAdminService,
+)
+from work_pattern_blueprint import (
+    WorkPatternBlueprintDependencies, create_work_pattern_blueprint,
+)
 
 work_pattern_service = WorkPatternService(WorkPatternDependencies(
     Staff=Staff,
@@ -8835,6 +8841,34 @@ get_pattern_day_for_staff = work_pattern_service.get_pattern_day_for_staff
 get_effective_staff_rules = work_pattern_service.get_effective_staff_rules
 is_staff_eligible_for_shift = work_pattern_service.is_staff_eligible_for_shift
 calculate_soft_rule_penalty = work_pattern_service.calculate_soft_rule_penalty
+
+work_pattern_admin_service = WorkPatternAdminService(
+    WorkPatternAdminDependencies(
+        db=db,
+        WorkPattern=WorkPattern,
+        WorkPatternDay=WorkPatternDay,
+        WorkPatternDayAllowedShift=WorkPatternDayAllowedShift,
+        ShiftType=ShiftType,
+        pattern_service=work_pattern_service,
+    )
+)
+app.register_blueprint(create_work_pattern_blueprint(
+    WorkPatternBlueprintDependencies(
+        db=db,
+        Staff=Staff,
+        ShiftType=ShiftType,
+        WorkPattern=WorkPattern,
+        WorkPatternDay=WorkPatternDay,
+        WorkPatternDayAllowedShift=WorkPatternDayAllowedShift,
+        StaffPatternAssignment=StaffPatternAssignment,
+        StaffRule=StaffRule,
+        is_admin_user=is_admin_user,
+        current_unit_id=_current_unit_id,
+        validate_csrf=_validate_csrf,
+        pattern_service=work_pattern_service,
+        admin_service=work_pattern_admin_service,
+    )
+))
 
 app.register_blueprint(create_live_position_blueprint(LivePositionDependencies(
     db=db, Unit=Unit, OperationalPosition=OperationalPosition,

--- a/docs/flexible_roster_design.md
+++ b/docs/flexible_roster_design.md
@@ -52,3 +52,23 @@ The first consumer will be the roster-validation service. CSV migration, pattern
 administration, fairness calculations and automatic proposals are separate
 stages. No optimiser may write live assignments directly; generated duties will
 remain proposal records until an authorised user accepts them.
+
+## Phase 2 administration
+
+Unit administrators manage normalised patterns from **Administration → Flexible
+work patterns**. The standard seed is idempotent: it creates missing 6-on/4-off
+and part-time 4-on/6-off examples but never overwrites a unit's existing rows.
+Units must configure active working `M`, `A`, and `N` shift types before using
+the seed, keeping all foreign keys local to that operational database.
+
+Staff profiles link to a separate effective-dated configuration screen. A new
+assignment is rejected when it overlaps another assignment for that person.
+Rules retain start and optional end dates; deactivation preserves their history.
+The 28-day preview uses the same resolver used by eligibility decisions rather
+than duplicating cycle arithmetic in the template.
+
+Once a pattern has been assigned, its cycle definition is immutable. It may be
+retired from future assignment, but structural changes require a replacement
+pattern and a new effective-dated staff assignment. This prevents an edit today
+from changing historical roster interpretation. The legacy CSV editor remains
+available as a labelled fallback until a normalised assignment is effective.

--- a/templates/administration_home.html
+++ b/templates/administration_home.html
@@ -13,6 +13,11 @@
       <span><strong>People and access</strong><small>Manage user accounts, roles and access.</small></span>
       <i class="fa-solid fa-arrow-right" aria-hidden="true"></i>
     </a>
+    <a class="module-card" href="{{ url_for('work_patterns.patterns') }}">
+      <span class="module-card__icon" aria-hidden="true"><i class="fa-solid fa-calendar-days"></i></span>
+      <span><strong>Flexible work patterns</strong><small>Manage recurring cycles, dated staff assignments and eligibility rules.</small></span>
+      <i class="fa-solid fa-arrow-right" aria-hidden="true"></i>
+    </a>
     {% if show_live_position %}
     <a class="module-card" href="{{ url_for('kiosk_accounts') }}">
       <span class="module-card__icon" aria-hidden="true"><i class="fa-solid fa-display"></i></span>

--- a/templates/staff_edit.html
+++ b/templates/staff_edit.html
@@ -51,6 +51,8 @@
   <div class="card">
     <div class="card-hd">Roster pattern</div>
     <div class="card-bd">
+      <p><a class="btn btn-primary" href="{{ url_for('work_patterns.staff_rules', staff_id=s.id) }}">Manage effective-dated patterns and rules</a></p>
+      <p class="text-muted">The normalised pattern engine takes precedence when an effective assignment exists. The settings below remain as the legacy fallback.</p>
       <label class="inheritance-choice"><input type="checkbox" name="pattern_override" data-personal-pattern-toggle {% if s.pattern_override %}checked{% endif %}> Use a personal pattern for this ATCO</label>
       <p class="text-muted">Leave this off to follow the effective watch pattern automatically, including scheduled watch moves.</p>
       <div class="pattern-builder" data-pattern-builder data-personal-pattern {% if not s.pattern_override %}hidden{% endif %}>

--- a/templates/work_patterns/detail.html
+++ b/templates/work_patterns/detail.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+{% block title %}{{ pattern.name }}{% endblock %}
+{% block content %}
+<section class="compliance-hero"><div><span class="admin-step">Flexible pattern</span><h2>{{ pattern.name }}</h2><p>Configure every day in the recurring cycle. Day one has index zero internally.</p></div></section>
+{% if is_in_use %}<div class="release-ready-message"><i class="fa-solid fa-lock"></i><div><strong>Pattern definition locked</strong><span>This pattern has staff history. Create a replacement pattern to change its cycle.</span></div></div>{% endif %}
+
+<form method="post" class="grid">
+  <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+  <input type="hidden" name="action" value="save">
+  <section class="card"><div class="card-hd">Pattern settings</div><div class="card-bd grid grid-3">
+    <label>Name<input name="name" value="{{ pattern.name }}" maxlength="120" required></label>
+    <label>Cycle length<input type="number" name="cycle_length_days" value="{{ pattern.cycle_length_days }}" readonly></label>
+    <label>Contracted minutes<input type="number" name="contracted_minutes_per_cycle" min="0" value="{{ pattern.contracted_minutes_per_cycle }}" required></label>
+    <label>Description<textarea name="description" maxlength="2000">{{ pattern.description }}</textarea></label>
+    <label><input type="checkbox" name="is_active" {% if pattern.is_active %}checked{% endif %}> Available for new assignments</label>
+  </div></section>
+  <section class="card"><div class="card-hd">Cycle days</div><div class="card-bd"><div class="table-wrap"><table><thead><tr><th>Day</th><th>Type</th><th>Fixed shift</th><th>Allowed shifts</th><th>Required</th><th>Notes</th></tr></thead><tbody>
+    {% for day in days %}<tr>
+      <td>{{ day.day_index + 1 }}</td>
+      <td><select name="day_type_{{ day.day_index }}">{% for value in day_types %}<option value="{{ value }}" {% if day.day_type == value %}selected{% endif %}>{{ value|replace('_', ' ')|title }}</option>{% endfor %}</select></td>
+      <td><select name="fixed_shift_type_id_{{ day.day_index }}"><option value="">None</option>{% for shift in shifts %}<option value="{{ shift.id }}" {% if day.fixed_shift_type_id == shift.id %}selected{% endif %}>{{ shift.code }} · {{ shift.name }}</option>{% endfor %}</select></td>
+      <td><select name="allowed_shift_type_ids_{{ day.day_index }}" multiple size="3">{% for shift in shifts %}<option value="{{ shift.id }}" {% if shift.id in allowed.get(day.id, ()) %}selected{% endif %}>{{ shift.code }}</option>{% endfor %}</select></td>
+      <td><input type="checkbox" name="required_work_{{ day.day_index }}" {% if day.required_work %}checked{% endif %}></td>
+      <td><input name="notes_{{ day.day_index }}" value="{{ day.notes }}" maxlength="500"></td>
+    </tr>{% endfor %}
+  </tbody></table></div><p class="text-muted">Cycle length is fixed after creation so historical cycle indexes remain stable. Create a replacement pattern when the cycle itself changes.</p></div></section>
+  <div>{% if not is_in_use %}<button class="btn btn-primary">Save pattern</button>{% endif %} <a class="btn" href="{{ url_for('work_patterns.patterns') }}">Back to patterns</a></div>
+</form>
+<form method="post" class="mt-3"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><input type="hidden" name="action" value="toggle_active"><button class="btn">{{ 'Retire from' if pattern.is_active else 'Restore to' }} new assignments</button></form>
+
+<section class="card mt-3"><div class="card-hd">28-day preview</div><div class="card-bd">
+  <form method="get" class="admin-form-grid"><label>Preview from<input type="date" name="preview_start" value="{{ preview_start.isoformat() }}"></label><div class="form-actions"><button class="btn">Refresh preview</button></div></form>
+  <div class="table-wrap"><table><thead><tr><th>Date</th><th>Resolved pattern day</th></tr></thead><tbody>{% for day, label in preview %}<tr><td>{{ day.strftime('%a %d %b %Y') }}</td><td>{{ label }}</td></tr>{% endfor %}</tbody></table></div>
+</div></section>
+{% endblock %}

--- a/templates/work_patterns/index.html
+++ b/templates/work_patterns/index.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% block title %}Work patterns{% endblock %}
+{% block content %}
+<section class="compliance-hero"><div><span class="admin-step">Roster administration</span><h2>Flexible work patterns</h2><p>Create reusable cycles for full-time and part-time staff. Existing CSV patterns remain available until each person is migrated.</p></div></section>
+
+<section class="card"><div class="card-hd">Pattern library</div><div class="card-bd">
+  <form method="post" class="d-inline"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><input type="hidden" name="action" value="seed"><button class="btn btn-primary">Add missing standard patterns</button></form>
+  <p class="text-muted">Adds 6-on/4-off and a part-time 4-on/6-off example once only. Existing patterns are never overwritten.</p>
+  <div class="admin-staff-list">
+    {% for pattern in patterns %}<article class="admin-staff-card"><div><strong>{{ pattern.name }}</strong><span>{{ pattern.cycle_length_days }} days · {{ pattern.contracted_minutes_per_cycle }} contracted minutes · {{ 'Active' if pattern.is_active else 'Inactive' }}</span></div><a class="btn" href="{{ url_for('work_patterns.pattern_detail', pattern_id=pattern.id) }}">Configure</a></article>{% else %}<p>No normalised patterns have been created yet.</p>{% endfor %}
+  </div>
+</div></section>
+
+<section class="card mt-3"><div class="card-hd">Create a blank pattern</div><div class="card-bd"><form method="post" class="admin-form-grid">
+  <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><input type="hidden" name="action" value="create">
+  <label>Name<input name="name" maxlength="120" required></label>
+  <label>Cycle length (days)<input type="number" name="cycle_length_days" min="1" max="366" value="10" required></label>
+  <label>Contracted minutes per cycle<input type="number" name="contracted_minutes_per_cycle" min="0" value="0" required></label>
+  <label>Description<textarea name="description" maxlength="2000"></textarea></label>
+  <div class="form-actions"><button class="btn btn-primary">Create pattern</button></div>
+</form></div></section>
+{% endblock %}

--- a/templates/work_patterns/staff_rules.html
+++ b/templates/work_patterns/staff_rules.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% block title %}Patterns and rules · {{ staff.name }}{% endblock %}
+{% block content %}
+<section class="compliance-hero"><div><span class="admin-step">Effective-dated roster configuration</span><h2>{{ staff.name }}</h2><p>Assign normalised patterns and record hard restrictions or soft preferences without changing historical roster calculations.</p></div></section>
+
+<section class="card"><div class="card-hd">Pattern history</div><div class="card-bd">
+  <div class="table-wrap"><table><thead><tr><th>Pattern</th><th>Effective period</th><th>Anchor</th><th>Minutes override</th><th>Action</th></tr></thead><tbody>
+  {% for row in assignments %}<tr><td>{{ pattern_names.get(row.work_pattern_id, 'Historical pattern #' ~ row.work_pattern_id) }}</td><td>{{ row.effective_from }} – {{ row.effective_to or 'open ended' }}</td><td>{{ row.anchor_date }} · day {{ row.anchor_day_index + 1 }}</td><td>{{ row.contracted_minutes_override if row.contracted_minutes_override is not none else 'Pattern default' }}</td><td>{% if not row.effective_to %}<form method="post"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><input type="hidden" name="action" value="end_assignment"><input type="hidden" name="assignment_id" value="{{ row.id }}"><input type="date" name="effective_to" min="{{ row.effective_from.isoformat() }}" required><button class="btn btn-sm">Set end date</button></form>{% endif %}</td></tr>
+  {% else %}<tr><td colspan="5">No normalised assignment yet; existing CSV/watch logic remains the fallback.</td></tr>{% endfor %}
+  </tbody></table></div>
+  <form method="post" class="admin-form-grid mt-3"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><input type="hidden" name="action" value="assign_pattern">
+    <label>Pattern<select name="work_pattern_id" required><option value="">Select pattern</option>{% for pattern in patterns %}<option value="{{ pattern.id }}">{{ pattern.name }}</option>{% endfor %}</select></label>
+    <label>Effective from<input type="date" name="effective_from" required></label><label>Effective to<input type="date" name="effective_to"></label>
+    <label>Anchor date<input type="date" name="anchor_date" required></label><label>Anchor cycle day<input type="number" name="anchor_day_index" min="0" value="0" required></label>
+    <label>Contracted minutes override<input type="number" name="contracted_minutes_override" min="0"></label><label>Notes<input name="notes" maxlength="500"></label>
+    <div class="form-actions"><button class="btn btn-primary">Add pattern assignment</button></div>
+  </form>
+</div></section>
+
+<section class="card mt-3"><div class="card-hd">Restrictions and preferences</div><div class="card-bd">
+  <div class="table-wrap"><table><thead><tr><th>Rule</th><th>Strength</th><th>Period</th><th>Reason</th><th>Status</th></tr></thead><tbody>{% for rule in rules %}<tr><td>{{ rule.rule_type|replace('_', ' ')|title }}</td><td>{{ rule.hardness }}</td><td>{{ rule.effective_from }} – {{ rule.effective_to or 'open ended' }}</td><td>{{ rule.reason or '—' }}</td><td>{% if rule.is_active %}<form method="post"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><input type="hidden" name="action" value="deactivate_rule"><input type="hidden" name="rule_id" value="{{ rule.id }}"><button class="btn btn-sm">Deactivate</button></form>{% else %}Historical{% endif %}</td></tr>{% else %}<tr><td colspan="5">No rules recorded.</td></tr>{% endfor %}</tbody></table></div>
+  <form method="post" class="admin-form-grid mt-3"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><input type="hidden" name="action" value="add_rule">
+    <label>Rule type<select name="rule_type">{% for value in rule_types %}<option value="{{ value }}">{{ value|replace('_', ' ')|title }}</option>{% endfor %}</select></label>
+    <label>Strength<select name="hardness"><option value="HARD">Hard – cannot be breached</option><option value="SOFT">Soft – permitted with penalty</option></select></label>
+    <label>Effective from<input type="date" name="effective_from" required></label><label>Effective to<input type="date" name="effective_to"></label>
+    <label>Specific shift<select name="shift_type_id"><option value="">None</option>{% for shift in shifts %}<option value="{{ shift.id }}">{{ shift.code }} · {{ shift.name }}</option>{% endfor %}</select></label>
+    <label>Shift group<select name="shift_group"><option value="">None</option>{% for group in ['M','D','A','N'] %}<option value="{{ group }}">{{ group }}</option>{% endfor %}</select></label>
+    <label>Maximum count/minutes<input type="number" name="maximum_count" min="0"></label><label>Rolling period (days)<input type="number" name="rolling_period_days" min="1"></label>
+    <fieldset><legend>Weekdays</legend>{% for label in ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'] %}<label><input type="checkbox" name="weekday_{{ loop.index0 }}"> {{ label }}</label>{% endfor %}</fieldset>
+    <label>Soft penalty weight<input type="number" name="penalty_weight" min="0" value="1"></label><label>Reason<input name="reason" maxlength="500"></label>
+    <div class="form-actions"><button class="btn btn-primary">Add rule</button></div>
+  </form>
+</div></section>
+
+<section class="card mt-3"><div class="card-hd">Resolved 28-day preview</div><div class="card-bd"><form method="get" class="admin-form-grid"><label>Preview from<input type="date" name="preview_start" value="{{ preview_start.isoformat() }}"></label><div class="form-actions"><button class="btn">Refresh preview</button></div></form><div class="table-wrap"><table><thead><tr><th>Date</th><th>Pattern</th><th>Cycle day</th><th>Type</th></tr></thead><tbody>{% for day, result in preview %}<tr><td>{{ day.strftime('%a %d %b %Y') }}</td>{% if result %}<td>{{ result.pattern.name }}</td><td>{{ result.cycle_index + 1 }}</td><td>{{ result.pattern_day.day_type|replace('_', ' ')|title }}</td>{% else %}<td colspan="3">Legacy CSV/watch fallback</td>{% endif %}</tr>{% endfor %}</tbody></table></div></div></section>
+<p><a class="btn" href="{{ url_for('admin_staff_edit', sid=staff.id) }}">Back to staff profile</a></p>
+{% endblock %}

--- a/tests/fixtures/route_map.json
+++ b/tests/fixtures/route_map.json
@@ -111,6 +111,30 @@
     "rule": "/administration/kiosk-accounts"
   },
   {
+    "endpoint": "work_patterns.staff_rules",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/administration/staff/<int:staff_id>/work-rules"
+  },
+  {
+    "endpoint": "work_patterns.patterns",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/administration/work-patterns"
+  },
+  {
+    "endpoint": "work_patterns.pattern_detail",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/administration/work-patterns/<int:pattern_id>"
+  },
+  {
     "endpoint": "assign_cell",
     "methods": [
       "POST"
@@ -783,4 +807,3 @@
     "rule": "/unit/onboarding"
   }
 ]
-

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -271,6 +271,21 @@ def copy_authenticated_session(source_client, target_client):
         target_session.update(values)
 
 
+def _clear_flexible_patterns(unit_id=1):
+    app.StaffRule.query.filter_by(unit_id=unit_id).delete()
+    app.StaffPatternAssignment.query.filter_by(unit_id=unit_id).delete()
+    day_ids = [
+        row.id for row in app.WorkPatternDay.query.filter_by(unit_id=unit_id).all()
+    ]
+    if day_ids:
+        app.WorkPatternDayAllowedShift.query.filter(
+            app.WorkPatternDayAllowedShift.work_pattern_day_id.in_(day_ids)
+        ).delete(synchronize_session=False)
+    app.WorkPatternDay.query.filter_by(unit_id=unit_id).delete()
+    app.WorkPattern.query.filter_by(unit_id=unit_id).delete()
+    db.session.commit()
+
+
 def test_reports_require_sensitive_data_acknowledgement(client):
     login(client)
     warning = client.get("/reports")
@@ -2714,3 +2729,163 @@ def test_primary_navigation_matches_role_permissions():
     dwm_page = dwm_client.get("/roster/2025-04")
     assert dwm_page.status_code == 200
     assert b"Secure session \xc2\xb7 Duty Watch Manager" in dwm_page.data
+
+
+def test_unit_admin_seeds_standard_patterns_idempotently(client):
+    with app.app.app_context():
+        _clear_flexible_patterns()
+    login(client)
+    first = client.post(
+        "/administration/work-patterns",
+        data={"_csrf_token": csrf(client), "action": "seed"},
+        follow_redirects=True,
+    )
+    assert first.status_code == 200
+    assert b"Added 2 standard pattern(s)." in first.data
+    second = client.post(
+        "/administration/work-patterns",
+        data={"_csrf_token": csrf(client), "action": "seed"},
+        follow_redirects=True,
+    )
+    assert b"Standard patterns already exist." in second.data
+    with app.app.app_context():
+        patterns = app.WorkPattern.query.filter_by(unit_id=1).all()
+        assert {row.name for row in patterns} == {
+            "Standard 6-on/4-off", "Part-time 4-on/6-off",
+        }
+        assert all(row.cycle_length_days == 10 for row in patterns)
+        six_on = next(row for row in patterns if row.name.startswith("Standard"))
+        days = app.WorkPatternDay.query.filter_by(
+            unit_id=1, work_pattern_id=six_on.id
+        ).order_by(app.WorkPatternDay.day_index).all()
+        assert [row.day_type for row in days] == ["FIXED_SHIFT"] * 6 + ["OFF"] * 4
+
+
+def test_pattern_admin_creates_and_configures_a_custom_cycle(client):
+    login(client)
+    response = client.post(
+        "/administration/work-patterns",
+        data={
+            "_csrf_token": csrf(client), "action": "create",
+            "name": "Three-day flexible test", "cycle_length_days": "3",
+            "contracted_minutes_per_cycle": "960",
+            "description": "Test pattern",
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    with app.app.app_context():
+        pattern = app.WorkPattern.query.filter_by(
+            unit_id=1, name="Three-day flexible test"
+        ).one()
+        morning = ShiftType.query.filter_by(unit_id=1, code="M").one()
+        afternoon = ShiftType.query.filter_by(unit_id=1, code="A").one()
+        pattern_id, morning_id, afternoon_id = pattern.id, morning.id, afternoon.id
+    saved = client.post(
+        f"/administration/work-patterns/{pattern_id}",
+        data={
+            "_csrf_token": csrf(client), "name": "Three-day flexible test",
+            "cycle_length_days": "3", "contracted_minutes_per_cycle": "960",
+            "description": "Configured test pattern", "is_active": "on",
+            "day_type_0": "FIXED_SHIFT", "fixed_shift_type_id_0": str(morning_id),
+            "required_work_0": "on", "notes_0": "Morning duty",
+            "day_type_1": "WORK_ALLOWED_SET",
+            "allowed_shift_type_ids_1": [str(morning_id), str(afternoon_id)],
+            "required_work_1": "on", "notes_1": "Flexible duty",
+            "day_type_2": "OFF", "notes_2": "Protected rest",
+        },
+        follow_redirects=True,
+    )
+    assert saved.status_code == 200
+    assert b"Pattern saved." in saved.data
+    assert b"28-day preview" in saved.data
+    with app.app.app_context():
+        days = app.WorkPatternDay.query.filter_by(
+            unit_id=1, work_pattern_id=pattern_id
+        ).order_by(app.WorkPatternDay.day_index).all()
+        assert [row.day_type for row in days] == [
+            "FIXED_SHIFT", "WORK_ALLOWED_SET", "OFF",
+        ]
+        allowed = app.WorkPatternDayAllowedShift.query.filter_by(
+            unit_id=1, work_pattern_day_id=days[1].id
+        ).all()
+        assert {row.shift_type_id for row in allowed} == {morning_id, afternoon_id}
+
+
+def test_admin_assigns_dated_pattern_and_hard_staff_rule(client):
+    login(client)
+    with app.app.app_context():
+        person = Staff.query.filter_by(unit_id=1, username="staff_test").one()
+        pattern = app.WorkPattern.query.filter_by(
+            unit_id=1, name="Standard 6-on/4-off"
+        ).one()
+        person_id, pattern_id = person.id, pattern.id
+    assigned = client.post(
+        f"/administration/staff/{person_id}/work-rules",
+        data={
+            "_csrf_token": csrf(client), "action": "assign_pattern",
+            "work_pattern_id": str(pattern_id), "effective_from": "2026-09-01",
+            "anchor_date": "2026-09-01", "anchor_day_index": "0",
+            "notes": "Permanent cycle",
+        },
+        follow_redirects=True,
+    )
+    assert assigned.status_code == 200
+    assert b"Effective-dated pattern assignment added." in assigned.data
+    rule = client.post(
+        f"/administration/staff/{person_id}/work-rules",
+        data={
+            "_csrf_token": csrf(client), "action": "add_rule",
+            "rule_type": "NO_NIGHT", "hardness": "HARD",
+            "effective_from": "2026-09-01", "penalty_weight": "1",
+            "reason": "Medical restriction",
+        },
+        follow_redirects=True,
+    )
+    assert rule.status_code == 200
+    assert b"Staff rule added." in rule.data
+    with app.app.app_context():
+        assert app.StaffPatternAssignment.query.filter_by(
+            unit_id=1, staff_id=person_id, work_pattern_id=pattern_id
+        ).count() == 1
+        stored_rule = app.StaffRule.query.filter_by(
+            unit_id=1, staff_id=person_id, rule_type="NO_NIGHT"
+        ).one()
+        assert stored_rule.hardness == "HARD"
+    locked = client.post(
+        f"/administration/work-patterns/{pattern_id}",
+        data={"_csrf_token": csrf(client), "action": "save"},
+        follow_redirects=True,
+    )
+    assert locked.status_code == 200
+    assert b"Assigned patterns are locked to preserve roster history." in locked.data
+
+    invalid_soft_restriction = client.post(
+        f"/administration/staff/{person_id}/work-rules",
+        data={
+            "_csrf_token": csrf(client), "action": "add_rule",
+            "rule_type": "NO_NIGHT", "hardness": "SOFT",
+            "effective_from": "2026-10-01", "penalty_weight": "5",
+        },
+        follow_redirects=True,
+    )
+    assert b"This restriction must be configured as a hard rule." in invalid_soft_restriction.data
+    with app.app.app_context():
+        assert app.StaffRule.query.filter_by(
+            unit_id=1, staff_id=person_id, rule_type="NO_NIGHT"
+        ).count() == 1
+
+
+def test_flexible_pattern_admin_is_permission_and_tenant_scoped():
+    ordinary = app.app.test_client()
+    login_as(ordinary, "staff_test")
+    assert ordinary.get("/administration/work-patterns").status_code == 403
+
+    admin_client = app.app.test_client()
+    login(admin_client)
+    with app.app.app_context():
+        other = Staff.query.filter_by(unit_id=3, username="other_staff_test").one()
+        other_id = other.id
+    assert admin_client.get(
+        f"/administration/staff/{other_id}/work-rules"
+    ).status_code == 404

--- a/work_pattern_admin_service.py
+++ b/work_pattern_admin_service.py
@@ -1,0 +1,168 @@
+"""Administrative mutations and standard seeds for flexible work patterns."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from work_pattern_service import WorkPatternService
+
+
+STANDARD_SIX_ON_FOUR_OFF = "Standard 6-on/4-off"
+STANDARD_FOUR_ON_SIX_OFF = "Part-time 4-on/6-off"
+
+
+@dataclass(frozen=True)
+class WorkPatternAdminDependencies:
+    db: Any
+    WorkPattern: Any
+    WorkPatternDay: Any
+    WorkPatternDayAllowedShift: Any
+    ShiftType: Any
+    pattern_service: WorkPatternService
+
+
+class WorkPatternAdminService:
+    def __init__(self, dependencies: WorkPatternAdminDependencies) -> None:
+        self.dependencies = dependencies
+
+    def seed_standard_patterns(self, unit_id: int) -> tuple[Any, ...]:
+        """Create missing standard patterns without altering existing rows."""
+        shifts = {
+            row.code.upper(): row
+            for row in self.dependencies.ShiftType.query.filter_by(
+                unit_id=unit_id, is_active=True, is_working=True
+            ).all()
+        }
+        missing = [code for code in ("M", "A", "N") if code not in shifts]
+        if missing:
+            raise ValueError(
+                "Create active working shift types for "
+                + ", ".join(missing)
+                + " before adding the standard patterns."
+            )
+        created: list[Any] = []
+        if not self._pattern_named(unit_id, STANDARD_SIX_ON_FOUR_OFF):
+            created.append(self._create_pattern(
+                unit_id,
+                STANDARD_SIX_ON_FOUR_OFF,
+                "M, M, A, A, N, N followed by four protected days off.",
+                [
+                    ("FIXED_SHIFT", shifts[code], ())
+                    for code in ("M", "M", "A", "A", "N", "N")
+                ] + [("OFF", None, ())] * 4,
+            ))
+        if not self._pattern_named(unit_id, STANDARD_FOUR_ON_SIX_OFF):
+            allowed = tuple(
+                shift for code, shift in shifts.items() if code in {"M", "D", "A"}
+            )
+            if not allowed:
+                allowed = (shifts["M"], shifts["A"])
+            created.append(self._create_pattern(
+                unit_id,
+                STANDARD_FOUR_ON_SIX_OFF,
+                "Four flexible working days followed by six protected days off.",
+                [("WORK_ALLOWED_SET", None, allowed)] * 4
+                + [("OFF", None, ())] * 6,
+                contracted_minutes=4 * 8 * 60,
+            ))
+        return tuple(created)
+
+    def replace_pattern_days(
+        self,
+        pattern: Any,
+        day_specs: Iterable[dict[str, Any]],
+    ) -> None:
+        specs = list(day_specs)
+        pattern.cycle_length_days = len(specs)
+        rows = []
+        for index, spec in enumerate(specs):
+            row = self.dependencies.WorkPatternDay(
+                unit_id=pattern.unit_id,
+                work_pattern_id=pattern.id,
+                day_index=index,
+                day_type=spec["day_type"],
+                fixed_shift_type_id=spec.get("fixed_shift_type_id"),
+                required_work=bool(spec.get("required_work")),
+                notes=str(spec.get("notes") or "")[:500],
+            )
+            rows.append(row)
+        self.dependencies.pattern_service.validate_pattern(pattern, rows)
+        existing_ids = [
+            row.id for row in self.dependencies.WorkPatternDay.query.filter_by(
+                unit_id=pattern.unit_id, work_pattern_id=pattern.id
+            ).all()
+        ]
+        if existing_ids:
+            self.dependencies.WorkPatternDayAllowedShift.query.filter(
+                self.dependencies.WorkPatternDayAllowedShift.unit_id == pattern.unit_id,
+                self.dependencies.WorkPatternDayAllowedShift.work_pattern_day_id.in_(
+                    existing_ids
+                ),
+            ).delete(synchronize_session=False)
+        self.dependencies.WorkPatternDay.query.filter_by(
+            unit_id=pattern.unit_id, work_pattern_id=pattern.id
+        ).delete(synchronize_session=False)
+        self.dependencies.db.session.flush()
+        for row, spec in zip(rows, specs, strict=True):
+            self.dependencies.db.session.add(row)
+            self.dependencies.db.session.flush()
+            for shift_type_id in spec.get("allowed_shift_type_ids", ()):
+                self.dependencies.db.session.add(
+                    self.dependencies.WorkPatternDayAllowedShift(
+                        unit_id=pattern.unit_id,
+                        work_pattern_day_id=row.id,
+                        shift_type_id=int(shift_type_id),
+                    )
+                )
+
+    def _pattern_named(self, unit_id: int, name: str) -> Any | None:
+        return self.dependencies.WorkPattern.query.filter_by(
+            unit_id=unit_id, name=name
+        ).first()
+
+    def _create_pattern(
+        self,
+        unit_id: int,
+        name: str,
+        description: str,
+        specs: list[tuple[str, Any | None, tuple[Any, ...]]],
+        *,
+        contracted_minutes: int | None = None,
+    ) -> Any:
+        fixed_minutes = sum(
+            _shift_minutes(shift) for day_type, shift, _ in specs
+            if day_type == "FIXED_SHIFT"
+        )
+        pattern = self.dependencies.WorkPattern(
+            unit_id=unit_id,
+            name=name,
+            description=description,
+            cycle_length_days=len(specs),
+            contracted_minutes_per_cycle=(
+                fixed_minutes if contracted_minutes is None else contracted_minutes
+            ),
+            is_active=True,
+        )
+        self.dependencies.db.session.add(pattern)
+        self.dependencies.db.session.flush()
+        self.replace_pattern_days(pattern, [
+            {
+                "day_type": day_type,
+                "fixed_shift_type_id": fixed.id if fixed else None,
+                "allowed_shift_type_ids": tuple(shift.id for shift in allowed),
+                "required_work": day_type not in {"OFF", "OPTIONAL_WORK"},
+            }
+            for day_type, fixed, allowed in specs
+        ])
+        return pattern
+
+
+def _shift_minutes(shift: Any | None) -> int:
+    if not shift or not shift.start_time or not shift.end_time:
+        return 8 * 60
+    start = shift.start_time.hour * 60 + shift.start_time.minute
+    end = shift.end_time.hour * 60 + shift.end_time.minute
+    if end <= start:
+        end += 24 * 60
+    return end - start

--- a/work_pattern_blueprint.py
+++ b/work_pattern_blueprint.py
@@ -1,0 +1,379 @@
+"""Unit-administrator UI for flexible work patterns and staff rules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Any, Callable
+
+from flask import Blueprint, abort, flash, redirect, render_template, request, url_for
+from flask_login import current_user, login_required
+
+from work_pattern_service import PATTERN_DAY_TYPES, STAFF_RULE_TYPES
+
+
+@dataclass(frozen=True)
+class WorkPatternBlueprintDependencies:
+    db: Any
+    Staff: Any
+    ShiftType: Any
+    WorkPattern: Any
+    WorkPatternDay: Any
+    WorkPatternDayAllowedShift: Any
+    StaffPatternAssignment: Any
+    StaffRule: Any
+    is_admin_user: Callable[[Any], bool]
+    current_unit_id: Callable[[], int]
+    validate_csrf: Callable[[], None]
+    pattern_service: Any
+    admin_service: Any
+
+
+def create_work_pattern_blueprint(
+    dependencies: WorkPatternBlueprintDependencies,
+) -> Blueprint:
+    blueprint = Blueprint("work_patterns", __name__)
+
+    def require_admin() -> int:
+        if not dependencies.is_admin_user(current_user):
+            abort(403)
+        return dependencies.current_unit_id()
+
+    def unit_shifts(unit_id: int) -> list[Any]:
+        return dependencies.ShiftType.query.filter_by(
+            unit_id=unit_id, is_active=True
+        ).order_by(dependencies.ShiftType.code).all()
+
+    @blueprint.route("/administration/work-patterns", methods=["GET", "POST"])
+    @login_required
+    def patterns():
+        unit_id = require_admin()
+        if request.method == "POST":
+            dependencies.validate_csrf()
+            action = (request.form.get("action") or "").strip()
+            try:
+                if action == "seed":
+                    created = dependencies.admin_service.seed_standard_patterns(unit_id)
+                    dependencies.db.session.commit()
+                    flash(
+                        f"Added {len(created)} standard pattern(s)."
+                        if created else "Standard patterns already exist.",
+                        "ok",
+                    )
+                elif action == "create":
+                    name = (request.form.get("name") or "").strip()[:120]
+                    if not name:
+                        raise ValueError("Pattern name is required.")
+                    if dependencies.WorkPattern.query.filter_by(
+                        unit_id=unit_id, name=name
+                    ).first():
+                        raise ValueError("A pattern with this name already exists.")
+                    cycle_length = _bounded_int(
+                        request.form.get("cycle_length_days"), 1, 366,
+                        "Cycle length must be between 1 and 366 days.",
+                    )
+                    pattern = dependencies.WorkPattern(
+                        unit_id=unit_id,
+                        name=name,
+                        description=(request.form.get("description") or "").strip()[:2000],
+                        cycle_length_days=cycle_length,
+                        contracted_minutes_per_cycle=_bounded_int(
+                            request.form.get("contracted_minutes_per_cycle"),
+                            0, 500_000,
+                            "Contracted minutes must be zero or greater.",
+                        ),
+                        is_active=True,
+                    )
+                    dependencies.db.session.add(pattern)
+                    dependencies.db.session.flush()
+                    dependencies.admin_service.replace_pattern_days(
+                        pattern,
+                        [{"day_type": "OFF"} for _ in range(cycle_length)],
+                    )
+                    dependencies.db.session.commit()
+                    flash("Pattern created. Configure each cycle day next.", "ok")
+                    return redirect(url_for("work_patterns.pattern_detail", pattern_id=pattern.id))
+                else:
+                    abort(400, "Unknown pattern action.")
+            except ValueError as exc:
+                dependencies.db.session.rollback()
+                flash(str(exc), "error")
+            return redirect(url_for("work_patterns.patterns"))
+        rows = dependencies.WorkPattern.query.filter_by(unit_id=unit_id).order_by(
+            dependencies.WorkPattern.is_active.desc(), dependencies.WorkPattern.name
+        ).all()
+        return render_template("work_patterns/index.html", patterns=rows)
+
+    @blueprint.route(
+        "/administration/work-patterns/<int:pattern_id>", methods=["GET", "POST"]
+    )
+    @login_required
+    def pattern_detail(pattern_id: int):
+        unit_id = require_admin()
+        pattern = dependencies.WorkPattern.query.filter_by(
+            id=pattern_id, unit_id=unit_id
+        ).first_or_404()
+        shifts = unit_shifts(unit_id)
+        if request.method == "POST":
+            dependencies.validate_csrf()
+            try:
+                action = (request.form.get("action") or "save").strip()
+                if action == "toggle_active":
+                    pattern.is_active = not pattern.is_active
+                    dependencies.db.session.commit()
+                    flash(
+                        "Pattern is available for new assignments."
+                        if pattern.is_active
+                        else "Pattern retired from new assignments; history is retained.",
+                        "ok",
+                    )
+                    return redirect(url_for(
+                        "work_patterns.pattern_detail", pattern_id=pattern.id
+                    ))
+                is_in_use = dependencies.StaffPatternAssignment.query.filter_by(
+                    unit_id=unit_id, work_pattern_id=pattern.id
+                ).first() is not None
+                if is_in_use:
+                    raise ValueError(
+                        "Assigned patterns are locked to preserve roster history. "
+                        "Create a replacement pattern for structural changes."
+                    )
+                cycle_length = _bounded_int(
+                    request.form.get("cycle_length_days"), 1, 366,
+                    "Cycle length must be between 1 and 366 days.",
+                )
+                name = (request.form.get("name") or "").strip()[:120]
+                duplicate = dependencies.WorkPattern.query.filter(
+                    dependencies.WorkPattern.unit_id == unit_id,
+                    dependencies.WorkPattern.name == name,
+                    dependencies.WorkPattern.id != pattern.id,
+                ).first()
+                if not name or duplicate:
+                    raise ValueError(
+                        "Pattern name is required and must be unique in this airport."
+                    )
+                pattern.name = name
+                pattern.description = (
+                    request.form.get("description") or ""
+                ).strip()[:2000]
+                pattern.contracted_minutes_per_cycle = _bounded_int(
+                    request.form.get("contracted_minutes_per_cycle"),
+                    0, 500_000,
+                    "Contracted minutes must be zero or greater.",
+                )
+                pattern.is_active = request.form.get("is_active") == "on"
+                specs = [
+                    _day_spec(request, index, shifts)
+                    for index in range(cycle_length)
+                ]
+                dependencies.admin_service.replace_pattern_days(pattern, specs)
+                dependencies.db.session.commit()
+                flash("Pattern saved.", "ok")
+            except (TypeError, ValueError) as exc:
+                dependencies.db.session.rollback()
+                flash(str(exc), "error")
+            return redirect(url_for("work_patterns.pattern_detail", pattern_id=pattern.id))
+        days = dependencies.WorkPatternDay.query.filter_by(
+            unit_id=unit_id, work_pattern_id=pattern.id
+        ).order_by(dependencies.WorkPatternDay.day_index).all()
+        allowed = {
+            day.id: {
+                row.shift_type_id
+                for row in dependencies.WorkPatternDayAllowedShift.query.filter_by(
+                    unit_id=unit_id, work_pattern_day_id=day.id
+                ).all()
+            }
+            for day in days
+        }
+        preview_start = _optional_date(request.args.get("preview_start")) or date.today()
+        preview = _pattern_preview(pattern, days, shifts, allowed, preview_start, 28)
+        is_in_use = dependencies.StaffPatternAssignment.query.filter_by(
+            unit_id=unit_id, work_pattern_id=pattern.id
+        ).first() is not None
+        return render_template(
+            "work_patterns/detail.html", pattern=pattern, days=days,
+            shifts=shifts, allowed=allowed, day_types=sorted(PATTERN_DAY_TYPES),
+            preview=preview, preview_start=preview_start, is_in_use=is_in_use,
+        )
+
+    @blueprint.route(
+        "/administration/staff/<int:staff_id>/work-rules", methods=["GET", "POST"]
+    )
+    @login_required
+    def staff_rules(staff_id: int):
+        unit_id = require_admin()
+        staff = dependencies.Staff.query.filter_by(
+            id=staff_id, unit_id=unit_id
+        ).first_or_404()
+        if request.method == "POST":
+            dependencies.validate_csrf()
+            action = (request.form.get("action") or "").strip()
+            try:
+                if action == "assign_pattern":
+                    assignment = dependencies.StaffPatternAssignment(
+                        unit_id=unit_id,
+                        staff_id=staff.id,
+                        work_pattern_id=int(request.form.get("work_pattern_id") or 0),
+                        effective_from=date.fromisoformat(request.form["effective_from"]),
+                        effective_to=_optional_date(request.form.get("effective_to")),
+                        anchor_date=date.fromisoformat(request.form["anchor_date"]),
+                        anchor_day_index=int(request.form.get("anchor_day_index") or 0),
+                        contracted_minutes_override=_optional_int(
+                            request.form.get("contracted_minutes_override")
+                        ),
+                        notes=(request.form.get("notes") or "").strip()[:500],
+                    )
+                    dependencies.pattern_service.validate_staff_pattern_assignment(assignment)
+                    dependencies.db.session.add(assignment)
+                    flash("Effective-dated pattern assignment added.", "ok")
+                elif action == "end_assignment":
+                    assignment = dependencies.StaffPatternAssignment.query.filter_by(
+                        id=int(request.form.get("assignment_id") or 0),
+                        unit_id=unit_id, staff_id=staff.id,
+                    ).first_or_404()
+                    end_date = date.fromisoformat(request.form["effective_to"])
+                    if end_date < assignment.effective_from:
+                        raise ValueError("Pattern end date cannot precede its start date.")
+                    assignment.effective_to = end_date
+                    dependencies.pattern_service.validate_staff_pattern_assignment(assignment)
+                    flash("Pattern assignment end date saved.", "ok")
+                elif action == "add_rule":
+                    rule = _build_rule(dependencies, unit_id, staff.id, request)
+                    dependencies.pattern_service.validate_staff_rule(rule)
+                    dependencies.db.session.add(rule)
+                    flash("Staff rule added.", "ok")
+                elif action == "deactivate_rule":
+                    rule = dependencies.StaffRule.query.filter_by(
+                        id=int(request.form.get("rule_id") or 0),
+                        unit_id=unit_id, staff_id=staff.id,
+                    ).first_or_404()
+                    rule.is_active = False
+                    flash("Staff rule deactivated; its history is retained.", "ok")
+                else:
+                    abort(400, "Unknown staff-pattern action.")
+                dependencies.db.session.commit()
+            except (KeyError, TypeError, ValueError) as exc:
+                dependencies.db.session.rollback()
+                flash(f"Could not save: {exc}", "error")
+            return redirect(url_for("work_patterns.staff_rules", staff_id=staff.id))
+        patterns = dependencies.WorkPattern.query.filter_by(
+            unit_id=unit_id, is_active=True
+        ).order_by(dependencies.WorkPattern.name).all()
+        pattern_names = {
+            row.id: row.name
+            for row in dependencies.WorkPattern.query.filter_by(unit_id=unit_id).all()
+        }
+        assignments = dependencies.StaffPatternAssignment.query.filter_by(
+            unit_id=unit_id, staff_id=staff.id
+        ).order_by(dependencies.StaffPatternAssignment.effective_from.desc()).all()
+        rules = dependencies.StaffRule.query.filter_by(
+            unit_id=unit_id, staff_id=staff.id
+        ).order_by(dependencies.StaffRule.is_active.desc(), dependencies.StaffRule.effective_from.desc()).all()
+        preview_start = _optional_date(request.args.get("preview_start")) or date.today()
+        preview = []
+        for offset in range(28):
+            day = preview_start + timedelta(days=offset)
+            resolution = dependencies.pattern_service.get_pattern_day_for_staff(staff.id, day)
+            preview.append((day, resolution))
+        return render_template(
+            "work_patterns/staff_rules.html", staff=staff, patterns=patterns,
+            assignments=assignments, rules=rules, shifts=unit_shifts(unit_id),
+            rule_types=sorted(STAFF_RULE_TYPES), preview=preview,
+            preview_start=preview_start,
+            pattern_names=pattern_names,
+        )
+
+    return blueprint
+
+
+def _bounded_int(raw: str | None, minimum: int, maximum: int, message: str) -> int:
+    try:
+        value = int(raw or 0)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(message) from exc
+    if not minimum <= value <= maximum:
+        raise ValueError(message)
+    return value
+
+
+def _optional_int(raw: str | None) -> int | None:
+    return int(raw) if raw not in {None, ""} else None
+
+
+def _optional_date(raw: str | None) -> date | None:
+    return date.fromisoformat(raw) if raw else None
+
+
+def _day_spec(req: Any, index: int, shifts: list[Any]) -> dict[str, Any]:
+    day_type = (req.form.get(f"day_type_{index}") or "").strip().upper()
+    if day_type not in PATTERN_DAY_TYPES:
+        raise ValueError(f"Cycle day {index + 1} has an invalid day type.")
+    shift_ids = {shift.id for shift in shifts}
+    fixed = _optional_int(req.form.get(f"fixed_shift_type_id_{index}"))
+    if fixed is not None and fixed not in shift_ids:
+        raise ValueError(f"Cycle day {index + 1} references an unavailable shift.")
+    allowed = tuple(
+        int(value) for value in req.form.getlist(f"allowed_shift_type_ids_{index}")
+        if int(value) in shift_ids
+    )
+    if day_type == "WORK_ALLOWED_SET" and not allowed:
+        raise ValueError(f"Cycle day {index + 1} must allow at least one shift.")
+    return {
+        "day_type": day_type,
+        "fixed_shift_type_id": fixed if day_type == "FIXED_SHIFT" else None,
+        "allowed_shift_type_ids": allowed if day_type == "WORK_ALLOWED_SET" else (),
+        "required_work": req.form.get(f"required_work_{index}") == "on",
+        "notes": req.form.get(f"notes_{index}") or "",
+    }
+
+
+def _build_rule(dependencies: Any, unit_id: int, staff_id: int, req: Any) -> Any:
+    shift_type_id = _optional_int(req.form.get("shift_type_id"))
+    if shift_type_id and not dependencies.ShiftType.query.filter_by(
+        id=shift_type_id, unit_id=unit_id
+    ).first():
+        raise ValueError("Selected shift is unavailable in this airport.")
+    weekdays_mask = sum(
+        1 << weekday for weekday in range(7)
+        if req.form.get(f"weekday_{weekday}") == "on"
+    ) or None
+    return dependencies.StaffRule(
+        unit_id=unit_id,
+        staff_id=staff_id,
+        rule_type=(req.form.get("rule_type") or "").strip().upper(),
+        hardness=(req.form.get("hardness") or "HARD").strip().upper(),
+        effective_from=date.fromisoformat(req.form["effective_from"]),
+        effective_to=_optional_date(req.form.get("effective_to")),
+        shift_type_id=shift_type_id,
+        shift_group=(req.form.get("shift_group") or "").strip().upper() or None,
+        maximum_count=_optional_int(req.form.get("maximum_count")),
+        rolling_period_days=_optional_int(req.form.get("rolling_period_days")),
+        weekdays_mask=weekdays_mask,
+        penalty_weight=int(req.form.get("penalty_weight") or 1),
+        reason=(req.form.get("reason") or "").strip()[:500],
+        authorised_by_user_id=getattr(current_user, "person_id", None),
+        is_active=True,
+    )
+
+
+def _pattern_preview(
+    pattern: Any, days: list[Any], shifts: list[Any], allowed: dict[int, set[int]],
+    start: date, count: int,
+) -> list[tuple[date, str]]:
+    by_index = {day.day_index: day for day in days}
+    shift_by_id = {shift.id: shift.code for shift in shifts}
+    preview = []
+    for offset in range(count):
+        day = by_index.get(offset % pattern.cycle_length_days)
+        label = "Not configured"
+        if day:
+            label = day.day_type.replace("_", " ").title()
+            if day.fixed_shift_type_id:
+                label = shift_by_id.get(day.fixed_shift_type_id, label)
+            elif day.day_type == "WORK_ALLOWED_SET":
+                label = " / ".join(
+                    shift_by_id[item] for item in sorted(allowed.get(day.id, set()))
+                    if item in shift_by_id
+                )
+        preview.append((start + timedelta(days=offset), label))
+    return preview

--- a/work_pattern_service.py
+++ b/work_pattern_service.py
@@ -120,6 +120,20 @@ class WorkPatternService:
             raise ValueError("Choose a supported staff rule type.")
         if rule.hardness not in {"HARD", "SOFT"}:
             raise ValueError("Rule hardness must be HARD or SOFT.")
+        hard_only = {
+            "NO_NIGHT", "NO_EARLY", "ALLOWED_SHIFT", "DISALLOWED_SHIFT",
+            "MAX_NIGHTS_PER_CYCLE", "MAX_SHIFTS_PER_CYCLE",
+            "AVAILABLE_WEEKDAYS", "UNAVAILABLE_WEEKDAYS",
+            "MAX_CONTRACTED_MINUTES",
+        }
+        soft_only = {
+            "AVOID_NIGHT", "AVOID_EARLY", "PREFERRED_SHIFT",
+            "PREFERRED_DAY_OFF",
+        }
+        if rule.rule_type in hard_only and rule.hardness != "HARD":
+            raise ValueError("This restriction must be configured as a hard rule.")
+        if rule.rule_type in soft_only and rule.hardness != "SOFT":
+            raise ValueError("This preference must be configured as a soft rule.")
         if rule.effective_to and rule.effective_to < rule.effective_from:
             raise ValueError("Rule end date cannot be before its start date.")
         if int(rule.penalty_weight or 0) < 0:


### PR DESCRIPTION
## What changed

- add idempotent standard 6-on/4-off and part-time 4-on/6-off pattern seeds
- add unit-administrator screens for pattern creation and cycle-day configuration
- add effective-dated staff pattern assignment and history management
- add hard restriction and soft preference administration
- add pattern and staff 28-day previews using the shared resolver
- lock assigned pattern definitions to protect historical calculations
- keep legacy CSV/watch patterns as the compatibility fallback
- isolate mutations and routes in dedicated services and a blueprint

## Why

Phase 1 introduced the normalized pattern and staff-rule domain. This phase makes that foundation safely usable by unit administrators without changing existing roster generation or published assignments.

## User impact

Unit administrators gain a Flexible work patterns tool under Administration and a normalized pattern/rule link from each staff profile. Existing staff continue using legacy CSV/watch behavior until an effective normalized assignment is explicitly added.

## Safety and compatibility

- unit-admin permission and CSRF protection apply to every mutation
- operational records are explicitly tenant scoped
- overlapping staff assignments are rejected
- assigned pattern structures cannot be edited retrospectively
- patterns and rules are retired/deactivated rather than deleting history
- unrelated local roster-count animation changes are excluded from this branch

## Validation

- clean committed-tree suite: `309 passed, 11 skipped`
- focused administration/service tests passed
- Python compilation passed
- Ruff passed
- route-map compatibility snapshot passed
- `git diff --check` passed

## Dependency

This is a stacked phase 2 PR targeting `agent/flexible-pattern-foundation`. Merge PR #182 first, then retarget or merge this PR into `main`.
