### PR TITLE
Make roster editing feel immediate

### DIFF
--- a/atcroster/__init__.py
+++ b/atcroster/__init__.py
@@ -9,6 +9,7 @@ from typing import Any
 from flask import Flask
 from werkzeug.middleware.proxy_fix import ProxyFix
 
+from atcroster.compression import register_response_compression
 from atcroster.config import (
     RuntimeSettings,
     environment_snapshot,
@@ -58,6 +59,7 @@ def create_app(
 
     if validate_external_services and settings.deployment_environment == "production":
         _validate_external_services(app)
+    register_response_compression(app)
     return app
 
 

--- a/atcroster/compression.py
+++ b/atcroster/compression.py
@@ -1,0 +1,50 @@
+"""Small response-compression boundary for dynamic application pages."""
+
+from __future__ import annotations
+
+import gzip
+
+from flask import Flask, Response, request
+
+
+COMPRESSIBLE_TYPES = (
+    "application/javascript",
+    "application/json",
+    "application/xml",
+    "image/svg+xml",
+    "text/",
+)
+
+
+def register_response_compression(app: Flask, *, minimum_size: int = 1024) -> None:
+    """Gzip suitable responses when the browser advertises support."""
+
+    def compress_response(response: Response) -> Response:
+        accepted = request.headers.get("Accept-Encoding", "").lower()
+        content_type = response.headers.get("Content-Type", "").lower()
+        if (
+            "gzip" not in accepted
+            or response.status_code < 200
+            or response.status_code >= 300
+            or response.direct_passthrough
+            or response.is_streamed
+            or response.headers.get("Content-Encoding")
+            or content_type.startswith("text/event-stream")
+            or request.headers.get("Range")
+            or not any(content_type.startswith(item) for item in COMPRESSIBLE_TYPES)
+        ):
+            return response
+        payload = response.get_data()
+        if len(payload) < minimum_size:
+            return response
+        compressed = gzip.compress(payload, compresslevel=5)
+        if len(compressed) >= len(payload):
+            return response
+        response.set_data(compressed)
+        response.headers["Content-Encoding"] = "gzip"
+        response.headers["Content-Length"] = str(len(compressed))
+        response.headers.add("Vary", "Accept-Encoding")
+        return response
+
+    compress_response.__name__ = "_compress_response"
+    app.after_request(compress_response)

--- a/roster_blueprint.py
+++ b/roster_blueprint.py
@@ -16,6 +16,7 @@ from flask import (
     abort,
     current_app,
     flash,
+    jsonify,
     redirect,
     render_template,
     request,
@@ -653,6 +654,65 @@ def create_roster_blueprint(dependencies: RosterDependencies) -> Blueprint:
         except (TypeError, ValueError):
             abort(400, "Invalid roster date.")
         unit_id = dependencies.current_unit_id()
+
+        def edit_error(message: str, status: int = 422):
+            if request.headers.get("X-Requested-With") == "XMLHttpRequest":
+                return jsonify(ok=False, error=message), status
+            flash(message, "error")
+            return redirect(url_for("roster_month", ym=ym))
+
+        def updated_day_summary() -> dict[str, Any]:
+            people = dependencies.Staff.query.filter_by(unit_id=unit_id).all()
+            assignments = dependencies.Assignment.query.filter_by(
+                unit_id=unit_id, day=duty_day
+            ).all()
+            codes = {item.staff_id: (item.code or "").upper() for item in assignments}
+            excluded = dependencies.exclude_from_counters()
+            _, training, _ = dependencies.shift_groups(unit_id)
+            training_codes = {shift.code for shift in training}
+            counts = Counter({group: 0 for group in ("M", "D", "A", "N")})
+            for member in people:
+                if not getattr(member, "is_operational", True):
+                    continue
+                if not dependencies.staff_is_countable_on(member, duty_day):
+                    continue
+                member_code = codes.get(member.id, "")
+                if (
+                    not member_code
+                    or member_code in excluded
+                    or member_code in training_codes
+                    or member_code in {"AL", "NOPS"}
+                ):
+                    continue
+                group = dependencies.shift_counter_group_for_day(
+                    member_code, duty_day, unit_id
+                )
+                if group:
+                    counts[group] += 1
+            requirement = dependencies.ensure_month_requirement(year, month)
+            special = dependencies.SpecialRequirement.query.filter_by(
+                unit_id=unit_id, day=duty_day
+            ).first()
+            required = dependencies.requirements_for_day(requirement, duty_day, special)
+            night_active = dependencies.night_active_on(unit_id, duty_day)
+            rag = {}
+            for group in ("M", "D", "A", "N"):
+                needed = 0 if group == "N" and not night_active else required[group]
+                available = counts[group]
+                rag[group] = (
+                    "green"
+                    if available >= needed
+                    else ("amber" if available >= max(0, needed - 1) else "red")
+                )
+            return {
+                "counts": dict(counts),
+                "required": required,
+                "rag": rag,
+                "night_active": night_active,
+                "total": sum(counts[group] for group in ("M", "D", "A"))
+                + (counts["N"] if night_active else 0),
+            }
+
         dependencies.lock_roster_month(unit_id, year, month)
         person = dependencies.Staff.query.filter_by(
             id=staff_id, unit_id=unit_id
@@ -694,22 +754,17 @@ def create_roster_blueprint(dependencies: RosterDependencies) -> Blueprint:
         annotation = request.form.get("annotation")
         if code:
             if annual_leave and not annotation_is_soal(assignment.annotation):
-                flash(
+                return edit_error(
                     "This annual-leave cell is locked. Apply the SOAL annotation "
-                    "before entering a shift, or amend the leave in Leave Administration.",
-                    "error",
+                    "before entering a shift, or amend the leave in Leave Administration."
                 )
-                return redirect(url_for("roster_month", ym=ym))
             if code in dependencies.banned_roster_codes():
-                flash(
+                return edit_error(
                     "Leave, sickness and TOIL use must be logged via the form, "
-                    "not the roster grid.",
-                    "error",
+                    "not the roster grid."
                 )
-                return redirect(url_for("roster_month", ym=ym))
             if not dependencies.get_shift(code):
-                flash(f"Unknown shift code '{code}'", "error")
-                return redirect(url_for("roster_month", ym=ym))
+                return edit_error(f"Unknown shift code '{code}'")
             assignment.code = code
             assignment.source = "manual"
 
@@ -730,14 +785,11 @@ def create_roster_blueprint(dependencies: RosterDependencies) -> Blueprint:
                     unit_id=unit_id, code=parsed["type"]
                 ).first()
             if new_value and (not parsed or not definition):
-                flash(f"Unknown annotation '{new_value}'.", "error")
-                return redirect(url_for("roster_month", ym=ym))
+                return edit_error(f"Unknown annotation '{new_value}'.")
             if definition and not definition.is_active and old_value != new_value:
-                flash(
-                    f"{definition.code} is inactive and cannot be newly applied.",
-                    "error",
+                return edit_error(
+                    f"{definition.code} is inactive and cannot be newly applied."
                 )
-                return redirect(url_for("roster_month", ym=ym))
             if (
                 definition
                 and definition.admin_only
@@ -745,8 +797,7 @@ def create_roster_blueprint(dependencies: RosterDependencies) -> Blueprint:
             ):
                 abort(403)
             if definition and definition.note_required and not annotation_note:
-                flash(f"{definition.code} requires a note.", "error")
-                return redirect(url_for("roster_month", ym=ym))
+                return edit_error(f"{definition.code} requires a note.")
             if old_value != new_value:
                 transaction_key = (request.form.get("transaction_key") or "").strip()[
                     :64
@@ -809,6 +860,17 @@ def create_roster_blueprint(dependencies: RosterDependencies) -> Blueprint:
         except IntegrityError:
             dependencies.db.session.rollback()
             abort(409, "This roster cell changed concurrently.")
+        if request.headers.get("X-Requested-With") == "XMLHttpRequest":
+            return jsonify(
+                ok=True,
+                staff_id=staff_id,
+                day=duty_day.isoformat(),
+                code=assignment.code,
+                annotation=assignment.annotation or "",
+                annotation_note=assignment.annotation_note or "",
+                version=assignment.version,
+                day_summary=updated_day_summary(),
+            )
         return redirect(url_for("roster_month", ym=ym))
 
     @blueprint.record_once

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -106,6 +106,10 @@
   /* Tighten spacing (unchanged) */
   .roster-grid{ margin-bottom:0; }
   .roster-footer{ margin-top:.5rem; }
+  .roster-save-status{ position:fixed; right:1rem; bottom:1rem; z-index:1200; padding:.55rem .8rem; border-radius:.55rem; background:#183153; color:#fff; box-shadow:0 8px 24px rgba(0,0,0,.2); opacity:0; transform:translateY(.5rem); pointer-events:none; transition:opacity .15s ease, transform .15s ease; }
+  .roster-save-status.is-visible{ opacity:1; transform:translateY(0); }
+  .roster-save-status.is-error{ background:#a61b29; }
+  .shift-picker.is-saving .code-input{ opacity:.65; cursor:progress; }
 
   @media print{
     /* Hide the overlay in print to avoid heavy borders */
@@ -116,6 +120,7 @@
 </style>
 
 <h2>ATC Roster – {{ month_title }}</h2>
+<div class="roster-save-status" data-roster-save-status role="status" aria-live="polite"></div>
 
 <div class="month-nav roster-month-nav">
   {% if prev_ym %}
@@ -198,6 +203,7 @@
           {% set applied_request = applied_request_map.get((s.id, d)) %}
           {% set prefix = ('m' if code == 'EM' else ('a' if code == 'LA' else code[:1]|lower)) %}
           <td class="cell {{ 'editable' if can_edit and not readonly else 'locked' }}{% if not s.is_operational %} nonop{% endif %}{% if f %} fatigue{% endif %}{% if rv_blocking %} roster-validation-blocking{% elif rv %} roster-validation-advisory{% endif %}{% if d == today %} is-today{% endif %}{% if code in training_codes %} training{% endif %}{% if applied_request %} request-applied{% endif %}"
+              data-roster-staff="{{ s.id }}" data-roster-day="{{ d.isoformat() }}"
               {% if applied_request %}title="Applied from an approved shift request" aria-label="{{ s.name }}, {{ d.strftime('%d %B %Y') }}, {{ code }}, applied from an approved shift request"{% endif %}>
             {% if applied_request %}
               <span class="request-applied-marker" aria-hidden="true"></span>
@@ -239,7 +245,8 @@
               <select
                 name="code"
                 class="code-input code-len-{{ code|length }} {% if code %}{{ code|lower }} group-{{ prefix }}{% endif %}"
-                data-auto-submit="true"
+                data-roster-auto-submit="true"
+                data-saved-value="{{ code }}"
                 {% if (not can_edit) or readonly %}disabled{% endif %}
                 {% if f %}title="{{ ', '.join(f) }}"{% endif %}
                 aria-label="{{ s.name }} shift on {{ d.strftime('%d %B %Y') }}"
@@ -326,12 +333,12 @@
         {% set a = counters[d]["A"] %}
         {% set n = counters[d]["N"] %}
         {% set total = m + dday + a + (n if night_active[d] else 0) %}
-        <td class="totcell{% if d == today %} is-today{% endif %}">
+        <td class="totcell{% if d == today %} is-today{% endif %}" data-roster-day="{{ d.isoformat() }}">
           <div class="daily-total"><strong>Total {{ total }}</strong></div>
-          <div class="rag {{ rag[d]['M'] }}">M <span class="rag-count{% if m > req_by_day[d]['M'] %} rag-count--over{% endif %}">{{ m }}</span>/{{ req_by_day[d]['M'] }}</div>
-          <div class="rag {{ rag[d]['D'] }}">D <span class="rag-count{% if dday > req_by_day[d]['D'] %} rag-count--over{% endif %}">{{ dday }}</span>/{{ req_by_day[d]['D'] }}</div>
-          <div class="rag {{ rag[d]['A'] }}">A <span class="rag-count{% if a > req_by_day[d]['A'] %} rag-count--over{% endif %}">{{ a }}</span>/{{ req_by_day[d]['A'] }}</div>
-          {% if night_active[d] %}<div class="rag {{ rag[d]['N'] }}">N <span class="rag-count{% if n > req_by_day[d]['N'] %} rag-count--over{% endif %}">{{ n }}</span>/{{ req_by_day[d]['N'] }}</div>{% endif %}
+          <div class="rag {{ rag[d]['M'] }}" data-roster-count-row="M">M <span class="rag-count{% if m > req_by_day[d]['M'] %} rag-count--over{% endif %}" data-roster-count>{{ m }}</span>/<span data-roster-required>{{ req_by_day[d]['M'] }}</span></div>
+          <div class="rag {{ rag[d]['D'] }}" data-roster-count-row="D">D <span class="rag-count{% if dday > req_by_day[d]['D'] %} rag-count--over{% endif %}" data-roster-count>{{ dday }}</span>/<span data-roster-required>{{ req_by_day[d]['D'] }}</span></div>
+          <div class="rag {{ rag[d]['A'] }}" data-roster-count-row="A">A <span class="rag-count{% if a > req_by_day[d]['A'] %} rag-count--over{% endif %}" data-roster-count>{{ a }}</span>/<span data-roster-required>{{ req_by_day[d]['A'] }}</span></div>
+          {% if night_active[d] %}<div class="rag {{ rag[d]['N'] }}" data-roster-count-row="N">N <span class="rag-count{% if n > req_by_day[d]['N'] %} rag-count--over{% endif %}" data-roster-count>{{ n }}</span>/<span data-roster-required>{{ req_by_day[d]['N'] }}</span></div>{% endif %}
         </td>
       {% endfor %}
     </tr>
@@ -422,6 +429,99 @@
   if (siteHeader && 'ResizeObserver' in window) {
     new ResizeObserver(updateRosterStickyTop).observe(siteHeader);
   }
+  const rosterRoot = document.getElementById('roster');
+  const rosterScrollKey = `atcroster:scroll:${window.location.pathname}`;
+  const rosterSaveStatus = document.querySelector('[data-roster-save-status]');
+  let rosterSaveStatusTimer;
+  if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
+  const rememberRosterPosition = () => {
+    sessionStorage.setItem(rosterScrollKey, JSON.stringify({ x: window.scrollX, y: window.scrollY }));
+  };
+  const rememberedRosterPosition = sessionStorage.getItem(rosterScrollKey);
+  if (rememberedRosterPosition) {
+    sessionStorage.removeItem(rosterScrollKey);
+    try {
+      const position = JSON.parse(rememberedRosterPosition);
+      requestAnimationFrame(() => window.scrollTo(position.x || 0, position.y || 0));
+    } catch (_error) {}
+  }
+  const showRosterSaveStatus = (message, error = false) => {
+    if (!rosterSaveStatus) return;
+    clearTimeout(rosterSaveStatusTimer);
+    rosterSaveStatus.textContent = message;
+    rosterSaveStatus.classList.toggle('is-error', error);
+    rosterSaveStatus.classList.add('is-visible');
+    rosterSaveStatusTimer = setTimeout(() => rosterSaveStatus.classList.remove('is-visible'), error ? 4500 : 1600);
+  };
+  const updateRosterDaySummary = (day, summary) => {
+    const totalCell = document.querySelector(`.totcell[data-roster-day="${day}"]`);
+    if (!totalCell || !summary) return;
+    const total = totalCell.querySelector('.daily-total strong');
+    if (total) total.textContent = `Total ${summary.total}`;
+    ['M', 'D', 'A', 'N'].forEach((group) => {
+      const row = totalCell.querySelector(`[data-roster-count-row="${group}"]`);
+      if (!row) return;
+      row.classList.remove('green', 'amber', 'red');
+      row.classList.add(summary.rag[group]);
+      const count = row.querySelector('[data-roster-count]');
+      const required = row.querySelector('[data-roster-required]');
+      count.textContent = summary.counts[group] || 0;
+      required.textContent = summary.required[group] || 0;
+      count.classList.toggle('rag-count--over', Number(count.textContent) > Number(required.textContent));
+    });
+  };
+  const saveRosterShift = async (form) => {
+    if (form.dataset.saving === '1') return;
+    const select = form.querySelector('[data-roster-auto-submit]');
+    const cell = form.closest('.cell');
+    if (!select || !cell) return;
+    const previousValue = select.dataset.savedValue || '';
+    const formData = new FormData(form);
+    form.dataset.saving = '1';
+    form.classList.add('is-saving');
+    select.disabled = true;
+    showRosterSaveStatus('Saving…');
+    try {
+      const response = await fetch(form.action, {
+        method: 'POST',
+        body: formData,
+        credentials: 'same-origin',
+        headers: { 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok || !payload.ok) throw new Error(payload.error || 'The roster change could not be saved.');
+      const code = payload.code || '';
+      select.value = code;
+      select.dataset.savedValue = code;
+      const prefix = code === 'EM' ? 'm' : (code === 'LA' ? 'a' : code.slice(0, 1).toLowerCase());
+      select.className = `code-input code-len-${code.length}${code ? ` ${code.toLowerCase()} group-${prefix}` : ''}`;
+      cell.querySelectorAll('input[name="assignment_version"]').forEach((input) => { input.value = payload.version; });
+      updateRosterDaySummary(payload.day, payload.day_summary);
+      showRosterSaveStatus('Saved');
+    } catch (error) {
+      select.value = previousValue;
+      showRosterSaveStatus(error.message || 'The roster change could not be saved.', true);
+    } finally {
+      select.disabled = false;
+      form.dataset.saving = '0';
+      form.classList.remove('is-saving');
+      select.focus({ preventScroll: true });
+    }
+  };
+  rosterRoot?.addEventListener('change', (event) => {
+    const select = event.target.closest('[data-roster-auto-submit]');
+    if (select) saveRosterShift(select.form);
+  });
+  document.addEventListener('submit', (event) => {
+    const form = event.target;
+    if (!form.closest('#roster')) return;
+    if (form.matches('.shift-picker')) {
+      event.preventDefault();
+      saveRosterShift(form);
+      return;
+    }
+    rememberRosterPosition();
+  });
   document.querySelectorAll('[data-annotation-select]').forEach((select) => {
     select.addEventListener('change', () => {
       const form = select.form;

--- a/tests/test_response_compression.py
+++ b/tests/test_response_compression.py
@@ -1,0 +1,48 @@
+from flask import Flask
+
+from atcroster.compression import register_response_compression
+
+
+def test_large_html_response_is_gzipped_for_supporting_browser():
+    app = Flask(__name__)
+    register_response_compression(app, minimum_size=100)
+
+    @app.get("/")
+    def large_page():
+        return "<p>Roster content</p>" * 200
+
+    response = app.test_client().get("/", headers={"Accept-Encoding": "gzip"})
+
+    assert response.status_code == 200
+    assert response.headers["Content-Encoding"] == "gzip"
+    assert "Accept-Encoding" in response.headers.getlist("Vary")
+    assert int(response.headers["Content-Length"]) < 4200
+
+
+def test_compression_is_not_forced_on_unsupported_browser():
+    app = Flask(__name__)
+    register_response_compression(app, minimum_size=100)
+
+    @app.get("/")
+    def large_page():
+        return "Roster content" * 200
+
+    response = app.test_client().get("/")
+
+    assert "Content-Encoding" not in response.headers
+
+
+def test_streaming_response_is_never_buffered_for_compression():
+    app = Flask(__name__)
+    register_response_compression(app, minimum_size=1)
+
+    @app.get("/events")
+    def events():
+        return (item for item in ["data: ready\n\n"]), {
+            "Content-Type": "text/event-stream"
+        }
+
+    response = app.test_client().get("/events", headers={"Accept-Encoding": "gzip"})
+
+    assert response.data == b"data: ready\n\n"
+    assert "Content-Encoding" not in response.headers

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -620,6 +620,9 @@ def test_roster_has_persistent_zoom_presets(client):
     assert b"transform: scale(var(--ui-scale))" not in stylesheet.data
     assert b"today-column overlay (layer 5)" in stylesheet.data
     assert b"z-index:7" in stylesheet.data
+    assert b'data-roster-auto-submit="true"' in response.data
+    assert b"Saving\xe2\x80\xa6" in response.data
+    assert b"atcroster:scroll:" in response.data
 
 
 def test_roster_renders_annual_leave_as_static_al_code(client):
@@ -920,6 +923,49 @@ def test_stale_roster_cell_version_is_rejected(client):
         ).one()
         assert assignment.code == "A"
         assert assignment.version == stale_version + 1
+
+
+def test_roster_shift_can_be_saved_without_a_page_reload(client):
+    login(client)
+    duty_day = date(2025, 4, 3)
+    with app.app.app_context():
+        admin = Staff.query.filter_by(username=ADMIN_CREDENTIALS["username"]).one()
+        assignment = Assignment.query.filter_by(
+            unit_id=1, staff_id=admin.id, day=duty_day
+        ).one()
+        original = (assignment.code, assignment.source, assignment.version)
+        staff_id = admin.id
+        version = assignment.version
+    try:
+        response = client.post(
+            f"/assign/{staff_id}/2025-04/{duty_day.isoformat()}",
+            data={
+                "_csrf_token": csrf(client),
+                "code": "D",
+                "assignment_version": version,
+            },
+            headers={
+                "Accept": "application/json",
+                "X-Requested-With": "XMLHttpRequest",
+            },
+        )
+
+        assert response.status_code == 200
+        payload = response.get_json()
+        assert payload["ok"] is True
+        assert payload["code"] == "D"
+        assert payload["version"] == version + 1
+        assert payload["day"] == duty_day.isoformat()
+        assert set(payload["day_summary"]) == {
+            "counts", "night_active", "rag", "required", "total",
+        }
+    finally:
+        with app.app.app_context():
+            assignment = Assignment.query.filter_by(
+                unit_id=1, staff_id=staff_id, day=duty_day
+            ).one()
+            assignment.code, assignment.source, assignment.version = original
+            db.session.commit()
 
 
 def test_roster_publication_emails_every_registered_unit_user(


### PR DESCRIPTION
## What changed

- save ordinary roster shift changes in the background without navigating or rebuilding the page
- retain keyboard focus and the exact horizontal/vertical screen position
- show compact Saving, Saved, and error feedback; failed saves restore the prior shift
- return authoritative assignment versions and daily staffing totals from the server
- update daily totals, M/D/A/N counts, RAG colours, and overstaffing pulse immediately
- preserve exact scroll position for annotation operations that still require a full refresh
- gzip large HTML/JSON/static responses while explicitly excluding streaming live-monitor responses and range requests

## Why

A fully populated monthly roster renders several megabytes of repeated HTML. Each edit previously transferred and rebuilt the entire page, then returned the browser to the top. The new flow keeps all existing server-side leave, SOAL, qualification, security, locking, and concurrency rules while making the common shift-edit path behave like an application.

## Validation

- `python -m pytest -q tests` — 327 passed, 11 skipped
- targeted background-save, response-compression, publication and roster rendering tests passed
- inline roster JavaScript passed `node --check`
- Ruff and diff checks passed