### PR TITLE
Fit publication frame to rendered roster

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -410,6 +410,11 @@
       }
 
       const host = table.closest('#roster') || table.parentElement;
+      // The publication-status frame follows the rendered table width. Reset
+      // it before measuring the available viewport for a fresh fit-width pass.
+      if (host?.classList.contains('roster-status-frame')) {
+        host.style.removeProperty('width');
+      }
       const hostRect = host ? host.getBoundingClientRect() : null;
       let containerWidth = hostRect && hostRect.width ? hostRect.width : 0;
 

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -443,6 +443,14 @@
   const rosterTable = document.querySelector('table.roster');
   const siteHeader = document.querySelector('.site-header');
   const rosterStickyShield = document.querySelector('[data-roster-sticky-shield]');
+  const rosterStatusFrame = document.getElementById('roster');
+  const updateRosterStatusFrameWidth = () => {
+    if (!rosterTable || !rosterStatusFrame) return;
+    const renderedWidth = rosterTable.getBoundingClientRect().width;
+    if (renderedWidth > 0) {
+      rosterStatusFrame.style.width = `${Math.ceil(renderedWidth)}px`;
+    }
+  };
   const updateRosterStickyTop = () => {
     const height = siteHeader ? Math.ceil(siteHeader.getBoundingClientRect().height) : 0;
     if (rosterStickyShield) rosterStickyShield.style.height = `${height}px`;
@@ -451,6 +459,7 @@
     const scale = Number.isFinite(configuredScale) && configuredScale > 0
       ? configuredScale : 1;
     rosterTable?.style.setProperty('--roster-sticky-top', `${Math.ceil(height / scale)}px`);
+    updateRosterStatusFrameWidth();
   };
   updateRosterStickyTop();
   window.addEventListener('resize', updateRosterStickyTop, { passive: true });

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -713,6 +713,9 @@ def test_roster_has_persistent_zoom_presets(client):
     assert b'<span aria-hidden="true">&nbsp;</span></button>' in response.data
     assert b"Saving\xe2\x80\xa6" in response.data
     assert b"atcroster:scroll:" in response.data
+    assert b"updateRosterStatusFrameWidth" in response.data
+    assert b"rosterStatusFrame.style.width" in response.data
+    assert b"host.style.removeProperty('width')" in response.data
     assert b"annotationButton.dataset.version = payload.version" in response.data
 
 


### PR DESCRIPTION
## What changed

- synchronises the draft/published outline width to the roster table after zoom is applied
- updates the outline on zoom and responsive header changes
- resets the outline width before Fit width calculates the available viewport

## Root cause

The publication frame remained a viewport-width block while the rendered roster table could be substantially wider or narrower after zooming.

## Validation

- `python -m pytest tests/test_routes.py -q` (106 passed)
- `git diff --check`
