### PR TITLE
Fix overlapping roster date headings

### DIFF
--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -152,12 +152,12 @@
   <thead>
     <tr>
       <th class="sticky left col-name">Name</th>
-      <th class="sticky left col-staff">Staff #</th>
-      <th class="sticky left col-date">Medical</th>
-      <th class="sticky left col-date">Tower UE</th>
-      <th class="sticky left col-date">Radar UE</th>
-      <th class="sticky left col-date">MET UE</th>
-      <th class="sticky left col-watch">W</th>
+      <th class="sticky col-staff">Staff #</th>
+      <th class="sticky col-date">Medical</th>
+      <th class="sticky col-date">Tower UE</th>
+      <th class="sticky col-date">Radar UE</th>
+      <th class="sticky col-date">MET UE</th>
+      <th class="sticky col-watch">W</th>
       {% for d in days %}
         {% set dow = d.strftime('%a') %}
         <th class="dayhead {% if d.weekday() in [5,6] %}weekend{% endif %}{% if d == today %} is-today{% endif %}">

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -3191,6 +3191,9 @@ def test_roster_keeps_day_header_below_sticky_site_header(client):
     assert response.status_code == 200
     assert b"--roster-sticky-top" in response.data
     assert b"ResizeObserver(updateRosterStickyTop)" in response.data
+    assert response.data.count(b'class="sticky left col-name"') == 1
+    assert b'class="sticky left col-date"' not in response.data
+    assert b'class="sticky col-date">Medical' in response.data
     with open(
         os.path.join(app.BASE_DIR, "static", "styles.css"), encoding="utf-8"
     ) as stylesheet_file:


### PR DESCRIPTION
## What changed

- keeps only the Name header horizontally pinned
- keeps staff number, medical, UE and watch headings vertically sticky in their natural columns
- prevents the metadata headings from stacking at `left: 0` and appearing to disappear

## Root cause

All seven metadata header cells carried the horizontal `left` sticky class. Once the header row was made vertically sticky, those cells could overlap during scrolling.

## Validation

- focused roster header regression test passed
- Ruff and diff checks passed