### PR TITLE
Run Railway migrations before deployment

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -3,6 +3,7 @@ builder = "DOCKERFILE"
 dockerfilePath = "Dockerfile"
 
 [deploy]
+preDeployCommand = "python scripts/migrate_all_databases.py"
 startCommand = "python scripts/start_service.py"
 healthcheckPath = "/health/ready"
 healthcheckTimeout = 300

--- a/tests/test_repository_quality.py
+++ b/tests/test_repository_quality.py
@@ -85,3 +85,9 @@ def test_worker_readiness_requires_database_heartbeat_not_only_process_liveness(
     assert "worker_heartbeat" in source
     assert "last_seen_at" in source
     assert 'self.path == "/health/ready" and worker_ready()' in source
+
+
+def test_railway_runs_tenant_migrations_before_starting_release():
+    manifest = (ROOT / "railway.toml").read_text()
+    assert 'preDeployCommand = "python scripts/migrate_all_databases.py"' in manifest
+    assert 'startCommand = "python scripts/start_service.py"' in manifest


### PR DESCRIPTION
## What changed

- configure Railway to run `scripts/migrate_all_databases.py` before starting a release
- add a repository contract test so the production migration hook cannot disappear unnoticed

## Why

The production runbook requires migrations inside Railway's private network, but the deployed service manifest showed no pre-deploy command. Local migration execution cannot resolve Railway private database hostnames. This restores the intended serialized control-and-operational database migration path.

## Safety

The migration script takes a PostgreSQL advisory lock, applies the control role first, validates routed database secrets, and then migrates each operational database. Application startup only follows a successful migration.

## Validation

- `8 passed` in `tests/test_repository_quality.py`
- `git diff --check` passed
- current `main` quality, PostgreSQL, container, secret scan and CodeQL checks passed before this manifest-only fix
