### PR TITLE
Remove roster validation summary box

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1269,12 +1269,6 @@ tfoot td{background:var(--card); font-weight:bold; color:var(--text);}
 .roster-validation-tooltip{display:none;position:absolute;z-index:30;right:0;bottom:18px;width:260px;padding:9px;border:1px solid var(--border);border-radius:8px;background:var(--card);color:var(--text);box-shadow:0 8px 24px rgba(0,0,0,.35);text-align:left;white-space:normal;}
 .roster-validation-tooltip span{display:block;margin-top:5px;font-weight:400;}
 .roster-validation-hazard:hover .roster-validation-tooltip,.roster-validation-hazard:focus .roster-validation-tooltip{display:block;}
-.roster-validation-summary{margin:1rem 0;padding:1rem;border:1px solid var(--border);border-left:5px solid #2e7d32;border-radius:10px;background:var(--card);}
-.roster-validation-summary--blocking{border-left-color:#dc3545;}
-.roster-validation-summary h3{margin:.15rem 0;}
-.roster-validation-summary p{margin:.25rem 0 0;}
-.roster-validation-summary details{margin-top:.75rem;}
-.roster-validation-summary ul{margin:.75rem 0 0;padding-left:1.2rem;}
 .validation-finding{margin:.35rem 0;}.validation-finding span{display:block;color:var(--muted);}.validation-finding--blocking strong{color:#ff8b94;}
 .rag-count--over{
   animation:roster-count-over-pulse 1.6s ease-in-out infinite;

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -386,19 +386,6 @@
   </section>
 {% endif %}
 
-<section class="roster-validation-summary {{ 'roster-validation-summary--blocking' if roster_validation.blocking_count else 'roster-validation-summary--clear' }}" aria-labelledby="roster-validation-title">
-  <div>
-    <span class="eyebrow">Pre-publication validation</span>
-    <h3 id="roster-validation-title">{{ roster_validation.blocking_count }} blocking · {{ roster_validation.advisory_count }} advisory</h3>
-    <p>{% if roster_validation.blocking_count %}Resolve every pattern or hard-rule breach before publishing.{% else %}No pattern or hard-rule breaches prevent publication.{% endif %} Soft preferences remain informational.</p>
-  </div>
-  {% if roster_validation.findings %}
-  <details><summary>Review validation findings</summary><ul>
-    {% for finding in roster_validation.findings %}<li class="validation-finding validation-finding--{{ finding.severity }}"><strong>{{ finding.staff_name }} · {{ finding.day.strftime('%d %b') }} · {{ finding.shift_code }}</strong><span>{{ finding.explanation }}</span></li>{% endfor %}
-  </ul></details>
-  {% endif %}
-</section>
-
 {% if roster_publication %}
   <div class="roster-state-note roster-state-note--published" role="status">
     <i class="fa-solid fa-circle-check" aria-hidden="true"></i>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -3239,7 +3239,7 @@ def test_roster_shows_pattern_breach_and_blocks_publication(client):
 
     roster = client.get("/roster/2025-09")
     assert roster.status_code == 200
-    assert b"Pre-publication validation" in roster.data
+    assert b"Pre-publication validation" not in roster.data
     assert b"Publication blocker" in roster.data
     assert b"protected non-working day" in roster.data
     assert b"Resolve blocking validation findings first" in roster.data


### PR DESCRIPTION
Removes the visible pre-publication validation panel from the monthly roster footer and its unused styles. Server-side validation, cell warnings and publication blocking remain active.