### PR TITLE
Exclude kiosk accounts from reports

### DIFF
--- a/live_position_blueprint.py
+++ b/live_position_blueprint.py
@@ -333,6 +333,7 @@ def create_live_position_blueprint(
             dependencies.Staff.query.filter_by(
                 unit_id=unit_id, membership_status="active", is_operational=True
             )
+            .filter(dependencies.Staff.role != "position_monitor")
             .order_by(dependencies.Staff.name)
             .all()
         )

--- a/reporting.py
+++ b/reporting.py
@@ -54,7 +54,7 @@ def compute_annotation_metrics(
     ]
     order = [column["code"] for column in columns]
     known = set(order)
-    staff_query = Staff.query
+    staff_query = Staff.query.filter(Staff.role != "position_monitor")
     if watch_id is not None:
         staff_query = staff_query.filter(Staff.watch_id == watch_id)
     staff_by_id = {person.id: person for person in staff_query.all()}
@@ -89,7 +89,9 @@ def compute_annotation_metrics(
         annotations.setdefault(code, 0)
         annotations[code] += 1
 
-    ordered_people_query = Staff.query.outerjoin(Watch, Staff.watch_id == Watch.id)
+    ordered_people_query = Staff.query.filter(
+        Staff.role != "position_monitor"
+    ).outerjoin(Watch, Staff.watch_id == Watch.id)
     if watch_id is not None:
         ordered_people_query = ordered_people_query.filter(Staff.watch_id == watch_id)
     ordered_people = ordered_people_query.order_by(
@@ -136,7 +138,10 @@ def leave_summary_for_month(
     ):
         assignments[row.staff_id][row.day] = row.code
 
-    query = Staff.query.filter(Staff.unit_id == unit_id).outerjoin(
+    query = Staff.query.filter(
+        Staff.unit_id == unit_id,
+        Staff.role != "position_monitor",
+    ).outerjoin(
         Watch, Staff.watch_id == Watch.id
     )
     if watch_id is not None:

--- a/reports_blueprint.py
+++ b/reports_blueprint.py
@@ -259,7 +259,8 @@ def create_reports_blueprint(dependencies: ReportsDependencies) -> Blueprint:
         unit_id = dependencies.current_unit_id()
         watches, selected_watch = watch_selection()
         people_query = dependencies.Staff.query.filter(
-            dependencies.Staff.unit_id == unit_id
+            dependencies.Staff.unit_id == unit_id,
+            dependencies.Staff.role != "position_monitor",
         ).outerjoin(
             dependencies.Watch,
             dependencies.Staff.watch_id == dependencies.Watch.id,
@@ -326,7 +327,8 @@ def create_reports_blueprint(dependencies: ReportsDependencies) -> Blueprint:
         unit_id = dependencies.current_unit_id()
         watches, selected_watch = watch_selection()
         people_query = dependencies.Staff.query.filter(
-            dependencies.Staff.unit_id == unit_id
+            dependencies.Staff.unit_id == unit_id,
+            dependencies.Staff.role != "position_monitor",
         ).outerjoin(
             dependencies.Watch,
             dependencies.Staff.watch_id == dependencies.Watch.id,

--- a/tests/test_live_position_monitoring.py
+++ b/tests/test_live_position_monitoring.py
@@ -614,6 +614,7 @@ def test_operational_activity_reports_split_solo_and_ojti_time(live_position_dat
     assert b"Alex Controller" in individual.data
     assert b"01:30" in individual.data
     assert b"Sam Instructor" in individual.data
+    assert b"Position screen" not in individual.data
     assert b"00:30" in individual.data
     assert b"75.0%" in individual.data
     position = client.get(

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1557,7 +1557,28 @@ def test_position_monitor_account_is_hidden_from_roster_and_export(client):
         )
         kiosk.set_password("not-used")
         db.session.add(kiosk)
+        db.session.flush()
+        db.session.add_all(
+            [
+                Assignment(
+                    unit_id=1,
+                    staff_id=kiosk.id,
+                    day=date(2027, 1, 5),
+                    code="AL",
+                    annotation="AAVA",
+                    source="manual",
+                ),
+                Assignment(
+                    unit_id=1,
+                    staff_id=kiosk.id,
+                    day=date.today(),
+                    code="SC",
+                    source="manual",
+                ),
+            ]
+        )
         db.session.commit()
+        kiosk_id = kiosk.id
 
     login(client)
     roster = client.get("/roster/2027-01")
@@ -1569,8 +1590,24 @@ def test_position_monitor_account_is_hidden_from_roster_and_export(client):
     assert b"KIOSK-HIDDEN" not in roster.data
     assert "Hidden Position Monitor" not in export.data.decode()
     assert "KIOSK-HIDDEN" not in export.data.decode()
+
+    acknowledge_reports(client)
+    report_responses = [
+        client.get("/metrics?start=2027-01-01&end=2027-01-31"),
+        client.get("/metrics/export?start=2027-01-01&end=2027-01-31"),
+        client.get("/reports/leave/2027-01"),
+        client.get("/reports/leave.csv?ym=2027-01"),
+        client.get("/reports/leave-year"),
+        client.get("/reports/sickness"),
+    ]
+    for response in report_responses:
+        assert response.status_code == 200
+        assert b"Hidden Position Monitor" not in response.data
+        assert b"KIOSK-HIDDEN" not in response.data
+
     with app.app.app_context():
-        Staff.query.filter_by(username="roster_hidden_kiosk").delete()
+        Assignment.query.filter_by(staff_id=kiosk_id).delete()
+        Staff.query.filter_by(id=kiosk_id).delete()
         db.session.commit()
 
 


### PR DESCRIPTION
## What changed

- excludes dedicated position-monitor accounts from all staff-backed reports and exports
- enforces the exclusion even if a kiosk is accidentally marked operational or has assignments
- adds regression coverage across roster, annotation, leave, sickness, and operational activity reports

## Validation

- `python -m pytest tests/test_routes.py tests/test_reports_blueprint.py -q` (108 passed)
- `python -m pytest tests/test_live_position_monitoring.py -q` (13 passed)
- Python compile checks and `git diff --check` passed
