### PR TITLE
Improve leave year report readability

### DIFF
--- a/reports_blueprint.py
+++ b/reports_blueprint.py
@@ -245,6 +245,14 @@ def create_reports_blueprint(dependencies: ReportsDependencies) -> Blueprint:
         if acknowledgement := require_acknowledgement():
             return acknowledgement
         today = date.today()
+        raw_end_date = (request.args.get("end_date") or "").strip()
+        if raw_end_date:
+            try:
+                report_end = date.fromisoformat(raw_end_date)
+            except ValueError:
+                abort(400, "Invalid report end date.")
+        else:
+            report_end = today
         unit_id = dependencies.current_unit_id()
         watches, selected_watch = watch_selection()
         people_query = dependencies.Staff.query.filter(
@@ -262,17 +270,21 @@ def create_reports_blueprint(dependencies: ReportsDependencies) -> Blueprint:
         ).all()
         rows = []
         for person in people:
-            start, end = dependencies.current_leave_year_window(person, today)
+            start, leave_year_end = dependencies.current_leave_year_window(
+                person, report_end
+            )
             assignments = dependencies.Assignment.query.filter(
                 dependencies.Assignment.staff_id == person.id,
                 dependencies.Assignment.day >= start,
-                dependencies.Assignment.day <= end,
+                dependencies.Assignment.day <= report_end,
             ).all()
             al_taken = sum(1 for assignment in assignments if assignment.code == "AL")
             entitlement = person.leave_entitlement_days or 0
             public_holidays = person.leave_public_holidays or 0
             carryover = person.leave_carryover_days or 0
