### PR TITLE
Make sticky roster headings fully opaque

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -865,6 +865,11 @@ table.roster th.sticky,
   box-shadow:0 4px 8px rgba(0,0,0,.24);
   z-index:10;
 }
+table.roster th.sticky{
+  /* The general table heading uses a translucent gradient. Sticky headings
+     must be fully opaque so scrolled roster values cannot show through. */
+  background:var(--head);
+}
 table.roster th.sticky::after,
 .roster th.dayhead::after{
   content:"";

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -3257,6 +3257,7 @@ def test_roster_keeps_day_header_below_sticky_site_header(client):
     assert "table.roster th.sticky" in stylesheet
     assert "table.roster th.sticky::after" in stylesheet
     assert "height:100vh;" in stylesheet
+    assert "table.roster th.sticky{" in stylesheet
     assert ".roster th.col-name{\n  z-index:12;" in stylesheet
     assert "#roster{overflow:visible;}" in stylesheet
     assert "#roster{overflow-x:auto" not in stylesheet


### PR DESCRIPTION
Ensures the qualification and metadata sticky headings use a solid background so scrolled roster values cannot show through. Includes focused route coverage.