### PR TITLE
Hide position monitor accounts from rosters

### DIFF
--- a/app.py
+++ b/app.py
@@ -1991,10 +1991,15 @@ def _load_month_roster_core(unit_id: int, y: int, m: int):
         try:
             staff = (Staff.query
                      .outerjoin(Watch, Staff.watch_id == Watch.id)
+                     .filter(Staff.role != "position_monitor")
                      .order_by(Watch.order_index, Staff.name)
                      .all())
         except Exception:
-            staff = Staff.query.order_by(Staff.id).all()
+            staff = (
+                Staff.query.filter(Staff.role != "position_monitor")
+                .order_by(Staff.id)
+                .all()
+            )
 
         # Assignments for the month (narrow columns)
         rows = (db.session.query(
@@ -2455,7 +2460,7 @@ def requirements_for_day(
 def generate_month(year: int, month: int, *args, **kwargs):
     """Ensure rows exist/are correct for the month without touching manual edits."""
     _, days = month_range(year, month)
-    for s in Staff.query.order_by(Staff.id):
+    for s in Staff.query.filter(Staff.role != "position_monitor").order_by(Staff.id):
         for d in days:
             refresh_day_from_pattern_and_leave(s, d)
     db.session.commit()

--- a/roster_blueprint.py
+++ b/roster_blueprint.py
@@ -273,6 +273,7 @@ def create_roster_blueprint(dependencies: RosterDependencies) -> Blueprint:
                 dependencies.Watch,
                 dependencies.Staff.watch_id == dependencies.Watch.id,
             )
+            .filter(dependencies.Staff.role != "position_monitor")
             .order_by(dependencies.Watch.order_index, dependencies.Staff.name)
             .all()
         )

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1459,6 +1459,35 @@ def test_roster_routes_render(client):
     assert export_resp.mimetype == "text/csv"
 
 
+def test_position_monitor_account_is_hidden_from_roster_and_export(client):
+    with app.app.app_context():
+        kiosk = Staff(
+            unit_id=1,
+            username="roster_hidden_kiosk",
+            name="Hidden Position Monitor",
+            staff_no="KIOSK-HIDDEN",
+            role="position_monitor",
+            is_operational=True,
+        )
+        kiosk.set_password("not-used")
+        db.session.add(kiosk)
+        db.session.commit()
+
+    login(client)
+    roster = client.get("/roster/2027-01")
+    export = client.get("/roster/2027-01/export")
+
+    assert roster.status_code == 200
+    assert export.status_code == 200
+    assert b"Hidden Position Monitor" not in roster.data
+    assert b"KIOSK-HIDDEN" not in roster.data
+    assert "Hidden Position Monitor" not in export.data.decode()
+    assert "KIOSK-HIDDEN" not in export.data.decode()
+    with app.app.app_context():
+        Staff.query.filter_by(username="roster_hidden_kiosk").delete()
+        db.session.commit()
+
+
 def test_csv_exports_neutralise_spreadsheet_formula_payloads(client):
     login(client)
     acknowledge_reports(client)


### PR DESCRIPTION
Excludes dedicated position_monitor identities from monthly roster display, CSV export and month generation without changing kiosk authentication or Live Position Monitoring. Adds a regression test covering an operationally flagged kiosk account.