### PR TITLE
Require an operational rating UE for roster counts

### DIFF
--- a/app.py
+++ b/app.py
@@ -1606,7 +1606,7 @@ def get_non_working_codes() -> set[str]:
 
 
 def staff_is_countable_on(person: Staff, on_date: date) -> bool:
-    """Return whether a person holds the credentials needed for staffing counts."""
+    """Require a current medical and at least one current operational rating UE."""
     if not person.medical_expiry or person.medical_expiry < on_date:
         return False
     return any(
@@ -1614,7 +1614,6 @@ def staff_is_countable_on(person: Staff, on_date: date) -> bool:
         for expiry in (
             person.tower_ue_expiry,
             person.radar_ue_expiry,
-            person.met_ue_expiry,
         )
     )
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2183,6 +2183,9 @@ def test_roster_counter_requires_current_medical_and_unit_endorsement():
     assert not app.staff_is_countable_on(person, roster_day)
 
     person.met_ue_expiry = roster_day
+    assert not app.staff_is_countable_on(person, roster_day)
+
+    person.radar_ue_expiry = roster_day
     assert app.staff_is_countable_on(person, roster_day)
 
 


### PR DESCRIPTION
Requires an in-date medical plus an in-date Tower or Radar UE before a controller contributes to roster staffing totals. MET UE alone no longer qualifies. The shared rule covers the roster view, asynchronous day totals, exports and publication preflight.