### PR TITLE
Fix roster sticky scroll context

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -984,7 +984,15 @@ th.sticky.left{left:0; z-index:3; background:var(--head);}
   border-color:var(--accent);
   background:var(--accent-soft);
 }
-#roster{overflow-x:auto; overflow-y:hidden;}
+/*
+ * Keep the roster in the document's scroll context. An overflow ancestor becomes
+ * the containing block for position:sticky, even when it only appears to scroll
+ * horizontally. That caused the sticky header offset to be measured from this
+ * frame (pushing it below the first staff row) and prevented it sticking during
+ * window scrolling. The page itself provides horizontal scrolling for the wide
+ * roster, allowing both the date header and name column to pin to the viewport.
+ */
+#roster{overflow:visible;}
 
 .roster .cell select.code-input{
   display:block;

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -3255,3 +3255,5 @@ def test_roster_keeps_day_header_below_sticky_site_header(client):
     assert ".roster th.dayhead" in stylesheet
     assert "top:var(--roster-sticky-top, 0px)" in stylesheet
     assert "table.roster th.sticky" in stylesheet
+    assert "#roster{overflow:visible;}" in stylesheet
+    assert "#roster{overflow-x:auto" not in stylesheet


### PR DESCRIPTION
## What changed
- keep the roster table in the document scroll context
- retain viewport-relative sticky day/date headers and names
- add regression assertions preventing the conflicting overflow wrapper from returning

## Root cause
The `#roster` wrapper used horizontal overflow, making it the containing block for `position: sticky`. The site-header offset was therefore applied from the roster frame itself, pushing date cells below the first staff row, while window scrolling could not activate sticky positioning.

## Validation
- inspected computed layout and bounding boxes on the authenticated production roster
- `python -m pytest -q tests/test_routes.py -k sticky_site_header`
- `python -m ruff check tests/test_routes.py`
- `git diff --check`