-            accrued, used = dependencies.toil_accrued_used(person.id, start, end)
+            accrued, used = dependencies.toil_accrued_used(
+                person.id, start, report_end
+            )
             rows.append(
                 {
                     "staff": person,
@@ -280,7 +292,7 @@ def create_reports_blueprint(dependencies: ReportsDependencies) -> Blueprint:
                     if person.watch
                     else "-",
                     "leave_year_start": start,
-                    "leave_year_end": end,
+                    "leave_year_end": leave_year_end,
                     "entitlement": entitlement,
                     "public_holidays": public_holidays,
                     "carryover": carryover,
@@ -295,6 +307,7 @@ def create_reports_blueprint(dependencies: ReportsDependencies) -> Blueprint:
             "report_leave_year.html",
             rows=rows,
             today=today,
+            report_end=report_end,
             watches=watches,
             selected_watch=selected_watch,
         )

--- a/static/styles.css
+++ b/static/styles.css
@@ -3532,9 +3532,23 @@ table:not(.roster) td {
   letter-spacing:.04em;
   text-transform:uppercase;
 }
-.report-filter select{
+.report-filter select,
+.report-filter input{
   width:min(280px, 100%);
 }
+
+.leave-year-col{border-left-color:rgba(255,255,255,.12) !important;}
+.leave-year-col--entitlement{background:rgba(48,113,184,.20) !important;}
+.leave-year-col--public-holidays{background:rgba(32,135,128,.20) !important;}
+.leave-year-col--carryover{background:rgba(113,82,168,.20) !important;}
+.leave-year-col--taken{background:rgba(190,112,35,.22) !important;}
+.leave-year-col--remaining{background:rgba(46,125,50,.24) !important;}
+.leave-year-col--toil-accrued{background:rgba(20,126,145,.20) !important;}
+.leave-year-col--toil-used{background:rgba(176,127,18,.20) !important;}
+.leave-year-col--toil-balance{background:rgba(46,125,50,.24) !important;}
+.leave-year-col.balance-positive{color:#8be09a !important;}
+.leave-year-col.balance-zero{color:#ffd166 !important;background:rgba(176,127,18,.24) !important;}
+.leave-year-col.balance-negative{color:#ff9aa2 !important;background:rgba(176,42,55,.28) !important;}
 
 .sensitive-data-gate{
   display:grid;

--- a/templates/report_leave_year.html
+++ b/templates/report_leave_year.html
@@ -3,7 +3,7 @@
 {% block content %}
 {% include "_report_actions.html" %}
 <section class="compliance-hero">
-  <div><span class="admin-step">Leave reporting</span><h2>Leave year</h2><p>Entitlement and balances as of {{ today }}.</p></div>
+  <div><span class="admin-step">Leave reporting</span><h2>Leave year</h2><p>Entitlement and balances as of {{ report_end }}.</p></div>
   <div class="compliance-actions"><a class="btn" href="{{ url_for('reports_index') }}">&larr; Reports</a></div>
 </section>
 
@@ -15,6 +15,8 @@
       <option value="{{ watch.id }}" {% if selected_watch and selected_watch.id == watch.id %}selected{% endif %}>{{ watch.name }}</option>
     {% endfor %}
   </select>
+  <label for="leave-year-end">Report to</label>
+  <input id="leave-year-end" type="date" name="end_date" value="{{ report_end.isoformat() }}">
   <button class="btn btn-primary" type="submit">Apply filter</button>
 </form>
 
@@ -23,26 +25,31 @@
     <thead>
       <tr>
         <th>ATCO</th><th>Watch</th><th>Year Window</th>
-        <th>Entitlement</th><th>Public Hols</th><th>Carryover</th>
-        <th>AL taken</th><th></th><th>Remaining</th>
-        <th>TOIL accrued</th><th>TOIL used</th><th>TOIL balance</th>
+        <th class="leave-year-col leave-year-col--entitlement">Entitlement</th>
+        <th class="leave-year-col leave-year-col--public-holidays">Public Hols</th>
+        <th class="leave-year-col leave-year-col--carryover">Carryover</th>
+        <th class="leave-year-col leave-year-col--taken">AL taken</th><th></th>
+        <th class="leave-year-col leave-year-col--remaining">Remaining</th>
+        <th class="leave-year-col leave-year-col--toil-accrued">TOIL accrued</th>
+        <th class="leave-year-col leave-year-col--toil-used">TOIL used</th>
+        <th class="leave-year-col leave-year-col--toil-balance">TOIL balance</th>
       </tr>
     </thead>
     <tbody>
       {% for r in rows %}
-        <tr>
+        <tr data-staff-id="{{ r.staff.id }}" data-al-taken="{{ r.al_taken }}" data-leave-remaining="{{ r.remaining }}">
           <td>{{ r.staff.name }}</td>
           <td>{{ r.watch }}</td>
           <td>{{ r.leave_year_start }} → {{ r.leave_year_end }}</td>
-          <td class="ta-right">{{ r.entitlement }}</td>
-          <td class="ta-right">{{ r.public_holidays }}</td>
-          <td class="ta-right">{{ r.carryover }}</td>
-          <td class="ta-right">{{ r.al_taken }}</td>
+          <td class="ta-right leave-year-col leave-year-col--entitlement">{{ r.entitlement }}</td>
+          <td class="ta-right leave-year-col leave-year-col--public-holidays">{{ r.public_holidays }}</td>
+          <td class="ta-right leave-year-col leave-year-col--carryover">{{ r.carryover }}</td>
+          <td class="ta-right leave-year-col leave-year-col--taken">{{ r.al_taken }}</td>
           <td></td>
-          <td class="ta-right"><strong>{{ r.remaining }}</strong></td>
-          <td class="ta-right">{{ '%.1f' % r.toil_accrued_days }}</td>
-          <td class="ta-right">{{ '%.1f' % r.toil_used_days }}</td>
-          <td class="ta-right"><strong>{{ '%.1f' % r.toil_balance_days }}</strong></td>
+          <td class="ta-right leave-year-col leave-year-col--remaining balance-{{ 'negative' if r.remaining < 0 else ('zero' if r.remaining == 0 else 'positive') }}"><strong>{{ r.remaining }}</strong></td>
+          <td class="ta-right leave-year-col leave-year-col--toil-accrued">{{ '%.1f' % r.toil_accrued_days }}</td>
+          <td class="ta-right leave-year-col leave-year-col--toil-used">{{ '%.1f' % r.toil_used_days }}</td>
+          <td class="ta-right leave-year-col leave-year-col--toil-balance balance-{{ 'negative' if r.toil_balance_days < 0 else ('zero' if r.toil_balance_days == 0 else 'positive') }}"><strong>{{ '%.1f' % r.toil_balance_days }}</strong></td>
         </tr>
       {% else %}
         <tr><td colspan="12">No users are assigned to this watch.</td></tr>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -349,6 +349,65 @@ def test_leave_year_report_filters_by_watch(client):
     assert b"<td>Admin Test</td>" not in watch_b_only.data
 
 
+def test_leave_year_report_uses_selected_end_date_and_coloured_balances(client):
+    login(client)
+    acknowledge_reports(client)
+    with app.app.app_context():
+        person = Staff.query.filter_by(
+            unit_id=1, username=ADMIN_CREDENTIALS["username"]
+        ).one()
+        original_values = (
+            person.leave_year_start_month,
+            person.leave_entitlement_days,
+            person.leave_public_holidays,
+            person.leave_carryover_days,
+            person.toil_half_days,
+        )
+        person.leave_year_start_month = 4
+        person.leave_entitlement_days = 20
+        person.leave_public_holidays = 5
+        person.leave_carryover_days = 2
+        person.toil_half_days = 3
+        assignments = [
+            Assignment(
+                unit_id=1,
+                staff_id=person.id,
+                day=date(2027, 5, day),
+                code="AL",
+                source="manual",
+            )
+            for day in (5, 20)
+        ]
+        db.session.add_all(assignments)
+        db.session.commit()
+        person_id = person.id
+        assignment_ids = [row.id for row in assignments]
+
+    early = client.get("/reports/leave-year?end_date=2027-05-10")
+    later = client.get("/reports/leave-year?end_date=2027-05-25")
+
+    assert early.status_code == 200
+    assert b'input id="leave-year-end" type="date" name="end_date" value="2027-05-10"' in early.data
+    assert b"Entitlement and balances as of 2027-05-10." in early.data
+    assert f'data-staff-id="{person_id}" data-al-taken="1" data-leave-remaining="26"'.encode() in early.data
+    assert f'data-staff-id="{person_id}" data-al-taken="2" data-leave-remaining="25"'.encode() in later.data
+    assert b"leave-year-col--remaining balance-positive" in early.data
+    assert b"leave-year-col--toil-balance balance-positive" in early.data
+    assert client.get("/reports/leave-year?end_date=not-a-date").status_code == 400
+
+    with app.app.app_context():
+        Assignment.query.filter(Assignment.id.in_(assignment_ids)).delete()
+        person = db.session.get(Staff, person_id)
+        (
+            person.leave_year_start_month,
+            person.leave_entitlement_days,
+            person.leave_public_holidays,
+            person.leave_carryover_days,
+            person.toil_half_days,
+        ) = original_values
+        db.session.commit()
+
+
 def test_sickness_report_filters_by_watch(client):
     login(client)
     acknowledge_reports(client)


### PR DESCRIPTION
Adds a user-selectable Report to date to the leave-year report and recalculates leave/TOIL activity through that date. Colour-codes leave and TOIL columns, with prominent positive, zero and negative styling for remaining leave and TOIL balance. Watch filtering, print and Save as PDF remain available.