### PR TITLE
Fix direct migration script imports

### DIFF
--- a/scripts/migrate_all_databases.py
+++ b/scripts/migrate_all_databases.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import re
+import sys
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -14,9 +15,14 @@ from alembic.runtime.migration import MigrationContext
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.engine import make_url
 
-from scripts.database_grants import apply_runtime_grants
-
 REPOSITORY = Path(__file__).resolve().parents[1]
+# Railway invokes this file directly. Add the repository root so imports within
+# the scripts package resolve identically in direct and module execution modes.
+if str(REPOSITORY) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY))
+
+from scripts.database_grants import apply_runtime_grants  # noqa: E402
+
 SECRET_NAME_PATTERN = re.compile(r"ATCROSTER_UNIT_[1-9][0-9]*_DATABASE_URL")
 MIGRATION_ADVISORY_LOCK_ID = 4_287_603_356
 

--- a/tests/test_migration_credentials.py
+++ b/tests/test_migration_credentials.py
@@ -1,3 +1,8 @@
+import os
+from pathlib import Path
+import subprocess
+import sys
+
 import pytest
 
 from scripts.migrate_all_databases import (
@@ -69,3 +74,23 @@ def test_local_upgrade_does_not_apply_postgresql_grants(monkeypatch):
     )
 
     _apply_runtime_grants_after_upgrade("sqlite:///local.db", "sqlite:///local.db")
+
+
+def test_migration_script_direct_entrypoint_loads_dependencies():
+    repository = Path(__file__).resolve().parents[1]
+    environment = os.environ.copy()
+    environment.pop("CONTROL_DATABASE_URL", None)
+    environment.pop("DATABASE_URL", None)
+
+    result = subprocess.run(
+        [sys.executable, "scripts/migrate_all_databases.py"],
+        cwd=repository,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "CONTROL_DATABASE_URL is required" in result.stderr
+    assert "ModuleNotFoundError" not in result.stderr


### PR DESCRIPTION
## What changed

- makes the Railway pre-deploy migration entry point add the repository root before importing the scripts package
- adds a subprocess regression test that invokes `python scripts/migrate_all_databases.py` exactly as Railway does

## Root cause

The runtime-grant hardening imported `scripts.database_grants`, but direct file execution only placed the `scripts` directory on Python’s import path. The worker pre-deploy therefore failed before any migration ran.

## Safety

The failed worker deployment never replaced the previous healthy worker. No database migration or application mutation occurred before the import failure.

## Validation

- migration credential tests: 7 passed
- direct entry point reaches the expected missing-configuration guard
- Ruff and diff checks passed