### PR TITLE
Keep today roster heading opaque

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -2097,7 +2097,7 @@ table.roster { zoom:var(--ui-scale); }
    ============================== */
 .roster th.dayhead.is-today {
   outline: 2px solid rgba(0,0,0,.15);
-  background: rgba(255,255,0,.10) !important;
+  background: #363d2e !important;
 }
 
 .roster td.cell.is-today {

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -64,7 +64,8 @@
   .roster td.totcell { position: relative; }
 
   /* Subtle background tint for today */
-  .roster th.dayhead.is-today { background: rgba(255,255,0,.10) !important; }
+  /* Keep the highlighted sticky heading opaque so roster values never bleed through. */
+  .roster th.dayhead.is-today { background: #363d2e !important; }
   .roster td.cell.is-today { background: rgba(255,255,0,.07) !important; }
 
   /* Draw the column outline ABOVE controls using ::before overlays */

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -3258,6 +3258,8 @@ def test_roster_keeps_day_header_below_sticky_site_header(client):
     assert "table.roster th.sticky::after" in stylesheet
     assert "height:100vh;" in stylesheet
     assert "table.roster th.sticky{" in stylesheet
+    assert ".roster th.dayhead.is-today" in stylesheet
+    assert "background: #363d2e !important;" in stylesheet
     assert ".roster th.col-name{\n  z-index:12;" in stylesheet
     assert "#roster{overflow:visible;}" in stylesheet
     assert "#roster{overflow-x:auto" not in stylesheet


### PR DESCRIPTION
Makes the highlighted Today sticky heading fully opaque so scrolled roster values cannot show through, while retaining its distinct highlight. Adds regression coverage.