### PR TITLE
Restore roster header row position

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -859,15 +859,13 @@ table.roster tbody tr:hover{background:rgba(84,118,192,.12);}
 .roster td{border:1px solid var(--line); text-align:center; padding:.25rem .35rem;}
 
 th.sticky{position:sticky; top:0; background:var(--head); color:#fff; z-index:2;}
-table.roster thead{
-  position:sticky;
+table.roster th.sticky,
+.roster th.dayhead{
   top:var(--roster-sticky-top, 0px);
-  z-index:20;
-  box-shadow:0 4px 8px rgba(0,0,0,.24);
 }
-table.roster thead th.sticky{
-  position:relative;
-  top:auto;
+.roster th.dayhead{
+  z-index:5;
+  box-shadow:0 4px 8px rgba(0,0,0,.24);
 }
 th.sticky.left{left:0; z-index:3; background:var(--head);}
 
@@ -878,9 +876,7 @@ th.sticky.left{left:0; z-index:3; background:var(--head);}
 }
 
 .roster th.col-name{
-  position:sticky;
-  left:0;
-  z-index:21;
+  z-index:6;
 }
 
 .roster td.col-name{
@@ -2133,7 +2129,6 @@ table.roster { zoom:var(--ui-scale); }
     transform:none !important;
   }
   thead{ display:table-header-group; }
-  .roster thead{ position:static !important; box-shadow:none !important; }
   tfoot{ display:table-footer-group; }
   th.sticky,
   .roster th.dayhead,

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -59,7 +59,7 @@
   :root { --today-col: rgba(255,255,0,.85); }
 
   /* Ensure cells can host absolutely-positioned overlays */
-  .roster th.dayhead { position: relative; }
+  .roster th.dayhead { position: sticky; }
   .roster td.cell { position: relative; }
   .roster td.totcell { position: relative; }
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -3247,6 +3247,5 @@ def test_roster_keeps_day_header_below_sticky_site_header(client):
     ) as stylesheet_file:
         stylesheet = stylesheet_file.read()
     assert ".roster th.dayhead" in stylesheet
-    assert "table.roster thead{" in stylesheet
     assert "top:var(--roster-sticky-top, 0px)" in stylesheet
-    assert "table.roster thead th.sticky" in stylesheet
+    assert "table.roster th.sticky" in stylesheet


### PR DESCRIPTION
## What changed

- restores sticky positioning to the individual roster header cells
- removes sticky positioning from the whole `thead`, which CSS zoom laid below the first staff row
- retains the zoom-corrected navigation offset and left-pinned Name column

## Validation

- focused roster header regression test passed
- Ruff and diff checks passed