### PR TITLE
Render roster leave codes explicitly

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -998,6 +998,23 @@ th.sticky.left{left:0; z-index:3; background:var(--head);}
   -moz-appearance:none;
 }
 
+.roster .cell .code-display{
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  width:100%;
+  height:30px;
+  font-size:.86rem;
+  font-weight:600;
+  line-height:1;
+  text-align:center;
+  text-transform:uppercase;
+}
+.roster .cell .code-display.code-len-3{font-size:calc(.78rem * var(--ui-scale));}
+.roster .cell .code-display.code-len-4{font-size:calc(.68rem * var(--ui-scale));}
+.roster .cell .code-display.code-len-5,
+.roster .cell .code-display.code-len-6{font-size:calc(.58rem * var(--ui-scale));}
+
 .roster .cell select.code-input.code-len-3{
   font-size:calc(.78rem * var(--ui-scale));
 }
@@ -1024,13 +1041,13 @@ select.code-input{
 .roster .cell select.code-input.group-n{ background: var(--yellow); color:#000; }
 .roster .cell select.code-input.off{ background: var(--off-blue); color:#10243a; }
 
-.roster .cell select.code-input.sc,
-.roster .cell select.code-input.ssc{ background: var(--red); color:#fff; }
-.roster .cell select.code-input.al,
-.roster .cell select.code-input.pl,
-.roster .cell select.code-input.spl,
-.roster .cell select.code-input.toui,
-.roster .cell select.code-input.tou8{ background: var(--blue); color:#000; }
+.roster .cell .code-input.sc,
+.roster .cell .code-input.ssc{ background: var(--red); color:#fff; }
+.roster .cell .code-input.al,
+.roster .cell .code-input.pl,
+.roster .cell .code-input.spl,
+.roster .cell .code-input.toui,
+.roster .cell .code-input.tou8{ background: var(--blue); color:#000; }
 
 .annot-select{
   width:100%;

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -214,6 +214,13 @@
             {% if ann and not code %}
               {{ annotation_badge(s, d, ann, ann_note, can_edit and not readonly, true) }}
             {% else %}
+            {% set protected_absence = code in ['SC','SSC','AL','PL','SPL','TOU8','TOUI'] %}
+            {% if protected_absence %}
+            <div class="shift-picker">
+              <span class="code-input code-display code-len-{{ code|length }} {{ code|lower }} group-{{ prefix }}"
+                    aria-label="{{ s.name }} absence on {{ d.strftime('%d %B %Y') }}: {{ code }}">{{ code }}</span>
+            </div>
+            {% else %}
             <form class="shift-picker" method="post" action="{{ url_for('assign_cell', staff_id=s.id, ym=ym, day=d.isoformat()) }}">
               <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
               <input type="hidden" name="assignment_version" value="{{ assignment_version_map.get((s.id, d), 0) }}">
@@ -227,11 +234,6 @@
                 aria-invalid="{% if f %}true{% else %}false{% endif %}"
               >
                 <option value="" {% if not code %}selected{% endif %}>—</option>
-
-                {# always display existing leave/sickness/TOIL-use in the cell, but disabled so it can't be picked here #}
-                {% if code in ['SC','SSC','AL','PL','SPL','TOU8','TOUI'] %}
-                  <option value="{{ code }}" selected disabled>{{ code }}</option>
-                {% endif %}
 
                 <optgroup label="Working shifts">
                   {% for sh in shifts_working %}
@@ -251,6 +253,7 @@
                 </optgroup>
               </select>
             </form>
+            {% endif %}
             {% endif %}
 
             {% set req_info = req_pending_map.get((s.id, d)) %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -606,6 +606,30 @@ def test_roster_has_persistent_zoom_presets(client):
     assert b"z-index:7" in stylesheet.data
 
 
+def test_roster_renders_annual_leave_as_static_al_code(client):
+    login(client)
+    client.get("/roster/2025-06")
+    duty_day = date(2025, 6, 3)
+    with app.app.app_context():
+        assignment = Assignment.query.filter_by(staff_id=1, day=duty_day).one()
+        original = (assignment.code, assignment.source, assignment.note)
+        assignment.code = "AL"
+        assignment.source = "leave"
+        assignment.note = "annual leave"
+        db.session.commit()
+
+    try:
+        response = client.get("/roster/2025-06")
+        assert response.status_code == 200
+        assert b'class="code-input code-display code-len-2 al group-a"' in response.data
+        assert b">AL</span>" in response.data
+    finally:
+        with app.app.app_context():
+            assignment = Assignment.query.filter_by(staff_id=1, day=duty_day).one()
+            assignment.code, assignment.source, assignment.note = original
+            db.session.commit()
+
+
 def test_favicon_is_served(client):
     resp = client.get("/favicon.ico")
     assert resp.status_code == 200


### PR DESCRIPTION
## What changed
- render AL and other protected absence codes as fixed roster labels
- remove duplicate selected absence options from shift dropdowns
- retain the established absence colours and responsive code sizing
- add a regression test proving AL is rendered explicitly

## Why
Browsers could retain the original dropdown value while applying AL styling because absence codes were represented by duplicate selected options in the ordinary shift control.

## Validation
- focused AL display and roster layout tests
- `python -m pytest -q tests`