### PR TITLE
Require SOAL for annual leave shifts

### DIFF
--- a/app.py
+++ b/app.py
@@ -8948,6 +8948,7 @@ app.register_blueprint(create_roster_blueprint(RosterDependencies(
     Staff=Staff,
     Notification=Notification,
     Assignment=Assignment,
+    Leave=Leave,
     Watch=Watch,
     Requirement=Requirement,
     SpecialRequirement=SpecialRequirement,

--- a/roster_blueprint.py
+++ b/roster_blueprint.py
@@ -33,6 +33,7 @@ class RosterDependencies:
     Staff: Any
     Notification: Any
     Assignment: Any
+    Leave: Any
     Watch: Any
     Requirement: Any
     SpecialRequirement: Any
@@ -78,6 +79,10 @@ class RosterDependencies:
 
 def create_roster_blueprint(dependencies: RosterDependencies) -> Blueprint:
     blueprint = Blueprint("roster", __name__)
+
+    def annotation_is_soal(value: str | None) -> bool:
+        parsed = dependencies.parse_annotation((value or "").strip().upper())
+        return bool(parsed and parsed.get("type") == "SOAL")
 
     @login_required
     def roster_month_publish(ym):
@@ -404,6 +409,20 @@ def create_roster_blueprint(dependencies: RosterDependencies) -> Blueprint:
         next_ym = f"{next_year:04d}-{next_month:02d}"
         start = date(year, month, 1)
         month_end = date(next_year, next_month, 1)
+        for leave in dependencies.Leave.query.filter(
+            dependencies.Leave.unit_id == unit_id,
+            dependencies.Leave.leave_type == "AL",
+            dependencies.Leave.start < month_end,
+            dependencies.Leave.end >= start,
+        ).all():
+            leave_day = max(start, leave.start)
+            final_day = min(month_end - timedelta(days=1), leave.end)
+            while leave_day <= final_day:
+                if not annotation_is_soal(
+                    annotation_map.get(leave.staff_id, {}).get(leave_day)
+                ):
+                    assignment_map.setdefault(leave.staff_id, {})[leave_day] = "AL"
+                leave_day += timedelta(days=1)
         working_shifts, training_shifts, nonworking_shifts = dependencies.shift_groups(
             unit_id
         )
@@ -638,6 +657,13 @@ def create_roster_blueprint(dependencies: RosterDependencies) -> Blueprint:
         person = dependencies.Staff.query.filter_by(
             id=staff_id, unit_id=unit_id
         ).first_or_404()
+        annual_leave = dependencies.Leave.query.filter(
+            dependencies.Leave.unit_id == unit_id,
+            dependencies.Leave.staff_id == staff_id,
+            dependencies.Leave.leave_type == "AL",
+            dependencies.Leave.start <= duty_day,
+            dependencies.Leave.end >= duty_day,
+        ).first()
         assignment = (
             dependencies.Assignment.query.filter_by(
                 unit_id=unit_id, staff_id=staff_id, day=duty_day
@@ -667,6 +693,13 @@ def create_roster_blueprint(dependencies: RosterDependencies) -> Blueprint:
         code = (request.form.get("code") or "").strip().upper()
         annotation = request.form.get("annotation")
         if code:
+            if annual_leave and not annotation_is_soal(assignment.annotation):
+                flash(
+                    "This annual-leave cell is locked. Apply the SOAL annotation "
+                    "before entering a shift, or amend the leave in Leave Administration.",
+                    "error",
+                )
+                return redirect(url_for("roster_month", ym=ym))
             if code in dependencies.banned_roster_codes():
                 flash(
                     "Leave, sickness and TOIL use must be logged via the form, "
@@ -766,6 +799,10 @@ def create_roster_blueprint(dependencies: RosterDependencies) -> Blueprint:
                             new_value=annotation_note,
                         )
                     )
+            if annual_leave and not annotation_is_soal(new_value):
+                assignment.code = "AL"
+                assignment.source = "leave"
+                assignment.note = "annual leave"
         assignment.version = current_version + 1
         try:
             dependencies.db.session.commit()

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -226,7 +226,7 @@
             {% if ann and not code %}
               {{ annotation_badge(s, d, ann, ann_note, can_edit and not readonly, true) }}
             {% else %}
-            {% set protected_absence = code in ['SC','SSC','AL','PL','SPL','TOU8','TOUI'] %}
+            {% set protected_absence = code in ['SC','SSC','AL','PL','SPL','TOU8','TOUI'] and ann != 'SOAL' %}
             {% if protected_absence %}
             <div class="shift-picker">
               <span class="code-input code-display code-len-{{ code|length }} {{ code|lower }} group-{{ prefix }}"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -30,6 +30,7 @@ from app import (
     AnnotationType,
     Assignment,
     ChangeLog,
+    Leave,
     ShiftType,
     Staff,
     StaffWatchHistory,
@@ -643,6 +644,146 @@ def test_roster_renders_annual_leave_as_static_al_code(client):
             assignment = Assignment.query.filter_by(staff_id=1, day=duty_day).one()
             assignment.code, assignment.source, assignment.note = original
             db.session.commit()
+
+
+def test_annual_leave_requires_soal_before_roster_shift_override(client):
+    login(client)
+    ym = "2025-06"
+    duty_day = date(2025, 6, 4)
+    client.get(f"/roster/{ym}")
+    with app.app.app_context():
+        assignment = Assignment.query.filter_by(staff_id=1, day=duty_day).one()
+        original = (
+            assignment.code,
+            assignment.source,
+            assignment.note,
+            assignment.annotation,
+            assignment.annotation_note,
+            assignment.version,
+        )
+        assignment.code = "AL"
+        assignment.source = "leave"
+        assignment.note = "annual leave"
+        assignment.annotation = ""
+        assignment.annotation_note = ""
+        soal_definition = AnnotationType.query.filter_by(
+            unit_id=1, code="SOAL"
+        ).first()
+        created_soal_definition = soal_definition is None
+        if soal_definition is None:
+            soal_definition = AnnotationType(
+                unit_id=1,
+                code="SOAL",
+                label="SOAL",
+                category="Overtime",
+                tags="ot,soal",
+                is_active=True,
+            )
+            db.session.add(soal_definition)
+        leave = Leave(
+            unit_id=1,
+            staff_id=1,
+            leave_type="AL",
+            start=duty_day,
+            end=duty_day,
+        )
+        db.session.add(leave)
+        db.session.commit()
+        app.refresh_annotation_cache()
+        leave_id = leave.id
+        soal_definition_id = soal_definition.id
+        version = assignment.version
+
+    try:
+        blocked = client.post(
+            f"/assign/1/{ym}/{duty_day.isoformat()}",
+            data={
+                "_csrf_token": csrf(client),
+                "assignment_version": version,
+                "code": "D",
+            },
+            follow_redirects=True,
+        )
+        assert blocked.status_code == 200
+        assert b"annual-leave cell is locked" in blocked.data
+        with app.app.app_context():
+            assignment = Assignment.query.filter_by(staff_id=1, day=duty_day).one()
+            assert assignment.code == "AL"
+            version = assignment.version
+
+        applied = client.post(
+            f"/assign/1/{ym}/{duty_day.isoformat()}",
+            data={
+                "_csrf_token": csrf(client),
+                "assignment_version": version,
+                "annotation": "SOAL",
+            },
+            follow_redirects=True,
+        )
+        assert applied.status_code == 200
+        with app.app.app_context():
+            assignment = Assignment.query.filter_by(staff_id=1, day=duty_day).one()
+            assert assignment.annotation == "SOAL"
+            version = assignment.version
+        assert b'class="code-input code-len-2 al group-a"' in applied.data
+        assert b"SOAL" in applied.data
+
+        shifted = client.post(
+            f"/assign/1/{ym}/{duty_day.isoformat()}",
+            data={
+                "_csrf_token": csrf(client),
+                "assignment_version": version,
+                "code": "D",
+            },
+            follow_redirects=True,
+        )
+        assert shifted.status_code == 200
+        with app.app.app_context():
+            assignment = Assignment.query.filter_by(staff_id=1, day=duty_day).one()
+            assert assignment.code == "D"
+            assert assignment.annotation == "SOAL"
+            assert db.session.get(Leave, leave_id) is not None
+            version = assignment.version
+
+        removed = client.post(
+            f"/assign/1/{ym}/{duty_day.isoformat()}",
+            data={
+                "_csrf_token": csrf(client),
+                "assignment_version": version,
+                "annotation": "__remove__",
+            },
+            follow_redirects=True,
+        )
+        assert removed.status_code == 200
+        assert b'class="code-input code-display code-len-2 al group-a"' in removed.data
+        with app.app.app_context():
+            assignment = Assignment.query.filter_by(staff_id=1, day=duty_day).one()
+            assert assignment.code == "AL"
+            assert not assignment.annotation
+            assert db.session.get(Leave, leave_id) is not None
+    finally:
+        with app.app.app_context():
+            leave = db.session.get(Leave, leave_id)
+            if leave:
+                db.session.delete(leave)
+            if created_soal_definition:
+                AnnotationAudit.query.filter_by(
+                    annotation_type_id=soal_definition_id
+                ).delete(synchronize_session=False)
+                definition = db.session.get(AnnotationType, soal_definition_id)
+                if definition:
+                    db.session.delete(definition)
+            assignment = Assignment.query.filter_by(staff_id=1, day=duty_day).one()
+            (
+                assignment.code,
+                assignment.source,
+                assignment.note,
+                assignment.annotation,
+                assignment.annotation_note,
+                assignment.version,
+            ) = original
+            db.session.commit()
+            app.refresh_annotation_cache()
 
 
 def test_favicon_is_served(client):


### PR DESCRIPTION
## What changed
- lock annual-leave roster cells against ordinary shift edits
- allow a shift only after the cell is annotated SOAL
- retain the underlying annual-leave record and leave-balance deduction
- restore the visible cell to AL when SOAL is removed
- overlay AL from Leave records in the roster view unless SOAL is active
- add an end-to-end regression test for the full workflow

## Why
Annual leave must only be amended through Leave Administration unless a sale-of-annual-leave override is explicitly recorded.

## Validation
- focused AL/SOAL workflow tests
- `python -m pytest -q tests`