### PR TITLE
Support direct migration script invocation

### DIFF
--- a/scripts/database_grants.py
+++ b/scripts/database_grants.py
@@ -8,7 +8,10 @@ import os
 import psycopg
 from psycopg import sql
 
-from scripts.database_backup import psycopg_dsn
+try:
+    from scripts.database_backup import psycopg_dsn
+except ModuleNotFoundError:  # Imported by a directly invoked sibling script.
+    from database_backup import psycopg_dsn
 
 
 AUDIT_TABLES = frozenset(

--- a/scripts/migrate_all_databases.py
+++ b/scripts/migrate_all_databases.py
@@ -14,7 +14,10 @@ from alembic.runtime.migration import MigrationContext
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.engine import make_url
 
-from scripts.database_grants import apply_runtime_grants
+try:
+    from scripts.database_grants import apply_runtime_grants
+except ModuleNotFoundError:  # Railway invokes this file directly.
+    from database_grants import apply_runtime_grants
 
 REPOSITORY = Path(__file__).resolve().parents[1]
 SECRET_NAME_PATTERN = re.compile(r"ATCROSTER_UNIT_[1-9][0-9]*_DATABASE_URL")

--- a/tests/test_migration_credentials.py
+++ b/tests/test_migration_credentials.py
@@ -1,3 +1,8 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
 import pytest
 
 from scripts.migrate_all_databases import (
@@ -69,3 +74,23 @@ def test_local_upgrade_does_not_apply_postgresql_grants(monkeypatch):
     )
 
     _apply_runtime_grants_after_upgrade("sqlite:///local.db", "sqlite:///local.db")
+
+
+def test_migration_script_supports_railway_direct_invocation(tmp_path):
+    script = Path(__file__).parents[1] / "scripts" / "migrate_all_databases.py"
+    environment = os.environ.copy()
+    environment.pop("CONTROL_DATABASE_URL", None)
+    environment.pop("DATABASE_URL", None)
+
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=environment,
+    )
+
+    assert result.returncode != 0
+    assert "CONTROL_DATABASE_URL is required" in result.stderr
+    assert "ModuleNotFoundError" not in result.stderr


### PR DESCRIPTION
## What changed

- allow the migration/grant modules to import correctly when Railway invokes `scripts/migrate_all_databases.py` as a file
- retain module-style imports used by tests and GitHub workflows
- add a regression test that launches the migration script from outside the repository, matching Railway's direct invocation behavior

## Why

The runtime-grant safeguard in PR #195 passed module-based CI but Railway's pre-deploy command invokes the file directly. Python therefore placed the `scripts` directory, rather than the repository root, on the import path. The new release correctly failed during pre-deploy and never replaced the healthy production instance.

## Validation

- targeted migration and repository-quality tests: 15 passed
- Ruff lint, formatting, and diff checks passed