### PR TITLE
Keep roster day header visible

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -859,6 +859,14 @@ table.roster tbody tr:hover{background:rgba(84,118,192,.12);}
 .roster td{border:1px solid var(--line); text-align:center; padding:.25rem .35rem;}
 
 th.sticky{position:sticky; top:0; background:var(--head); color:#fff; z-index:2;}
+table.roster th.sticky,
+.roster th.dayhead{
+  top:var(--roster-sticky-top, 0px);
+}
+.roster th.dayhead{
+  z-index:5;
+  box-shadow:0 4px 8px rgba(0,0,0,.24);
+}
 th.sticky.left{left:0; z-index:3; background:var(--head);}
 
 .roster th.col-name,
@@ -2123,6 +2131,7 @@ table.roster { zoom:var(--ui-scale); }
   thead{ display:table-header-group; }
   tfoot{ display:table-footer-group; }
   th.sticky,
+  .roster th.dayhead,
   .roster th.col-name,
   .roster td.col-name{
     position:static !important;

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -411,6 +411,17 @@
 
 <script nonce="{{ csp_nonce() }}">
   function printRoster(){ window.print(); }
+  const rosterTable = document.querySelector('table.roster');
+  const siteHeader = document.querySelector('.site-header');
+  const updateRosterStickyTop = () => {
+    const height = siteHeader ? Math.ceil(siteHeader.getBoundingClientRect().height) : 0;
+    rosterTable?.style.setProperty('--roster-sticky-top', `${height}px`);
+  };
+  updateRosterStickyTop();
+  window.addEventListener('resize', updateRosterStickyTop, { passive: true });
+  if (siteHeader && 'ResizeObserver' in window) {
+    new ResizeObserver(updateRosterStickyTop).observe(siteHeader);
+  }
   document.querySelectorAll('[data-annotation-select]').forEach((select) => {
     select.addEventListener('change', () => {
       const form = select.form;

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -3182,3 +3182,18 @@ def test_roster_shows_pattern_breach_and_blocks_publication(client):
         ).delete()
         app.WorkPattern.query.filter_by(id=pattern_id, unit_id=1).delete()
         db.session.commit()
+
+
+def test_roster_keeps_day_header_below_sticky_site_header(client):
+    login(client)
+    response = client.get("/roster/2025-09")
+
+    assert response.status_code == 200
+    assert b"--roster-sticky-top" in response.data
+    assert b"ResizeObserver(updateRosterStickyTop)" in response.data
+    with open(
+        os.path.join(app.BASE_DIR, "static", "styles.css"), encoding="utf-8"
+    ) as stylesheet_file:
+        stylesheet = stylesheet_file.read()
+    assert ".roster th.dayhead" in stylesheet
+    assert "top:var(--roster-sticky-top, 0px)" in stylesheet


### PR DESCRIPTION
## What changed

- keeps roster day/date headings sticky during vertical scrolling
- dynamically offsets the roster header below the sticky site navigation at every screen size
- preserves the higher-layer sticky staff-name intersection
- disables sticky positioning for print output

## Validation

- `python -m pytest -q` — 324 passed, 11 skipped
- focused roster sticky-header tests — passed
- Ruff and diff checks — passed