### PR TITLE
Keep zoomed roster dates visible

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -859,13 +859,15 @@ table.roster tbody tr:hover{background:rgba(84,118,192,.12);}
 .roster td{border:1px solid var(--line); text-align:center; padding:.25rem .35rem;}
 
 th.sticky{position:sticky; top:0; background:var(--head); color:#fff; z-index:2;}
-table.roster th.sticky,
-.roster th.dayhead{
+table.roster thead{
+  position:sticky;
   top:var(--roster-sticky-top, 0px);
-}
-.roster th.dayhead{
-  z-index:5;
+  z-index:20;
   box-shadow:0 4px 8px rgba(0,0,0,.24);
+}
+table.roster thead th.sticky{
+  position:relative;
+  top:auto;
 }
 th.sticky.left{left:0; z-index:3; background:var(--head);}
 
@@ -876,7 +878,9 @@ th.sticky.left{left:0; z-index:3; background:var(--head);}
 }
 
 .roster th.col-name{
-  z-index:6;
+  position:sticky;
+  left:0;
+  z-index:21;
 }
 
 .roster td.col-name{
@@ -2129,6 +2133,7 @@ table.roster { zoom:var(--ui-scale); }
     transform:none !important;
   }
   thead{ display:table-header-group; }
+  .roster thead{ position:static !important; box-shadow:none !important; }
   tfoot{ display:table-footer-group; }
   th.sticky,
   .roster th.dayhead,

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -59,7 +59,7 @@
   :root { --today-col: rgba(255,255,0,.85); }
 
   /* Ensure cells can host absolutely-positioned overlays */
-  .roster th.dayhead { position: sticky; }
+  .roster th.dayhead { position: relative; }
   .roster td.cell { position: relative; }
   .roster td.totcell { position: relative; }
 
@@ -422,12 +422,23 @@
   const siteHeader = document.querySelector('.site-header');
   const updateRosterStickyTop = () => {
     const height = siteHeader ? Math.ceil(siteHeader.getBoundingClientRect().height) : 0;
-    rosterTable?.style.setProperty('--roster-sticky-top', `${height}px`);
+    const rosterHost = document.getElementById('roster');
+    const configuredScale = Number(rosterHost?.dataset.scale || 1);
+    const scale = Number.isFinite(configuredScale) && configuredScale > 0
+      ? configuredScale : 1;
+    rosterTable?.style.setProperty('--roster-sticky-top', `${Math.ceil(height / scale)}px`);
   };
   updateRosterStickyTop();
   window.addEventListener('resize', updateRosterStickyTop, { passive: true });
   if (siteHeader && 'ResizeObserver' in window) {
     new ResizeObserver(updateRosterStickyTop).observe(siteHeader);
+  }
+  const rosterScaleHost = document.getElementById('roster');
+  if (rosterScaleHost && 'MutationObserver' in window) {
+    new MutationObserver(updateRosterStickyTop).observe(rosterScaleHost, {
+      attributes: true,
+      attributeFilter: ['data-scale'],
+    });
   }
   const rosterRoot = document.getElementById('roster');
   const rosterScrollKey = `atcroster:scroll:${window.location.pathname}`;

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -3237,6 +3237,8 @@ def test_roster_keeps_day_header_below_sticky_site_header(client):
     assert response.status_code == 200
     assert b"--roster-sticky-top" in response.data
     assert b"ResizeObserver(updateRosterStickyTop)" in response.data
+    assert b"Math.ceil(height / scale)" in response.data
+    assert b"MutationObserver(updateRosterStickyTop)" in response.data
     assert response.data.count(b'class="sticky left col-name"') == 1
     assert b'class="sticky left col-date"' not in response.data
     assert b'class="sticky col-date">Medical' in response.data
@@ -3245,4 +3247,6 @@ def test_roster_keeps_day_header_below_sticky_site_header(client):
     ) as stylesheet_file:
         stylesheet = stylesheet_file.read()
     assert ".roster th.dayhead" in stylesheet
+    assert "table.roster thead{" in stylesheet
     assert "top:var(--roster-sticky-top, 0px)" in stylesheet
+    assert "table.roster thead th.sticky" in stylesheet


### PR DESCRIPTION
## What changed

- makes the roster `thead` sticky as one reliable row
- compensates the sticky offset for the active CSS zoom/fit-width scale
- recalculates whenever the roster zoom changes
- preserves the sticky Name column and normal print layout

## Root cause

The navigation height was applied inside a CSS-zoomed table. At Fit width or reduced zoom, the offset was scaled down and the day/date row remained underneath the site navigation.

## Validation

- focused rendered-route regression test passed
- Ruff and diff checks passed