### PR TITLE
Filter existing leave by watch

### DIFF
--- a/absence_requests_blueprint.py
+++ b/absence_requests_blueprint.py
@@ -25,6 +25,7 @@ from flask_login import current_user, login_required
 class AbsenceRequestDependencies:
     db: Any
     Staff: Any
+    Watch: Any
     Leave: Any
     Assignment: Any
     is_admin_user: Callable
@@ -80,6 +81,24 @@ def create_absence_requests_blueprint(
         end_of_month = days[-1]
         month_title = datetime(year, month, 1).strftime("%B %Y")
         prev_ym, next_ym = dependencies.clamp_prev_next(year, month)
+
+        watch_value = (request.args.get("watch_id") or "").strip()
+        selected_watch_id = None
+        if watch_value:
+            try:
+                selected_watch_id = int(watch_value)
+            except ValueError:
+                abort(400, "Invalid watch filter.")
+            selected_watch = dependencies.Watch.query.filter_by(
+                id=selected_watch_id,
+                unit_id=dependencies.current_unit_id(),
+            ).first()
+            if not selected_watch:
+                abort(400, "Invalid watch filter.")
+        watches = dependencies.Watch.query.order_by(
+            dependencies.Watch.order_index,
+            dependencies.Watch.name,
+        ).all()
 
         if request.method == "POST":
             dependencies.validate_csrf()
@@ -396,14 +415,20 @@ def create_absence_requests_blueprint(
                 return redirect(url_for("leave", ym=ym_param))
 
         # ---------- GET: month-filtered data ----------
-        leaves = (
-            dependencies.Leave.query.filter(
+        leaves_query = (
+            dependencies.Leave.query.join(
+                dependencies.Staff,
+                dependencies.Leave.staff_id == dependencies.Staff.id,
+            ).filter(
                 dependencies.Leave.end >= start_of_month,
                 dependencies.Leave.start <= end_of_month,
             )
-            .order_by(dependencies.Leave.start.asc())
-            .all()
         )
+        if selected_watch_id is not None:
+            leaves_query = leaves_query.filter(
+                dependencies.Staff.watch_id == selected_watch_id
+            )
+        leaves = leaves_query.order_by(dependencies.Leave.start.asc()).all()
         all_sickness_codes = [
             item["code"]
             for item in dependencies.get_absence_types("sickness", active_only=False)
@@ -434,6 +459,8 @@ def create_absence_requests_blueprint(
             month_title=month_title,
             prev_ym=prev_ym,
             next_ym=next_ym,
+            watches=watches,
+            selected_watch_id=selected_watch_id,
         )
 
     @login_required

--- a/app.py
+++ b/app.py
@@ -9043,6 +9043,7 @@ app.register_blueprint(create_absence_requests_blueprint(
     AbsenceRequestDependencies(
         db=db,
         Staff=Staff,
+        Watch=Watch,
         Leave=Leave,
         Assignment=Assignment,
         is_admin_user=is_admin_user,

--- a/templates/leave.html
+++ b/templates/leave.html
@@ -133,11 +133,11 @@
   <!-- Month navigation -->
   <div class="month-nav leave-month-nav">
     {% if prev_ym %}
-      <a class="btn ghost" href="{{ url_for('leave', ym=prev_ym) }}">&larr; {{ prev_ym }}</a>
+      <a class="btn ghost" href="{{ url_for('leave', ym=prev_ym, watch_id=selected_watch_id) }}">&larr; {{ prev_ym }}</a>
     {% else %}
       <span class="btn ghost disabled-nav-control">&larr; —</span>
     {% endif %}
-    <a class="btn ghost" href="{{ url_for('leave', ym=next_ym) }}">{{ next_ym }} &rarr;</a>
+    <a class="btn ghost" href="{{ url_for('leave', ym=next_ym, watch_id=selected_watch_id) }}">{{ next_ym }} &rarr;</a>
   </div>
 
   <!-- Sickness instances overlapping the selected month -->
@@ -197,7 +197,21 @@
 
   <!-- Existing Leave (month) -->
   <div class="card">
-    <div class="card-header"><strong>Existing Leave — {{ month_title }}</strong></div>
+    <div class="card-header d-flex flex-wrap justify-content-between align-items-end gap-3">
+      <strong>Existing Leave — {{ month_title }}</strong>
+      <form method="get" class="d-flex flex-wrap align-items-end gap-2" aria-label="Filter existing leave by watch">
+        <input type="hidden" name="ym" value="{{ ym }}">
+        <label class="form-label mb-0" for="leave-watch-filter">Watch
+          <select id="leave-watch-filter" class="form-select form-select-sm" name="watch_id">
+            <option value="">Whole unit</option>
+            {% for watch in watches %}
+            <option value="{{ watch.id }}" {% if selected_watch_id == watch.id %}selected{% endif %}>{{ watch.name }}</option>
+            {% endfor %}
+          </select>
+        </label>
+        <button class="btn btn-sm" type="submit">Apply filter</button>
+      </form>
+    </div>
     <div class="card-body table-responsive">
       <table class="table table-sm align-middle">
         <thead>
@@ -211,7 +225,7 @@
         </thead>
         <tbody>
           {% for lv in leaves %}
-          <tr>
+          <tr data-leave-id="{{ lv.id }}">
             <td>{{ lv.staff.name }}</td>
             <td>{{ lv.leave_type }}</td>
             <td>{{ lv.start }}</td>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2695,6 +2695,56 @@ def test_business_change_and_audit_evidence_roll_back_atomically(client):
         assert Assignment.query.filter_by(staff_id=person.id, day=day).first() is None
 
 
+def test_existing_leave_can_filter_by_watch_or_whole_unit(client):
+    login(client)
+    with app.app.app_context():
+        watch_a = Watch.query.filter_by(unit_id=1, name="Watch A").one()
+        watch_b = Watch.query.filter_by(unit_id=1, name="Watch B").one()
+        person_a = Staff.query.filter_by(username=ADMIN_CREDENTIALS["username"]).one()
+        person_b = Staff.query.filter_by(username="staff_test").one()
+        original_watch_ids = (person_a.watch_id, person_b.watch_id)
+        person_a.watch_id = watch_a.id
+        person_b.watch_id = watch_b.id
+        leave_a = Leave(
+            unit_id=1,
+            staff_id=person_a.id,
+            leave_type="AL",
+            start=date(2029, 7, 2),
+            end=date(2029, 7, 3),
+        )
+        leave_b = Leave(
+            unit_id=1,
+            staff_id=person_b.id,
+            leave_type="AL",
+            start=date(2029, 7, 4),
+            end=date(2029, 7, 5),
+        )
+        db.session.add_all([leave_a, leave_b])
+        db.session.commit()
+        leave_a_id, leave_b_id = leave_a.id, leave_b.id
+        watch_a_id, watch_b_id = watch_a.id, watch_b.id
+
+    whole_unit = client.get("/leave?ym=2029-07")
+    watch_a_page = client.get(f"/leave?ym=2029-07&watch_id={watch_a_id}")
+    watch_b_page = client.get(f"/leave?ym=2029-07&watch_id={watch_b_id}")
+
+    assert whole_unit.status_code == 200
+    assert b">Whole unit</option>" in whole_unit.data
+    assert f'data-leave-id="{leave_a_id}"'.encode() in whole_unit.data
+    assert f'data-leave-id="{leave_b_id}"'.encode() in whole_unit.data
+    assert f'data-leave-id="{leave_a_id}"'.encode() in watch_a_page.data
+    assert f'data-leave-id="{leave_b_id}"'.encode() not in watch_a_page.data
+    assert f'data-leave-id="{leave_b_id}"'.encode() in watch_b_page.data
+    assert f'data-leave-id="{leave_a_id}"'.encode() not in watch_b_page.data
+
+    with app.app.app_context():
+        Leave.query.filter(Leave.id.in_([leave_a_id, leave_b_id])).delete()
+        person_a = Staff.query.filter_by(username=ADMIN_CREDENTIALS["username"]).one()
+        person_b = Staff.query.filter_by(username="staff_test").one()
+        person_a.watch_id, person_b.watch_id = original_watch_ids
+        db.session.commit()
+
+
 def test_airport_absence_catalogue_and_calendar_token(client):
     with app.app.app_context():
         app.MfaCredential.query.delete()


### PR DESCRIPTION
Adds a tenant-scoped Watch filter to the Existing Leave panel with Whole unit as the default. The selection persists through month navigation, invalid watch IDs are rejected, and route coverage verifies Watch A, Watch B and whole-unit results.