### PR TITLE
Shield sticky roster header across viewport

### DIFF
--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -62,6 +62,19 @@
      roster navigation, print or zoom controls before they scroll away. */
   .site-header { box-shadow: 0 2px 0 var(--head); }
 
+  /* The roster is wider than the viewport and the document owns horizontal
+     scrolling. Keep an opaque viewport-wide layer behind the site header so
+     roster rows cannot appear above the sticky date headings at the far right. */
+  .roster-sticky-shield {
+    position: fixed;
+    inset: 0 0 auto 0;
+    width: 100vw;
+    height: 0;
+    background: #11161d;
+    pointer-events: none;
+    z-index: 9;
+  }
+
   /* Ensure cells can host absolutely-positioned overlays */
   .roster th.dayhead { position: sticky; }
   .roster td.cell { position: relative; }
@@ -129,6 +142,7 @@
   }
 </style>
 
+<div class="roster-sticky-shield" data-roster-sticky-shield aria-hidden="true"></div>
 <h2>ATC Roster – {{ month_title }}</h2>
 <div class="roster-save-status" data-roster-save-status role="status" aria-live="polite"></div>
 
@@ -427,8 +441,10 @@
   function printRoster(){ window.print(); }
   const rosterTable = document.querySelector('table.roster');
   const siteHeader = document.querySelector('.site-header');
+  const rosterStickyShield = document.querySelector('[data-roster-sticky-shield]');
   const updateRosterStickyTop = () => {
     const height = siteHeader ? Math.ceil(siteHeader.getBoundingClientRect().height) : 0;
+    if (rosterStickyShield) rosterStickyShield.style.height = `${height}px`;
     const rosterHost = document.getElementById('roster');
     const configuredScale = Number(rosterHost?.dataset.scale || 1);
     const scale = Number.isFinite(configuredScale) && configuredScale > 0

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1543,6 +1543,8 @@ def test_roster_routes_render(client):
     export_resp = client.get(f"/roster/{month}/export")
     assert export_resp.status_code == 200
     assert export_resp.mimetype == "text/csv"
+    assert b'data-roster-sticky-shield' in roster_resp.data
+    assert b'rosterStickyShield.style.height' in roster_resp.data
 
 
 def test_position_monitor_account_is_hidden_from_roster_and_export(client):


### PR DESCRIPTION
## What changed

- adds an opaque fixed shield across the complete viewport above the sticky roster date row
- dynamically matches the shield height to the responsive site header
- preserves the date header, name column, toolbar, zoom, print, and roster editing behaviour

## Root cause

The roster owns document-level horizontal scrolling. At the far right, the viewport-wide site header had scrolled out of the horizontal view, allowing roster rows to show through above the sticky date headings.

## Validation

- `python -m pytest tests/test_routes.py -q` (106 passed)
- `git diff --check`
