### PR TITLE
Complete opaque roster header mask

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -862,9 +862,19 @@ th.sticky{position:sticky; top:0; background:var(--head); color:#fff; z-index:2;
 table.roster th.sticky,
 .roster th.dayhead{
   top:var(--roster-sticky-top, 0px);
-  /* Mask roster rows that have scrolled above the pinned header. */
-  box-shadow:0 -100vh 0 var(--head), 0 4px 8px rgba(0,0,0,.24);
+  box-shadow:0 4px 8px rgba(0,0,0,.24);
   z-index:10;
+}
+table.roster th.sticky::after,
+.roster th.dayhead::after{
+  content:"";
+  position:absolute;
+  right:-1px;
+  bottom:100%;
+  left:-1px;
+  height:100vh;
+  background:var(--head);
+  pointer-events:none;
 }
 .roster th.dayhead{
   background:var(--head2);

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -3255,7 +3255,8 @@ def test_roster_keeps_day_header_below_sticky_site_header(client):
     assert ".roster th.dayhead" in stylesheet
     assert "top:var(--roster-sticky-top, 0px)" in stylesheet
     assert "table.roster th.sticky" in stylesheet
-    assert "box-shadow:0 -100vh 0 var(--head)" in stylesheet
+    assert "table.roster th.sticky::after" in stylesheet
+    assert "height:100vh;" in stylesheet
     assert ".roster th.col-name{\n  z-index:12;" in stylesheet
     assert "#roster{overflow:visible;}" in stylesheet
     assert "#roster{overflow-x:auto" not in stylesheet


### PR DESCRIPTION
## What changed
- replace the incomplete displaced-shadow mask with a dedicated opaque panel above every sticky roster heading
- keep the panel bounded above the heading so it cannot cover roster rows below
- update the sticky-header regression assertion

## Why
Live production browser verification of PR #207 found a thin strip of roster text still visible immediately above the sticky header. A regular box shadow has only the dimensions of its source cell and did not fill the entire area.

## Validation
- `python -m pytest -q tests/test_routes.py -k sticky_site_header`
- `python -m ruff check tests/test_routes.py`
- `git diff --check`