### PR TITLE
Refresh runtime grants after migrations

### DIFF
--- a/scripts/migrate_all_databases.py
+++ b/scripts/migrate_all_databases.py
@@ -14,6 +14,8 @@ from alembic.runtime.migration import MigrationContext
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.engine import make_url
 
+from scripts.database_grants import apply_runtime_grants
+
 REPOSITORY = Path(__file__).resolve().parents[1]
 SECRET_NAME_PATTERN = re.compile(r"ATCROSTER_UNIT_[1-9][0-9]*_DATABASE_URL")
 MIGRATION_ADVISORY_LOCK_ID = 4_287_603_356
@@ -33,12 +35,33 @@ def _migration_database_url(secret_name: str, runtime_url: str) -> str:
         migration_secret_name = "CONTROL_MIGRATION_DATABASE_URL"
     elif SECRET_NAME_PATTERN.fullmatch(secret_name):
         migration_secret_name = (
-            secret_name.removesuffix("_DATABASE_URL")
-            + "_MIGRATION_DATABASE_URL"
+            secret_name.removesuffix("_DATABASE_URL") + "_MIGRATION_DATABASE_URL"
         )
     else:
         raise ValueError("Unsupported database secret name.")
     return os.environ.get(migration_secret_name) or runtime_url
+
+
+def _apply_runtime_grants_after_upgrade(migration_url: str, runtime_url: str) -> None:
+    """Grant the runtime login access to relations created by this release.
+
+    PostgreSQL does not automatically extend existing table grants to tables
+    created later by Alembic. Railway's pre-deploy migration therefore needs to
+    refresh the least-privilege grants before the new application starts.
+    """
+    migration = make_url(migration_url)
+    runtime = make_url(runtime_url)
+    if migration.get_backend_name() not in {"postgres", "postgresql"}:
+        return
+    if _canonical_database_url(migration_url) == _canonical_database_url(runtime_url):
+        return
+    if not runtime.username:
+        raise RuntimeError("Runtime database URL must identify a PostgreSQL role.")
+    apply_runtime_grants(
+        migration_url,
+        runtime.username,
+        os.environ.get("ATCROSTER_AUDIT_READ_ROLE") or None,
+    )
 
 
 @contextmanager
@@ -152,11 +175,10 @@ def main() -> None:
     )
     if not control_runtime_url:
         raise SystemExit("CONTROL_DATABASE_URL is required.")
-    control_url = _migration_database_url(
-        "CONTROL_DATABASE_URL", control_runtime_url
-    )
+    control_url = _migration_database_url("CONTROL_DATABASE_URL", control_runtime_url)
     with deployment_migration_lock(control_url):
         control_version = upgrade_database(control_url, "control")
+        _apply_runtime_grants_after_upgrade(control_url, control_runtime_url)
         print(f"Control database upgraded to {control_version}.")
         control_engine = create_engine(
             _sqlalchemy_database_url(control_url), pool_pre_ping=True
@@ -209,6 +231,9 @@ def main() -> None:
                 )
             version = upgrade_database(operational_url, "operational")
             _ensure_info_annotation(operational_url, unit_id)
+            _apply_runtime_grants_after_upgrade(
+                operational_url, runtime_operational_url
+            )
             print(f"Operational database for unit {unit_id} upgraded to {version}.")
 
 

--- a/tests/test_migration_credentials.py
+++ b/tests/test_migration_credentials.py
@@ -1,13 +1,17 @@
 import pytest
 
-from scripts.migrate_all_databases import _migration_database_url
+from scripts.migrate_all_databases import (
+    _apply_runtime_grants_after_upgrade,
+    _migration_database_url,
+)
 
 
 def test_migration_database_url_prefers_separate_control_owner(monkeypatch):
     monkeypatch.setenv("CONTROL_MIGRATION_DATABASE_URL", "postgresql://owner/control")
-    assert _migration_database_url(
-        "CONTROL_DATABASE_URL", "postgresql://runtime/control"
-    ) == "postgresql://owner/control"
+    assert (
+        _migration_database_url("CONTROL_DATABASE_URL", "postgresql://runtime/control")
+        == "postgresql://owner/control"
+    )
 
 
 def test_migration_database_url_prefers_matching_unit_owner(monkeypatch):
@@ -15,18 +19,53 @@ def test_migration_database_url_prefers_matching_unit_owner(monkeypatch):
         "ATCROSTER_UNIT_2_MIGRATION_DATABASE_URL",
         "postgresql://owner/operational",
     )
-    assert _migration_database_url(
-        "ATCROSTER_UNIT_2_DATABASE_URL", "postgresql://runtime/operational"
-    ) == "postgresql://owner/operational"
+    assert (
+        _migration_database_url(
+            "ATCROSTER_UNIT_2_DATABASE_URL", "postgresql://runtime/operational"
+        )
+        == "postgresql://owner/operational"
+    )
 
 
 def test_migration_database_url_retains_local_runtime_fallback(monkeypatch):
     monkeypatch.delenv("CONTROL_MIGRATION_DATABASE_URL", raising=False)
-    assert _migration_database_url(
-        "CONTROL_DATABASE_URL", "sqlite:///local.db"
-    ) == "sqlite:///local.db"
+    assert (
+        _migration_database_url("CONTROL_DATABASE_URL", "sqlite:///local.db")
+        == "sqlite:///local.db"
+    )
 
 
 def test_migration_database_url_rejects_uncontrolled_secret_names():
     with pytest.raises(ValueError, match="Unsupported database secret"):
         _migration_database_url("SOME_DATABASE_URL", "sqlite:///unsafe.db")
+
+
+def test_postgresql_upgrade_refreshes_runtime_grants(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "scripts.migrate_all_databases.apply_runtime_grants",
+        lambda *args: calls.append(args),
+    )
+    monkeypatch.setenv("ATCROSTER_AUDIT_READ_ROLE", "audit_reader")
+
+    _apply_runtime_grants_after_upgrade(
+        "postgresql://owner:secret@database.example/airport",
+        "postgresql://runtime:secret@database.example/airport",
+    )
+
+    assert calls == [
+        (
+            "postgresql://owner:secret@database.example/airport",
+            "runtime",
+            "audit_reader",
+        )
+    ]
+
+
+def test_local_upgrade_does_not_apply_postgresql_grants(monkeypatch):
+    monkeypatch.setattr(
+        "scripts.migrate_all_databases.apply_runtime_grants",
+        lambda *args: pytest.fail("runtime grants should not run for SQLite"),
+    )
+
+    _apply_runtime_grants_after_upgrade("sqlite:///local.db", "sqlite:///local.db")


### PR DESCRIPTION
## What changed

- refresh least-privilege runtime database grants immediately after every control and airport database migration
- derive the runtime PostgreSQL role from the runtime connection URL without logging credentials
- retain the existing SQLite/local-development behavior
- add regression tests for PostgreSQL grant refresh and the local no-op path

## Root cause

The flexible-pattern migration created `staff_pattern_assignment` using the migration-owner role. Existing grants on older tables did not automatically apply to that new table, so the production runtime role received `permission denied` when roster validation queried it. This caused `/roster/2026-08` to return HTTP 500.

## Production recovery

The missing grants were refreshed directly on the control database and both operational databases. The authenticated Glasgow roster request was then reproduced inside the live web service and returned HTTP 200 with the rendered roster.

## Validation

- `python -m pytest -q tests` — 321 passed, 11 skipped
- targeted migration and repository-quality tests — 14 passed
- Ruff lint and formatting checks passed