### PR TITLE
Hide empty annotation labels

### DIFF
--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -289,7 +289,7 @@
                       data-staff-name="{{ s.name }}"
                       data-day-label="{{ d.strftime('%d %B %Y') }}"
                       title="Annotate"
-                      aria-label="{{ s.name }} annotation on {{ d.strftime('%d %B %Y') }}">Annotate</button>
+                      aria-label="{{ s.name }} annotation on {{ d.strftime('%d %B %Y') }}"><span aria-hidden="true">&nbsp;</span></button>
               {% else %}
               <span class="annot-select" aria-hidden="true">—</span>
               {% endif %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -623,6 +623,8 @@ def test_roster_has_persistent_zoom_presets(client):
     assert response.data.count(b'name="code" data-roster-shift-select') == 1
     assert response.data.count(b"data-roster-shift-open") > 1
     assert response.data.count(b'class="annot-select" data-annotation-select') == 1
+    assert b">Annotate</button>" not in response.data
+    assert b'<span aria-hidden="true">&nbsp;</span></button>' in response.data
     assert b"data-roster-auto-submit" not in response.data
     assert b"Saving\xe2\x80\xa6" in response.data
     assert b"atcroster:scroll:" in response.data


### PR DESCRIPTION
## What changed
- removed the visible **Annotate** text from empty roster annotation controls
- retained the blank clickable annotation space, tooltip, and accessible label
- added a regression assertion to prevent the visible label returning

## Why
Repeating the label beneath every roster cell adds visual noise. The annotation area should remain available without displaying text in every cell.

## Validation
- `python -m pytest -q tests` — 328 passed, 11 skipped
- `git diff --check`