### PR TITLE
Add unit and watch filters to all reports

### DIFF
--- a/app.py
+++ b/app.py
@@ -5423,10 +5423,13 @@ def notification_delete(notification_id):
 # (… unchanged metrics functions from your file …)
 
 
-def _compute_metrics_range(start_day: date, end_day: date):
+def _compute_metrics_range(
+    start_day: date, end_day: date, watch_id: int | None = None
+):
     return compute_annotation_metrics(
         start_day,
         end_day,
+        watch_id=watch_id,
         Assignment=Assignment,
         Staff=Staff,
         Watch=Watch,

--- a/reporting.py
+++ b/reporting.py
@@ -25,6 +25,7 @@ def compute_annotation_metrics(
     start_day: date,
     end_day: date,
     *,
+    watch_id: int | None = None,
     Assignment: Any,
     Staff: Any,
     Watch: Any,
@@ -53,7 +54,10 @@ def compute_annotation_metrics(
     ]
     order = [column["code"] for column in columns]
     known = set(order)
-    staff_by_id = {person.id: person for person in Staff.query.all()}
+    staff_query = Staff.query
+    if watch_id is not None:
+        staff_query = staff_query.filter(Staff.watch_id == watch_id)
+    staff_by_id = {person.id: person for person in staff_query.all()}
     metrics: dict[int, dict[str, object]] = {}
 
     for assignment in assignments:
@@ -85,11 +89,12 @@ def compute_annotation_metrics(
         annotations.setdefault(code, 0)
         annotations[code] += 1
 
-    ordered_people = (
-        Staff.query.outerjoin(Watch, Staff.watch_id == Watch.id)
-        .order_by(Watch.order_index, Staff.name)
-        .all()
-    )
+    ordered_people_query = Staff.query.outerjoin(Watch, Staff.watch_id == Watch.id)
+    if watch_id is not None:
+        ordered_people_query = ordered_people_query.filter(Staff.watch_id == watch_id)
+    ordered_people = ordered_people_query.order_by(
+        Watch.order_index, Staff.name
+    ).all()
     rows = []
     for person in ordered_people:
         row = metrics.get(

--- a/reports_blueprint.py
+++ b/reports_blueprint.py
@@ -36,7 +36,7 @@ class ReportsDependencies:
     current_unit_id: Callable[[], int]
     validate_csrf: Callable[[], None]
     consume_rate_limit: Callable[..., bool]
-    compute_metrics_range: Callable[[date, date], tuple]
+    compute_metrics_range: Callable[[date, date, int | None], tuple]
     financial_year_start: Callable[[date], date]
     parse_year_month: Callable[[str], tuple[int, int]]
     ensure_month_requirement: Callable[[int, int], Any]
@@ -96,8 +96,9 @@ def create_reports_blueprint(dependencies: ReportsDependencies) -> Blueprint:
             request.args.get("start", default_start.isoformat())
         )
         end_day = date.fromisoformat(request.args.get("end", today.isoformat()))
+        watches, selected_watch = watch_selection()
         staff_metrics, totals, annotation_columns = dependencies.compute_metrics_range(
-            start_day, end_day
+            start_day, end_day, selected_watch.id if selected_watch else None
         )
         return render_template(
             "metrics.html",
@@ -106,6 +107,8 @@ def create_reports_blueprint(dependencies: ReportsDependencies) -> Blueprint:
             staff_metrics=staff_metrics,
             totals=totals,
             annotation_columns=annotation_columns,
+            watches=watches,
+            selected_watch=selected_watch,
         )
 
     @login_required
@@ -127,8 +130,9 @@ def create_reports_blueprint(dependencies: ReportsDependencies) -> Blueprint:
             request.args.get("start", default_start.isoformat())
         )
         end_day = date.fromisoformat(request.args.get("end", today.isoformat()))
+        watches, selected_watch = watch_selection()
         staff_metrics, totals, annotation_columns = dependencies.compute_metrics_range(
-            start_day, end_day
+            start_day, end_day, selected_watch.id if selected_watch else None
         )
         output = io.StringIO()
         writer = csv.writer(output)
@@ -151,15 +155,14 @@ def create_reports_blueprint(dependencies: ReportsDependencies) -> Blueprint:
             )
         writer.writerow([])
         writer.writerow(
-            ["All ATCOs", "", ""]
+            [selected_watch.name if selected_watch else "Entire unit", "", ""]
             + [
                 totals["annotations"].get(column["code"], 0)
                 for column in annotation_columns
             ]
         )
-        filename = (
-            f"annotation-totals_{start_day.isoformat()}_to_{end_day.isoformat()}.csv"
-        )
+        watch_suffix = f"_watch-{selected_watch.id}" if selected_watch else ""
+        filename = f"annotation-totals_{start_day.isoformat()}_to_{end_day.isoformat()}{watch_suffix}.csv"
         return Response(
             output.getvalue().encode("utf-8"),
             mimetype="text/csv; charset=utf-8",

--- a/templates/live_position/operational_activity_report.html
+++ b/templates/live_position/operational_activity_report.html
@@ -31,7 +31,7 @@
   </label>
   <label>Watch
     <select name="watch_id">
-      <option value="">All watches</option>
+      <option value="">Entire unit</option>
       {% for watch in watches %}<option value="{{ watch.id }}" {% if selected_watch_id == watch.id %}selected{% endif %}>{{ watch.name }}</option>{% endfor %}
     </select>
   </label>

--- a/templates/metrics.html
+++ b/templates/metrics.html
@@ -14,8 +14,15 @@
     <input id="start" name="start" type="date" value="{{ start.isoformat() }}">
     <label for="end">To</label>
     <input id="end" name="end" type="date" value="{{ end.isoformat() }}">
+    <label for="metrics-watch">Watch</label>
+    <select id="metrics-watch" name="watch_id">
+      <option value="">Entire unit</option>
+      {% for watch in watches %}
+        <option value="{{ watch.id }}" {% if selected_watch and selected_watch.id == watch.id %}selected{% endif %}>{{ watch.name }}</option>
+      {% endfor %}
+    </select>
     <button class="btn btn-primary" type="submit">Update</button>
-    <a class="btn" href="{{ url_for('metrics_export', start=start.isoformat(), end=end.isoformat()) }}">Download CSV</a>
+    <a class="btn" href="{{ url_for('metrics_export', start=start.isoformat(), end=end.isoformat(), watch_id=selected_watch.id if selected_watch else None) }}">Download CSV</a>
   </form>
 
   <div class="card">
@@ -46,7 +53,7 @@
         </tbody>
         <tfoot>
           <tr class="strong">
-            <td>All ATCOs</td>
+            <td>{{ selected_watch.name if selected_watch else 'Entire unit' }}</td>
             <td></td>
             {% for col in annotation_columns %}
               <td>{{ totals.annotations[col.code] }}</td>

--- a/templates/report_leave.html
+++ b/templates/report_leave.html
@@ -13,7 +13,7 @@
 <form class="report-filter card" method="get">
   <label for="leave-watch">Filter by watch</label>
   <select id="leave-watch" name="watch_id">
-    <option value="">All users</option>
+    <option value="">Entire unit</option>
     {% for watch in watches %}
       <option value="{{ watch.id }}" {% if selected_watch and selected_watch.id == watch.id %}selected{% endif %}>{{ watch.name }}</option>
     {% endfor %}

--- a/templates/report_leave_year.html
+++ b/templates/report_leave_year.html
@@ -10,7 +10,7 @@
 <form class="report-filter card" method="get">
   <label for="leave-year-watch">Filter by watch</label>
   <select id="leave-year-watch" name="watch_id">
-    <option value="">All users</option>
+    <option value="">Entire unit</option>
     {% for watch in watches %}
       <option value="{{ watch.id }}" {% if selected_watch and selected_watch.id == watch.id %}selected{% endif %}>{{ watch.name }}</option>
     {% endfor %}

--- a/templates/report_sickness.html
+++ b/templates/report_sickness.html
@@ -10,7 +10,7 @@
 <form class="report-filter card" method="get">
   <label for="sickness-watch">Filter by watch</label>
   <select id="sickness-watch" name="watch_id">
-    <option value="">All users</option>
+    <option value="">Entire unit</option>
     {% for watch in watches %}
       <option value="{{ watch.id }}" {% if selected_watch and selected_watch.id == watch.id %}selected{% endif %}>{{ watch.name }}</option>
     {% endfor %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -333,7 +333,7 @@ def test_leave_year_report_filters_by_watch(client):
 
     all_users = client.get("/reports/leave-year")
     assert all_users.status_code == 200
-    assert b"All users" in all_users.data
+    assert b"Entire unit" in all_users.data
     assert b"Apply filter" in all_users.data
     assert b"<td>Admin Test</td>" in all_users.data
     assert b"<td>Duty Watch Manager Test</td>" in all_users.data
@@ -347,6 +347,33 @@ def test_leave_year_report_filters_by_watch(client):
     assert watch_b_only.status_code == 200
     assert b"<td>Duty Watch Manager Test</td>" in watch_b_only.data
     assert b"<td>Admin Test</td>" not in watch_b_only.data
+
+
+def test_annotation_totals_report_and_export_filter_by_watch(client):
+    login(client)
+    acknowledge_reports(client)
+    with app.app.app_context():
+        watch_a = Watch.query.filter_by(unit_id=1, name="Watch A").one()
+        watch_b = Watch.query.filter_by(unit_id=1, name="Watch B").one()
+
+    entire_unit = client.get("/metrics")
+    assert entire_unit.status_code == 200
+    assert b"Entire unit" in entire_unit.data
+    assert b"Admin Test" in entire_unit.data
+    assert b"Duty Watch Manager Test" in entire_unit.data
+
+    watch_a_only = client.get(f"/metrics?watch_id={watch_a.id}")
+    assert watch_a_only.status_code == 200
+    assert b"Admin Test" in watch_a_only.data
+    assert b"Duty Watch Manager Test" not in watch_a_only.data
+    assert f"watch_id={watch_a.id}".encode() in watch_a_only.data
+
+    watch_b_export = client.get(f"/metrics/export?watch_id={watch_b.id}")
+    assert watch_b_export.status_code == 200
+    csv_text = watch_b_export.data.decode()
+    assert "Duty Watch Manager Test" in csv_text
+    assert "Admin Test" not in csv_text
+    assert f"watch-{watch_b.id}" in watch_b_export.headers["Content-Disposition"]
 
 
 def test_leave_year_report_uses_selected_end_date_and_coloured_balances(client):
@@ -433,7 +460,7 @@ def test_sickness_report_filters_by_watch(client):
 
     all_users = client.get("/reports/sickness")
     assert all_users.status_code == 200
-    assert b"All users" in all_users.data
+    assert b"Entire unit" in all_users.data
     assert b"Apply filter" in all_users.data
     assert b"<td>Admin Test</td>" in all_users.data
     assert b"<td>Duty Watch Manager Test</td>" in all_users.data


### PR DESCRIPTION
## What changed

- added Watch / Entire unit filtering to annotation totals
- applied the selected watch to CSV exports and totals
- standardised the unfiltered option across leave, sickness, leave-year, and operational activity reports
- added regression coverage for report and export filtering

## Validation

- `python -m pytest tests/test_routes.py tests/test_reports_blueprint.py -q` (108 passed)
- `python -m pytest tests/test_live_position_monitoring.py -q` (13 passed)
- `python -m compileall -q app.py reports_blueprint.py reporting.py`
- `git diff --check`
