### PR TITLE
Keep roster name heading above date columns

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -881,7 +881,7 @@ th.sticky.left{left:0; background:var(--head);}
   left:0;
 }
 
-.roster th.col-name{
+table.roster th.col-name{
   z-index:12;
 }
 


### PR DESCRIPTION
Raises the sticky Name heading above sticky date headings during horizontal scrolling, completing the Today/name layering correction. Focused roster tests pass.