### PR TITLE
Align roster shield to viewport edge

### DIFF
--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -65,11 +65,12 @@
   /* The roster is wider than the viewport and the document owns horizontal
      scrolling. Keep an opaque viewport-wide layer behind the site header so
      roster rows cannot appear above the sticky date headings at the far right. */
-  .roster-sticky-shield {
+  .roster-page .page-content > .roster-sticky-shield {
     position: fixed;
     inset: 0 0 auto 0;
     width: 100vw;
     height: 0;
+    margin: 0;
     background: #11161d;
     pointer-events: none;
     z-index: 9;


### PR DESCRIPTION
## What changed

- prevents the roster page content margin from offsetting the fixed sticky-header shield
- keeps the shield aligned to both viewport edges at every responsive width

## Validation

- `python -m pytest tests/test_routes.py -q` (106 passed)
- production browser inspection identified and measured the inherited 12px offset
- `git diff --check`
