### PR TITLE
Add safe legacy pattern migration

### DIFF
--- a/app.py
+++ b/app.py
@@ -8827,6 +8827,9 @@ from work_pattern_blueprint import (
 from roster_validation_service import (
     RosterValidationDependencies, RosterValidationService,
 )
+from work_pattern_migration_service import (
+    WorkPatternMigrationDependencies, WorkPatternMigrationService,
+)
 
 work_pattern_service = WorkPatternService(WorkPatternDependencies(
     Staff=Staff,
@@ -8865,6 +8868,18 @@ roster_validation_service = RosterValidationService(
         work_pattern_service=work_pattern_service,
     )
 )
+work_pattern_migration_service = WorkPatternMigrationService(
+    WorkPatternMigrationDependencies(
+        db=db,
+        Staff=Staff,
+        WorkPattern=WorkPattern,
+        WorkPatternDay=WorkPatternDay,
+        ShiftType=ShiftType,
+        StaffPatternAssignment=StaffPatternAssignment,
+        pattern_context=_pattern_context,
+        pattern_service=work_pattern_service,
+    )
+)
 app.register_blueprint(create_work_pattern_blueprint(
     WorkPatternBlueprintDependencies(
         db=db,
@@ -8880,6 +8895,7 @@ app.register_blueprint(create_work_pattern_blueprint(
         validate_csrf=_validate_csrf,
         pattern_service=work_pattern_service,
         admin_service=work_pattern_admin_service,
+        migration_service=work_pattern_migration_service,
     )
 ))
 

--- a/docs/flexible_roster_design.md
+++ b/docs/flexible_roster_design.md
@@ -90,3 +90,17 @@ Count and contracted-minute checks distinguish a proposed duty from an existing
 assignment. Existing duties are measured once: reaching a configured maximum is
 valid, while exceeding it is a blocker. Proposal eligibility continues to
 include the candidate duty when testing the limit.
+
+## Phase 4 legacy migration
+
+Unit administrators can run a dated migration dry-run from the flexible-pattern
+library. The report resolves each person's effective personal, watch or unit CSV
+cycle through the existing legacy logic and compares its ordered codes with
+active normalised patterns. A row is eligible only when exactly one normalised
+pattern has the same fixed-shift and OFF sequence.
+
+Ambiguous, invalid and unmatched cycles cannot be selected and continue to use
+the legacy fallback. The server repeats the analysis when migration is submitted
+so a stale browser report cannot force an unsafe match. Migration only inserts
+an effective-dated `StaffPatternAssignment`, retaining the legacy anchor and
+leaving every existing roster assignment unchanged.

--- a/templates/work_patterns/index.html
+++ b/templates/work_patterns/index.html
@@ -4,6 +4,7 @@
 <section class="compliance-hero"><div><span class="admin-step">Roster administration</span><h2>Flexible work patterns</h2><p>Create reusable cycles for full-time and part-time staff. Existing CSV patterns remain available until each person is migrated.</p></div></section>
 
 <section class="card"><div class="card-hd">Pattern library</div><div class="card-bd">
+  <p><a class="btn" href="{{ url_for('work_patterns.migration') }}">Migrate legacy staff patterns</a></p>
   <form method="post" class="d-inline"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><input type="hidden" name="action" value="seed"><button class="btn btn-primary">Add missing standard patterns</button></form>
   <p class="text-muted">Adds 6-on/4-off and a part-time 4-on/6-off example once only. Existing patterns are never overwritten.</p>
   <div class="admin-staff-list">

--- a/templates/work_patterns/migration.html
+++ b/templates/work_patterns/migration.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block title %}Migrate legacy patterns{% endblock %}
+{% block content %}
+<section class="compliance-hero"><div><span class="admin-step">Safe migration</span><h2>Legacy pattern migration</h2><p>Review a dry-run before creating effective-dated assignments. Only exact ordered cycle matches can be selected. Existing roster duties are never edited.</p></div></section>
+
+<section class="card"><div class="card-hd">Dry-run date</div><div class="card-bd">
+  <form method="get" class="admin-form-grid"><label>Effective from<input type="date" name="effective_from" value="{{ effective_from.isoformat() }}" required></label><div class="form-actions"><button class="btn">Run dry-run</button></div></form>
+  <p class="text-muted">{{ report.exact_count }} exact match(es). Ambiguous and unmatched staff remain on the legacy fallback.</p>
+</div></section>
+
+<form method="post" class="card mt-3"><div class="card-hd">Migration report</div><div class="card-bd">
+  <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><input type="hidden" name="effective_from" value="{{ effective_from.isoformat() }}">
+  <div class="table-wrap"><table><thead><tr><th>Select</th><th>Staff</th><th>Source</th><th>Legacy cycle</th><th>Anchor</th><th>Result</th></tr></thead><tbody>
+  {% for row in report.rows %}<tr><td>{% if row.can_migrate %}<input type="checkbox" name="staff_ids" value="{{ row.staff_id }}" aria-label="Migrate {{ row.staff_name }}">{% else %}—{% endif %}</td><td>{{ row.staff_name }}</td><td>{{ row.source|title }}</td><td>{{ row.legacy_cycle|join(', ') if row.legacy_cycle else '—' }}</td><td>{{ row.legacy_anchor }}</td><td><strong>{{ row.status|replace('_', ' ')|title }}</strong>{% if row.pattern_name %}<br>{{ row.pattern_name }}{% endif %}<br><span class="text-muted">{{ row.explanation }}</span></td></tr>{% else %}<tr><td colspan="6">No staff found.</td></tr>{% endfor %}
+  </tbody></table></div>
+  <div class="form-actions mt-3"><button class="btn btn-primary" {% if not report.exact_count %}disabled{% endif %} data-confirm="Create normalised assignments for the selected exact matches? Existing roster duties will remain unchanged.">Migrate selected exact matches</button></div>
+</div></form>
+{% endblock %}

--- a/tests/fixtures/route_map.json
+++ b/tests/fixtures/route_map.json
@@ -135,6 +135,14 @@
     "rule": "/administration/work-patterns/<int:pattern_id>"
   },
   {
+    "endpoint": "work_patterns.migration",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/administration/work-patterns/migration"
+  },
+  {
     "endpoint": "assign_cell",
     "methods": [
       "POST"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2910,6 +2910,9 @@ def test_flexible_pattern_admin_is_permission_and_tenant_scoped():
     ordinary = app.app.test_client()
     login_as(ordinary, "staff_test")
     assert ordinary.get("/administration/work-patterns").status_code == 403
+    assert ordinary.get(
+        "/administration/work-patterns/migration"
+    ).status_code == 403
 
     admin_client = app.app.test_client()
     login(admin_client)
@@ -2919,6 +2922,65 @@ def test_flexible_pattern_admin_is_permission_and_tenant_scoped():
     assert admin_client.get(
         f"/administration/staff/{other_id}/work-rules"
     ).status_code == 404
+
+
+def test_admin_dry_runs_and_migrates_only_exact_legacy_pattern(client):
+    login(client)
+    effective_from = date(2025, 1, 1)
+    with app.app.app_context():
+        app.work_pattern_admin_service.seed_standard_patterns(1)
+        person = Staff(
+            unit_id=1,
+            username="legacy_pattern_migration_test",
+            password_hash="unused",
+            name="Legacy Migration Test",
+            staff_no="LEG-MIG-1",
+            role="user",
+            pattern_override=True,
+            pattern_csv="M,M,A,A,N,N,OFF,OFF,OFF,OFF",
+            pattern_anchor=effective_from,
+        )
+        db.session.add(person)
+        db.session.commit()
+        person_id = person.id
+        duties_before = [
+            (row.id, row.staff_id, row.day, row.code, row.version)
+            for row in Assignment.query.filter_by(unit_id=1).order_by(Assignment.id)
+        ]
+
+    dry_run = client.get(
+        "/administration/work-patterns/migration?effective_from=2025-01-01"
+    )
+    assert dry_run.status_code == 200
+    assert b"Exact Match" in dry_run.data
+    assert b"Standard 6-on/4-off" in dry_run.data
+
+    migrated = client.post(
+        "/administration/work-patterns/migration",
+        data={
+            "_csrf_token": csrf(client),
+            "effective_from": "2025-01-01",
+            "staff_ids": str(person_id),
+        },
+        follow_redirects=True,
+    )
+    assert migrated.status_code == 200
+    assert b"Existing roster duties were not changed." in migrated.data
+    with app.app.app_context():
+        row = app.StaffPatternAssignment.query.filter_by(
+            unit_id=1, staff_id=person_id, effective_from=effective_from
+        ).one()
+        pattern = app.WorkPattern.query.filter_by(id=row.work_pattern_id).one()
+        assert pattern.name == "Standard 6-on/4-off"
+        assert row.anchor_date == effective_from
+        duties_after = [
+            (item.id, item.staff_id, item.day, item.code, item.version)
+            for item in Assignment.query.filter_by(unit_id=1).order_by(Assignment.id)
+        ]
+        assert duties_after == duties_before
+        db.session.delete(row)
+        db.session.delete(db.session.get(Staff, person_id))
+        db.session.commit()
 
 
 def test_roster_shows_pattern_breach_and_blocks_publication(client):

--- a/work_pattern_blueprint.py
+++ b/work_pattern_blueprint.py
@@ -27,6 +27,7 @@ class WorkPatternBlueprintDependencies:
     validate_csrf: Callable[[], None]
     pattern_service: Any
     admin_service: Any
+    migration_service: Any
 
 
 def create_work_pattern_blueprint(
@@ -103,6 +104,48 @@ def create_work_pattern_blueprint(
             dependencies.WorkPattern.is_active.desc(), dependencies.WorkPattern.name
         ).all()
         return render_template("work_patterns/index.html", patterns=rows)
+
+    @blueprint.route(
+        "/administration/work-patterns/migration", methods=["GET", "POST"]
+    )
+    @login_required
+    def migration():
+        unit_id = require_admin()
+        try:
+            effective_from = _optional_date(
+                request.values.get("effective_from")
+            ) or date.today()
+        except ValueError:
+            abort(400, "Invalid migration effective date.")
+        report = dependencies.migration_service.analyse(unit_id, effective_from)
+        if request.method == "POST":
+            dependencies.validate_csrf()
+            try:
+                selected = {
+                    int(value) for value in request.form.getlist("staff_ids")
+                }
+                if not selected:
+                    raise ValueError("Select at least one exact match to migrate.")
+                created = dependencies.migration_service.migrate_exact(
+                    unit_id, effective_from, selected
+                )
+                dependencies.db.session.commit()
+                flash(
+                    f"Migrated {len(created)} staff pattern assignment(s). "
+                    "Existing roster duties were not changed.",
+                    "ok",
+                )
+                return redirect(url_for(
+                    "work_patterns.migration",
+                    effective_from=effective_from.isoformat(),
+                ))
+            except (TypeError, ValueError) as exc:
+                dependencies.db.session.rollback()
+                flash(f"Migration stopped: {exc}", "error")
+        return render_template(
+            "work_patterns/migration.html", report=report,
+            effective_from=effective_from,
+        )
 
     @blueprint.route(
         "/administration/work-patterns/<int:pattern_id>", methods=["GET", "POST"]

--- a/work_pattern_migration_service.py
+++ b/work_pattern_migration_service.py
@@ -1,0 +1,159 @@
+"""Safe, explicit migration from legacy CSV cycles to normalised patterns."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class LegacyPatternMigrationRow:
+    staff_id: int
+    staff_name: str
+    source: str
+    legacy_cycle: tuple[str, ...]
+    legacy_anchor: date
+    status: str
+    explanation: str
+    pattern_id: int | None = None
+    pattern_name: str | None = None
+
+    @property
+    def can_migrate(self) -> bool:
+        return self.status == "exact_match"
+
+
+@dataclass(frozen=True)
+class LegacyPatternMigrationResult:
+    effective_from: date
+    rows: tuple[LegacyPatternMigrationRow, ...]
+
+    @property
+    def exact_count(self) -> int:
+        return sum(row.can_migrate for row in self.rows)
+
+
+@dataclass(frozen=True)
+class WorkPatternMigrationDependencies:
+    db: Any
+    Staff: Any
+    WorkPattern: Any
+    WorkPatternDay: Any
+    ShiftType: Any
+    StaffPatternAssignment: Any
+    pattern_context: Callable[[Any, date], tuple[list[str], date]]
+    pattern_service: Any
+
+
+class WorkPatternMigrationService:
+    def __init__(self, dependencies: WorkPatternMigrationDependencies) -> None:
+        self.dependencies = dependencies
+
+    def analyse(self, unit_id: int, effective_from: date) -> LegacyPatternMigrationResult:
+        signatures = self._normalised_signatures(unit_id)
+        rows = []
+        staff_rows = self.dependencies.Staff.query.filter_by(
+            unit_id=unit_id
+        ).order_by(self.dependencies.Staff.name, self.dependencies.Staff.id).all()
+        for staff in staff_rows:
+            existing = self._effective_assignment(unit_id, staff.id, effective_from)
+            if existing:
+                rows.append(LegacyPatternMigrationRow(
+                    staff.id, staff.name, "normalised", (), effective_from,
+                    "already_migrated", "A normalised pattern already applies on this date.",
+                ))
+                continue
+            cycle, anchor = self.dependencies.pattern_context(staff, effective_from)
+            signature = tuple(str(code).strip().upper() for code in cycle if str(code).strip())
+            source = "personal override" if staff.pattern_override else (
+                "watch pattern" if staff.watch_id else "unit pattern"
+            )
+            matches = signatures.get(signature, ())
+            if not signature:
+                status, explanation = "invalid_legacy", "The effective legacy cycle is empty or invalid."
+                pattern = None
+            elif len(matches) == 1:
+                status, explanation = "exact_match", "Exact ordered cycle match; safe to migrate."
+                pattern = matches[0]
+            elif len(matches) > 1:
+                status = "ambiguous"
+                explanation = "More than one normalised pattern has this cycle. Select manually."
+                pattern = None
+            else:
+                status = "no_match"
+                explanation = "No exact normalised cycle exists; legacy fallback will remain active."
+                pattern = None
+            rows.append(LegacyPatternMigrationRow(
+                staff.id, staff.name, source, signature, anchor, status, explanation,
+                getattr(pattern, "id", None), getattr(pattern, "name", None),
+            ))
+        return LegacyPatternMigrationResult(effective_from, tuple(rows))
+
+    def migrate_exact(
+        self, unit_id: int, effective_from: date, staff_ids: set[int]
+    ) -> tuple[Any, ...]:
+        report = self.analyse(unit_id, effective_from)
+        eligible = {
+            row.staff_id: row for row in report.rows
+            if row.can_migrate and row.staff_id in staff_ids
+        }
+        if eligible.keys() != staff_ids:
+            raise ValueError(
+                "Selection changed or includes a non-exact match. Run the dry-run again."
+            )
+        created = []
+        for staff_id in sorted(eligible):
+            row = eligible[staff_id]
+            assignment = self.dependencies.StaffPatternAssignment(
+                unit_id=unit_id,
+                staff_id=staff_id,
+                work_pattern_id=row.pattern_id,
+                effective_from=effective_from,
+                anchor_date=row.legacy_anchor,
+                anchor_day_index=0,
+                notes="Migrated from exact legacy CSV cycle match.",
+            )
+            self.dependencies.pattern_service.validate_staff_pattern_assignment(assignment)
+            self.dependencies.db.session.add(assignment)
+            created.append(assignment)
+        self.dependencies.db.session.flush()
+        return tuple(created)
+
+    def _effective_assignment(
+        self, unit_id: int, staff_id: int, on_date: date
+    ) -> Any | None:
+        model = self.dependencies.StaffPatternAssignment
+        return model.query.filter(
+            model.unit_id == unit_id,
+            model.staff_id == staff_id,
+            model.effective_from <= on_date,
+            (model.effective_to.is_(None) | (model.effective_to >= on_date)),
+        ).first()
+
+    def _normalised_signatures(self, unit_id: int) -> dict[tuple[str, ...], tuple[Any, ...]]:
+        shifts = {
+            row.id: row.code.upper()
+            for row in self.dependencies.ShiftType.query.filter_by(unit_id=unit_id).all()
+        }
+        grouped: dict[tuple[str, ...], list[Any]] = {}
+        patterns = self.dependencies.WorkPattern.query.filter_by(
+            unit_id=unit_id, is_active=True
+        ).all()
+        for pattern in patterns:
+            days = self.dependencies.WorkPatternDay.query.filter_by(
+                unit_id=unit_id, work_pattern_id=pattern.id
+            ).order_by(self.dependencies.WorkPatternDay.day_index).all()
+            if len(days) != pattern.cycle_length_days:
+                continue
+            signature = []
+            for day in days:
+                if day.day_type == "OFF":
+                    signature.append("OFF")
+                elif day.day_type == "FIXED_SHIFT" and day.fixed_shift_type_id in shifts:
+                    signature.append(shifts[day.fixed_shift_type_id])
+                else:
+                    break
+            else:
+                grouped.setdefault(tuple(signature), []).append(pattern)
+        return {key: tuple(value) for key, value in grouped.items()}


### PR DESCRIPTION
## What changed

- adds an administrator dry-run report for effective legacy staff patterns
- resolves personal, watch and unit fallback cycles through the existing authoritative logic
- permits selection only when exactly one active normalised pattern has the same ordered fixed-shift/OFF cycle
- repeats matching on submission and rejects stale, ambiguous, invalid, unmatched or overlapping selections
- retains the legacy anchor and creates only an effective-dated pattern assignment
- leaves all existing roster duties untouched

## Impact

Unit administrators can pilot migration with selected staff while unmatched or customised patterns continue using the legacy fallback. No automatic bulk conversion occurs.

## Validation

- `python -m pytest -q` — 319 passed, 11 skipped
- Ruff — passed
- route compatibility contract — passed
- `git diff --check` — passed