### PR TITLE
Add roster pattern publication validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -8824,6 +8824,9 @@ from work_pattern_admin_service import (
 from work_pattern_blueprint import (
     WorkPatternBlueprintDependencies, create_work_pattern_blueprint,
 )
+from roster_validation_service import (
+    RosterValidationDependencies, RosterValidationService,
+)
 
 work_pattern_service = WorkPatternService(WorkPatternDependencies(
     Staff=Staff,
@@ -8850,6 +8853,16 @@ work_pattern_admin_service = WorkPatternAdminService(
         WorkPatternDayAllowedShift=WorkPatternDayAllowedShift,
         ShiftType=ShiftType,
         pattern_service=work_pattern_service,
+    )
+)
+roster_validation_service = RosterValidationService(
+    RosterValidationDependencies(
+        Staff=Staff,
+        ShiftType=ShiftType,
+        Assignment=Assignment,
+        StaffPatternAssignment=StaffPatternAssignment,
+        StaffRule=StaffRule,
+        work_pattern_service=work_pattern_service,
     )
 )
 app.register_blueprint(create_work_pattern_blueprint(
@@ -8973,6 +8986,7 @@ app.register_blueprint(create_roster_blueprint(RosterDependencies(
     shift_groups=_shift_groups_snapshot,
     watch_id_for_staff_on=watch_id_for_staff_on,
     roster_fatigue_flags=roster_fatigue_flags_for_range,
+    roster_validation=roster_validation_service,
     get_annotation_groups=get_annotation_groups,
     lock_roster_month=_lock_roster_month,
 )))

--- a/docs/flexible_roster_design.md
+++ b/docs/flexible_roster_design.md
@@ -72,3 +72,21 @@ retired from future assignment, but structural changes require a replacement
 pattern and a new effective-dated staff assignment. This prevents an edit today
 from changing historical roster interpretation. The legacy CSV editor remains
 available as a labelled fallback until a normalised assignment is effective.
+
+## Phase 3 roster validation
+
+The monthly roster now evaluates existing working assignments against effective
+normalised patterns and staff rules. Pattern mismatches and hard-rule breaches
+are publication blockers. Soft-rule breaches are clearly marked preferences:
+they remain advisory and never prevent publication or alter an assignment.
+
+Validation is read-only. It adds cell-level explanations and a pre-publication
+summary, but does not move, replace or generate duties. The publication handler
+locks the month before validating and refuses to create a snapshot while any
+blocking finding remains, so bypassing the disabled browser button cannot
+publish a roster that fails these checks.
+
+Count and contracted-minute checks distinguish a proposed duty from an existing
+assignment. Existing duties are measured once: reaching a configured maximum is
+valid, while exceeding it is a blocker. Proposal eligibility continues to
+include the candidate duty when testing the limit.

--- a/roster_blueprint.py
+++ b/roster_blueprint.py
@@ -71,6 +71,7 @@ class RosterDependencies:
     shift_groups: Callable[[int], tuple]
     watch_id_for_staff_on: Callable[[int, date], int | None]
     roster_fatigue_flags: Callable[..., dict]
+    roster_validation: Any
     get_annotation_groups: Callable[[], list]
     lock_roster_month: Callable[[int, int, int], Any]
 
@@ -88,7 +89,21 @@ def create_roster_blueprint(dependencies: RosterDependencies) -> Blueprint:
         if not dependencies.month_has_data(year, month):
             dependencies.ensure_month_requirement(year, month)
             dependencies.generate_month(year, month)
+        # Serialise roster writes before evaluating publication eligibility so
+        # the validated assignments are the same assignments we snapshot.
         dependencies.lock_roster_month(unit_id, year, month)
+        month_start, month_days = dependencies.month_range(year, month)
+        validation = dependencies.roster_validation.validate_range(
+            unit_id, month_start, month_days[-1]
+        )
+        if not validation.can_publish:
+            flash(
+                f"Roster publication blocked: {validation.blocking_count} "
+                "pattern or hard-rule breach"
+                f"{'es' if validation.blocking_count != 1 else ''} must be resolved.",
+                "error",
+            )
+            return redirect(url_for("roster_month", ym=ym))
         active = dependencies.active_publication(year, month)
         if active and dependencies.publication_matches_live(active, year, month):
             flash(
@@ -484,6 +499,9 @@ def create_roster_blueprint(dependencies: RosterDependencies) -> Blueprint:
             )
             for person in staff
         }
+        roster_validation = dependencies.roster_validation.validate_range(
+            unit_id, days[0], days[-1]
+        )
         requests = dependencies.ShiftRequest.query.filter(
             dependencies.ShiftRequest.unit_id == unit_id,
             dependencies.ShiftRequest.day >= start,
@@ -581,6 +599,8 @@ def create_roster_blueprint(dependencies: RosterDependencies) -> Blueprint:
             rag=rag,
             expiry_classes=expiry_classes,
             fatigue=fatigue,
+            roster_validation=roster_validation,
+            roster_validation_by_cell=roster_validation.by_cell(),
             watch_break_after_ids=watch_break_after_ids,
             prev_ym=previous_ym,
             next_ym=next_ym,

--- a/roster_validation_service.py
+++ b/roster_validation_service.py
@@ -1,0 +1,155 @@
+"""Read-only validation of assigned roster duties against staff constraints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RosterValidationFinding:
+    staff_id: int
+    staff_name: str
+    day: date
+    shift_code: str
+    severity: str
+    reason_code: str
+    explanation: str
+
+    @property
+    def blocks_publication(self) -> bool:
+        return self.severity == "blocking"
+
+
+@dataclass(frozen=True)
+class RosterValidationResult:
+    findings: tuple[RosterValidationFinding, ...]
+
+    @property
+    def blocking_count(self) -> int:
+        return sum(item.blocks_publication for item in self.findings)
+
+    @property
+    def advisory_count(self) -> int:
+        return len(self.findings) - self.blocking_count
+
+    @property
+    def can_publish(self) -> bool:
+        return self.blocking_count == 0
+
+    def by_cell(self) -> dict[tuple[int, date], tuple[RosterValidationFinding, ...]]:
+        grouped: dict[tuple[int, date], list[RosterValidationFinding]] = {}
+        for finding in self.findings:
+            grouped.setdefault((finding.staff_id, finding.day), []).append(finding)
+        return {key: tuple(value) for key, value in grouped.items()}
+
+
+@dataclass(frozen=True)
+class RosterValidationDependencies:
+    Staff: Any
+    ShiftType: Any
+    Assignment: Any
+    StaffPatternAssignment: Any
+    StaffRule: Any
+    work_pattern_service: Any
+
+
+class RosterValidationService:
+    def __init__(self, dependencies: RosterValidationDependencies) -> None:
+        self.dependencies = dependencies
+
+    def validate_range(
+        self, unit_id: int, start: date, end: date
+    ) -> RosterValidationResult:
+        """Validate inclusive dates without mutating any roster record."""
+        relevant_staff_ids = self._relevant_staff_ids(unit_id, start, end)
+        if not relevant_staff_ids:
+            return RosterValidationResult(())
+        staff = {
+            row.id: row
+            for row in self.dependencies.Staff.query.filter(
+                self.dependencies.Staff.unit_id == unit_id,
+                self.dependencies.Staff.id.in_(relevant_staff_ids),
+            ).all()
+        }
+        shifts = {
+            row.code.upper(): row
+            for row in self.dependencies.ShiftType.query.filter_by(
+                unit_id=unit_id, is_active=True, is_working=True
+            ).all()
+        }
+        assignments = self.dependencies.Assignment.query.filter(
+            self.dependencies.Assignment.unit_id == unit_id,
+            self.dependencies.Assignment.staff_id.in_(relevant_staff_ids),
+            self.dependencies.Assignment.day >= start,
+            self.dependencies.Assignment.day <= end,
+        ).order_by(
+            self.dependencies.Assignment.day,
+            self.dependencies.Assignment.staff_id,
+        ).all()
+        findings: list[RosterValidationFinding] = []
+        for assignment in assignments:
+            person = staff.get(assignment.staff_id)
+            shift = shifts.get((assignment.code or "").upper())
+            if not person or not shift:
+                continue
+            result = self.dependencies.work_pattern_service.is_staff_eligible_for_shift(
+                person.id, assignment.day, shift.id, existing_assignment=True
+            )
+            if not result.eligible:
+                findings.append(RosterValidationFinding(
+                    staff_id=person.id,
+                    staff_name=person.name,
+                    day=assignment.day,
+                    shift_code=shift.code,
+                    severity="blocking",
+                    reason_code=result.reason_code,
+                    explanation=result.explanation,
+                ))
+                continue
+            for reason in result.reasons:
+                if not reason.code.startswith("SOFT_"):
+                    continue
+                findings.append(RosterValidationFinding(
+                    staff_id=person.id,
+                    staff_name=person.name,
+                    day=assignment.day,
+                    shift_code=shift.code,
+                    severity="advisory",
+                    reason_code=reason.code,
+                    explanation=reason.explanation,
+                ))
+        return RosterValidationResult(tuple(findings))
+
+    def _relevant_staff_ids(
+        self, unit_id: int, start: date, end: date
+    ) -> set[int]:
+        assignment_ids = {
+            row[0]
+            for row in self.dependencies.StaffPatternAssignment.query.with_entities(
+                self.dependencies.StaffPatternAssignment.staff_id
+            ).filter(
+                self.dependencies.StaffPatternAssignment.unit_id == unit_id,
+                self.dependencies.StaffPatternAssignment.effective_from <= end,
+                (
+                    self.dependencies.StaffPatternAssignment.effective_to.is_(None)
+                    | (self.dependencies.StaffPatternAssignment.effective_to >= start)
+                ),
+            ).all()
+        }
+        rule_ids = {
+            row[0]
+            for row in self.dependencies.StaffRule.query.with_entities(
+                self.dependencies.StaffRule.staff_id
+            ).filter(
+                self.dependencies.StaffRule.unit_id == unit_id,
+                self.dependencies.StaffRule.is_active.is_(True),
+                self.dependencies.StaffRule.effective_from <= end,
+                (
+                    self.dependencies.StaffRule.effective_to.is_(None)
+                    | (self.dependencies.StaffRule.effective_to >= start)
+                ),
+            ).all()
+        }
+        return assignment_ids | rule_ids

--- a/static/styles.css
+++ b/static/styles.css
@@ -1240,6 +1240,20 @@ tfoot td{background:var(--card); font-weight:bold; color:var(--text);}
 .rag.green{color:#2ecc71;}
 .rag.amber{color:#f1c40f;}
 .rag.red{color:#e74c3c;}
+.roster-validation-blocking{box-shadow:inset 0 0 0 2px #dc3545;}
+.roster-validation-advisory{box-shadow:inset 0 0 0 2px #f0ad4e;}
+.roster-validation-hazard{position:absolute;right:2px;bottom:2px;z-index:7;width:15px;height:15px;border-radius:50%;display:grid;place-items:center;font-size:10px;font-weight:900;cursor:help;color:#fff;background:#b02a37;}
+.roster-validation-hazard--advisory{background:#9a6700;}
+.roster-validation-tooltip{display:none;position:absolute;z-index:30;right:0;bottom:18px;width:260px;padding:9px;border:1px solid var(--border);border-radius:8px;background:var(--card);color:var(--text);box-shadow:0 8px 24px rgba(0,0,0,.35);text-align:left;white-space:normal;}
+.roster-validation-tooltip span{display:block;margin-top:5px;font-weight:400;}
+.roster-validation-hazard:hover .roster-validation-tooltip,.roster-validation-hazard:focus .roster-validation-tooltip{display:block;}
+.roster-validation-summary{margin:1rem 0;padding:1rem;border:1px solid var(--border);border-left:5px solid #2e7d32;border-radius:10px;background:var(--card);}
+.roster-validation-summary--blocking{border-left-color:#dc3545;}
+.roster-validation-summary h3{margin:.15rem 0;}
+.roster-validation-summary p{margin:.25rem 0 0;}
+.roster-validation-summary details{margin-top:.75rem;}
+.roster-validation-summary ul{margin:.75rem 0 0;padding-left:1.2rem;}
+.validation-finding{margin:.35rem 0;}.validation-finding span{display:block;color:var(--muted);}.validation-finding--blocking strong{color:#ff8b94;}
 .rag-count--over{
   animation:roster-count-over-pulse 1.6s ease-in-out infinite;
   font-weight:800;

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -191,11 +191,13 @@
         {% for d in days %}
           {% set code = a_map.get(s.id, {}).get(d, "") %}          
           {% set f = fatigue.get(s.id, {}).get(d) %}
+          {% set rv = roster_validation_by_cell.get((s.id, d), ()) %}
+          {% set rv_blocking = rv|selectattr('blocks_publication')|list %}
           {% set ann = ann_map.get(s.id, {}).get(d, "") %}
           {% set ann_note = ann_note_map.get(s.id, {}).get(d, "") %}
           {% set applied_request = applied_request_map.get((s.id, d)) %}
           {% set prefix = ('m' if code == 'EM' else ('a' if code == 'LA' else code[:1]|lower)) %}
-          <td class="cell {{ 'editable' if can_edit and not readonly else 'locked' }}{% if not s.is_operational %} nonop{% endif %}{% if f %} fatigue{% endif %}{% if d == today %} is-today{% endif %}{% if code in training_codes %} training{% endif %}{% if applied_request %} request-applied{% endif %}"
+          <td class="cell {{ 'editable' if can_edit and not readonly else 'locked' }}{% if not s.is_operational %} nonop{% endif %}{% if f %} fatigue{% endif %}{% if rv_blocking %} roster-validation-blocking{% elif rv %} roster-validation-advisory{% endif %}{% if d == today %} is-today{% endif %}{% if code in training_codes %} training{% endif %}{% if applied_request %} request-applied{% endif %}"
               {% if applied_request %}title="Applied from an approved shift request" aria-label="{{ s.name }}, {{ d.strftime('%d %B %Y') }}, {{ code }}, applied from an approved shift request"{% endif %}>
             {% if applied_request %}
               <span class="request-applied-marker" aria-hidden="true"></span>
@@ -207,6 +209,16 @@
                 <span class="fatigue-tooltip" role="tooltip">
                   <strong>Fatigue warning</strong>
                   {% for reason in f %}<span>{{ reason }}</span>{% endfor %}
+                </span>
+              </span>
+            {% endif %}
+            {% if rv %}
+              <span class="roster-validation-hazard roster-validation-hazard--{{ 'blocking' if rv_blocking else 'advisory' }}" tabindex="0" role="img"
+                    aria-label="Roster validation: {{ rv|map(attribute='explanation')|join('; ') }}">
+                <span aria-hidden="true">{{ '!' if rv_blocking else 'i' }}</span>
+                <span class="roster-validation-tooltip" role="tooltip">
+                  <strong>{{ 'Publication blocker' if rv_blocking else 'Staff preference' }}</strong>
+                  {% for finding in rv %}<span>{{ finding.explanation }}</span>{% endfor %}
                 </span>
               </span>
             {% endif %}
@@ -347,6 +359,19 @@
   </section>
 {% endif %}
 
+<section class="roster-validation-summary {{ 'roster-validation-summary--blocking' if roster_validation.blocking_count else 'roster-validation-summary--clear' }}" aria-labelledby="roster-validation-title">
+  <div>
+    <span class="eyebrow">Pre-publication validation</span>
+    <h3 id="roster-validation-title">{{ roster_validation.blocking_count }} blocking · {{ roster_validation.advisory_count }} advisory</h3>
+    <p>{% if roster_validation.blocking_count %}Resolve every pattern or hard-rule breach before publishing.{% else %}No pattern or hard-rule breaches prevent publication.{% endif %} Soft preferences remain informational.</p>
+  </div>
+  {% if roster_validation.findings %}
+  <details><summary>Review validation findings</summary><ul>
+    {% for finding in roster_validation.findings %}<li class="validation-finding validation-finding--{{ finding.severity }}"><strong>{{ finding.staff_name }} · {{ finding.day.strftime('%d %b') }} · {{ finding.shift_code }}</strong><span>{{ finding.explanation }}</span></li>{% endfor %}
+  </ul></details>
+  {% endif %}
+</section>
+
 {% if roster_publication %}
   <div class="roster-state-note roster-state-note--published" role="status">
     <i class="fa-solid fa-circle-check" aria-hidden="true"></i>
@@ -367,7 +392,7 @@
       <form method="post" action="{{ url_for('roster_month_publish', ym=ym) }}"
             data-confirm="Publish the {{ month_title }} roster? Staff will see it as the current published roster.">
         <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
-        <button class="btn btn-sm" type="submit">Publish roster</button>
+        <button class="btn btn-sm" type="submit" {% if roster_validation.blocking_count %}disabled title="Resolve blocking validation findings first"{% endif %}>Publish roster</button>
       </form>
     {% endif %}
   </div>

--- a/tests/test_roster_validation_service.py
+++ b/tests/test_roster_validation_service.py
@@ -1,0 +1,115 @@
+from datetime import date, time
+
+import app
+
+
+def test_roster_validation_finds_blockers_and_soft_preferences():
+    with app.app.app_context():
+        app.db.create_all()
+        unit = app.Unit(
+            code="RVAL", name="Roster Validation Test", onboarding_step=100
+        )
+        app.db.session.add(unit)
+        app.db.session.flush()
+        morning = app.ShiftType(
+            unit_id=unit.id, code="M", name="Morning",
+            start_time=time(6), end_time=time(14), is_working=True,
+        )
+        night = app.ShiftType(
+            unit_id=unit.id, code="N", name="Night",
+            start_time=time(22), end_time=time(6), is_working=True,
+        )
+        app.db.session.add_all([morning, night])
+        app.db.session.flush()
+        patterned = _person(unit.id, "patterned", "RV-1")
+        preferred = _person(unit.id, "preferred", "RV-2")
+        restricted = _person(unit.id, "restricted", "RV-3")
+        irrelevant = _person(unit.id, "irrelevant", "RV-4")
+        app.db.session.add_all([patterned, preferred, restricted, irrelevant])
+        app.db.session.flush()
+        pattern = app.WorkPattern(
+            unit_id=unit.id, name="One on one off", cycle_length_days=2,
+            contracted_minutes_per_cycle=480,
+        )
+        app.db.session.add(pattern)
+        app.db.session.flush()
+        app.db.session.add_all([
+            app.WorkPatternDay(
+                unit_id=unit.id, work_pattern_id=pattern.id, day_index=0,
+                day_type="FIXED_SHIFT", fixed_shift_type_id=morning.id,
+                required_work=True,
+            ),
+            app.WorkPatternDay(
+                unit_id=unit.id, work_pattern_id=pattern.id, day_index=1,
+                day_type="OFF", required_work=False,
+            ),
+            app.StaffPatternAssignment(
+                unit_id=unit.id, staff_id=patterned.id,
+                work_pattern_id=pattern.id, effective_from=date(2026, 9, 1),
+                anchor_date=date(2026, 9, 1), anchor_day_index=0,
+            ),
+            app.StaffRule(
+                unit_id=unit.id, staff_id=preferred.id,
+                rule_type="AVOID_NIGHT", hardness="SOFT",
+                effective_from=date(2026, 9, 1), penalty_weight=3,
+            ),
+            app.StaffRule(
+                unit_id=unit.id, staff_id=restricted.id,
+                rule_type="NO_NIGHT", hardness="HARD",
+                effective_from=date(2026, 9, 1), penalty_weight=0,
+            ),
+        ])
+        app.db.session.add_all([
+            app.Assignment(
+                unit_id=unit.id, staff_id=patterned.id,
+                day=date(2026, 9, 1), code=morning.code,
+            ),
+            app.Assignment(
+                unit_id=unit.id, staff_id=patterned.id,
+                day=date(2026, 9, 2), code=morning.code,
+            ),
+            app.Assignment(
+                unit_id=unit.id, staff_id=preferred.id,
+                day=date(2026, 9, 1), code=night.code,
+            ),
+            app.Assignment(
+                unit_id=unit.id, staff_id=restricted.id,
+                day=date(2026, 9, 1), code=night.code,
+            ),
+            app.Assignment(
+                unit_id=unit.id, staff_id=irrelevant.id,
+                day=date(2026, 9, 1), code=morning.code,
+            ),
+        ])
+        app.db.session.commit()
+
+        result = app.roster_validation_service.validate_range(
+            unit.id, date(2026, 9, 1), date(2026, 9, 2)
+        )
+
+        assert result.blocking_count == 2
+        assert result.advisory_count == 1
+        assert not result.can_publish
+        facts = {
+            (row.staff_id, row.day, row.reason_code, row.severity)
+            for row in result.findings
+        }
+        assert (
+            patterned.id, date(2026, 9, 2),
+            "PATTERN_NON_WORKING_DAY", "blocking",
+        ) in facts
+        assert (
+            restricted.id, date(2026, 9, 1), "NO_NIGHT_RULE", "blocking",
+        ) in facts
+        assert (
+            preferred.id, date(2026, 9, 1), "SOFT_AVOID_NIGHT", "advisory",
+        ) in facts
+        assert all(row.staff_id != irrelevant.id for row in result.findings)
+
+
+def _person(unit_id: int, username: str, staff_no: str):
+    return app.Staff(
+        unit_id=unit_id, username=f"roster_validation_{username}",
+        password_hash="unused", name=username.title(), staff_no=staff_no,
+        role="user", is_operational=True,
+    )

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2919,3 +2919,63 @@ def test_flexible_pattern_admin_is_permission_and_tenant_scoped():
     assert admin_client.get(
         f"/administration/staff/{other_id}/work-rules"
     ).status_code == 404
+
+
+def test_roster_shows_pattern_breach_and_blocks_publication(client):
+    login(client)
+    with app.app.app_context():
+        person = Staff.query.filter_by(unit_id=1, username="staff_test").one()
+        morning = ShiftType.query.filter_by(unit_id=1, code="M").one()
+        pattern = app.WorkPattern(
+            unit_id=1, name="Publication blocker test", cycle_length_days=1,
+            contracted_minutes_per_cycle=0,
+        )
+        db.session.add(pattern)
+        db.session.flush()
+        db.session.add(app.WorkPatternDay(
+            unit_id=1, work_pattern_id=pattern.id, day_index=0,
+            day_type="OFF", required_work=False,
+        ))
+        db.session.add(app.StaffPatternAssignment(
+            unit_id=1, staff_id=person.id, work_pattern_id=pattern.id,
+            effective_from=date(2025, 9, 1), effective_to=date(2025, 9, 30),
+            anchor_date=date(2025, 9, 1), anchor_day_index=0,
+        ))
+        assignment = Assignment.query.filter_by(
+            unit_id=1, staff_id=person.id, day=date(2025, 9, 1)
+        ).first()
+        if not assignment:
+            assignment = Assignment(
+                unit_id=1, staff_id=person.id, day=date(2025, 9, 1), code="M"
+            )
+            db.session.add(assignment)
+        assignment.code = morning.code
+        db.session.commit()
+        pattern_id = pattern.id
+
+    roster = client.get("/roster/2025-09")
+    assert roster.status_code == 200
+    assert b"Pre-publication validation" in roster.data
+    assert b"Publication blocker" in roster.data
+    assert b"protected non-working day" in roster.data
+    assert b"Resolve blocking validation findings first" in roster.data
+
+    published = client.post(
+        "/roster/2025-09/publish",
+        data={"_csrf_token": csrf(client)},
+        follow_redirects=True,
+    )
+    assert published.status_code == 200
+    assert b"Roster publication blocked" in published.data
+    with app.app.app_context():
+        assert app.RosterPublication.query.filter_by(
+            unit_id=1, year=2025, month=9, state="published"
+        ).count() == 0
+        app.StaffPatternAssignment.query.filter_by(
+            unit_id=1, work_pattern_id=pattern_id
+        ).delete()
+        app.WorkPatternDay.query.filter_by(
+            unit_id=1, work_pattern_id=pattern_id
+        ).delete()
+        app.WorkPattern.query.filter_by(id=pattern_id, unit_id=1).delete()
+        db.session.commit()

--- a/tests/test_work_pattern_service.py
+++ b/tests/test_work_pattern_service.py
@@ -292,3 +292,34 @@ def test_overlapping_effective_pattern_ranges_are_rejected(pattern_service):
     )
     with pytest.raises(ValueError, match="overlaps"):
         service.validate_staff_pattern_assignment(candidate)
+
+
+def test_existing_assignment_is_not_counted_twice_at_rule_limit(pattern_service):
+    service, unit, person, shifts = pattern_service
+    on_date = date(2026, 8, 1)
+    app.db.session.add_all([
+        app.Assignment(
+            unit_id=unit.id, staff_id=person.id, day=on_date, code="M"
+        ),
+        app.StaffRule(
+            unit_id=unit.id, staff_id=person.id,
+            rule_type="MAX_SHIFTS_PER_CYCLE", hardness="HARD",
+            effective_from=on_date, rolling_period_days=7, maximum_count=1,
+        ),
+        app.StaffRule(
+            unit_id=unit.id, staff_id=person.id,
+            rule_type="MAX_CONTRACTED_MINUTES", hardness="HARD",
+            effective_from=on_date, rolling_period_days=7, maximum_count=480,
+        ),
+    ])
+    app.db.session.commit()
+
+    proposal = service.is_staff_eligible_for_shift(
+        person.id, on_date, shifts["M"].id
+    )
+    existing = service.is_staff_eligible_for_shift(
+        person.id, on_date, shifts["M"].id, existing_assignment=True
+    )
+
+    assert not proposal.eligible
+    assert existing.eligible

--- a/work_pattern_service.py
+++ b/work_pattern_service.py
@@ -226,7 +226,8 @@ class WorkPatternService:
         )
 
     def is_staff_eligible_for_shift(
-        self, staff_id: int, on_date: date, shift_type_id: int
+        self, staff_id: int, on_date: date, shift_type_id: int,
+        *, existing_assignment: bool = False,
     ) -> EligibilityResult:
         staff = self.dependencies.Staff.query.filter_by(id=staff_id).first()
         shift = self.dependencies.ShiftType.query.filter_by(
@@ -271,7 +272,10 @@ class WorkPatternService:
         for rule in rules:
             if rule.hardness != "HARD":
                 continue
-            reason = self._hard_rule_reason(rule, shift, group, is_night, is_early, on_date)
+            reason = self._hard_rule_reason(
+                rule, shift, group, is_night, is_early, on_date,
+                existing_assignment=existing_assignment,
+            )
             if reason:
                 hard_reasons.append(reason)
         if hard_reasons:
@@ -323,7 +327,7 @@ class WorkPatternService:
 
     def _hard_rule_reason(
         self, rule: Any, shift: Any, group: str, is_night: bool,
-        is_early: bool, on_date: date,
+        is_early: bool, on_date: date, *, existing_assignment: bool = False,
     ) -> EligibilityReason | None:
         applies = _rule_targets_shift(rule, shift, group)
         if rule.rule_type == "NO_NIGHT" and is_night:
@@ -340,10 +344,18 @@ class WorkPatternService:
         if rule.rule_type in {"MAX_NIGHTS_PER_CYCLE", "MAX_SHIFTS_PER_CYCLE"}:
             if rule.rule_type == "MAX_NIGHTS_PER_CYCLE" and not is_night:
                 return None
-            if self._assignment_count(rule, on_date, nights_only=rule.rule_type == "MAX_NIGHTS_PER_CYCLE") >= int(rule.maximum_count or 0):
+            count = self._assignment_count(
+                rule, on_date,
+                nights_only=rule.rule_type == "MAX_NIGHTS_PER_CYCLE",
+            )
+            limit = int(rule.maximum_count or 0)
+            if count > limit or (count >= limit and not existing_assignment):
                 return _rule_reason(rule, rule.rule_type, "Employee has reached the configured maximum duty count.")
         if rule.rule_type == "MAX_CONTRACTED_MINUTES":
-            if self._assigned_minutes(rule, on_date) + _shift_minutes(shift) > int(rule.maximum_count or 0):
+            proposed_minutes = self._assigned_minutes(rule, on_date)
+            if not existing_assignment:
+                proposed_minutes += _shift_minutes(shift)
+            if proposed_minutes > int(rule.maximum_count or 0):
                 return _rule_reason(rule, "MAX_CONTRACTED_MINUTES", "This shift would exceed the employee's configured maximum minutes.")
         return None
 


### PR DESCRIPTION
## What changed

- validates existing roster duties against effective normalised patterns and staff rules
- marks blocking breaches and advisory preferences in roster cells
- adds a pre-publication summary and disables publication while blockers remain
- enforces the same check server-side after acquiring the month lock
- avoids double-counting an existing duty in count and minutes limits

## Impact

Roster publication now stops when an assigned working duty conflicts with a normalised pattern or hard staff rule. Soft preferences remain informational and assignments are never changed automatically.

## Validation

- `python -m pytest -q` — 318 passed, 11 skipped
- focused roster/work-pattern tests — 10 passed
- Ruff — passed
- `git diff --check` — passed