### PR TITLE
Exclude roster shield from content margins

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -2999,7 +2999,7 @@ body.report-pdf-requested .report-output-actions{
   padding-inline:0;
 }
 
-.roster-page .page-content > :not(#roster){
+.roster-page .page-content > :not(#roster):not(.roster-sticky-shield){
   margin-inline:clamp(.75rem, 1.5vw, 1.5rem);
 }
 

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -65,7 +65,7 @@
   /* The roster is wider than the viewport and the document owns horizontal
      scrolling. Keep an opaque viewport-wide layer behind the site header so
      roster rows cannot appear above the sticky date headings at the far right. */
-  .roster-page .page-content > .roster-sticky-shield {
+  .roster-sticky-shield {
     position: fixed;
     inset: 0 0 auto 0;
     width: 100vw;


### PR DESCRIPTION
## What changed

- excludes the fixed roster shield from the generic roster content margin selector
- removes the specificity conflict caused by `:not(#roster)`
- ensures the shield remains exactly viewport-aligned at x=0

## Validation

- `python -m pytest tests/test_routes.py -q` (106 passed)
- `git diff --check`
