### PR TITLE
Restore roster toolbar and correct Today layering

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -870,17 +870,6 @@ table.roster th.sticky{
      must be fully opaque so scrolled roster values cannot show through. */
   background:var(--head);
 }
-table.roster th.sticky::after,
-.roster th.dayhead::after{
-  content:"";
-  position:absolute;
-  right:-1px;
-  bottom:100%;
-  left:-1px;
-  height:100vh;
-  background:var(--head);
-  pointer-events:none;
-}
 .roster th.dayhead{
   background:var(--head2);
 }
@@ -898,7 +887,7 @@ th.sticky.left{left:0; background:var(--head);}
 
 .roster td.col-name{
   /* Stay above ordinary cells while remaining below every sticky heading. */
-  z-index:4;
+  z-index:8;
   background:var(--card);
   box-shadow:4px 0 8px rgba(0,0,0,.18);
 }

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -58,6 +58,10 @@
 <style nonce="{{ csp_nonce() }}">
   :root { --today-col: rgba(255,255,0,.85); }
 
+  /* Seal the sub-pixel seam beneath the site header without covering the
+     roster navigation, print or zoom controls before they scroll away. */
+  .site-header { box-shadow: 0 2px 0 var(--head); }
+
   /* Ensure cells can host absolutely-positioned overlays */
   .roster th.dayhead { position: sticky; }
   .roster td.cell { position: relative; }
@@ -66,7 +70,10 @@
   /* Subtle background tint for today */
   /* Keep the highlighted sticky heading opaque so roster values never bleed through. */
   .roster th.dayhead.is-today { background: #363d2e !important; }
-  .roster td.cell.is-today { background: rgba(255,255,0,.07) !important; }
+  .roster td.cell.is-today {
+    z-index: 1;
+    background: rgba(255,255,0,.07) !important;
+  }
 
   /* Draw the column outline ABOVE controls using ::before overlays */
   .roster th.dayhead.is-today::before{

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -3255,8 +3255,6 @@ def test_roster_keeps_day_header_below_sticky_site_header(client):
     assert ".roster th.dayhead" in stylesheet
     assert "top:var(--roster-sticky-top, 0px)" in stylesheet
     assert "table.roster th.sticky" in stylesheet
-    assert "table.roster th.sticky::after" in stylesheet
-    assert "height:100vh;" in stylesheet
     assert "table.roster th.sticky{" in stylesheet
     assert ".roster th.dayhead.is-today" in stylesheet
     assert "background: #363d2e !important;" in stylesheet


### PR DESCRIPTION
Restores the roster navigation, Print and zoom controls by replacing the oversized sticky-header mask with a narrow page-header seam. Keeps Today highlighting beneath the sticky ATCO name column. Focused roster tests pass.