### PR TITLE
Decouple publication outline from roster layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -2510,14 +2510,28 @@ table.roster { zoom:var(--ui-scale); }
 .roster-status-banner--published { background:rgba(60,190,125,.12); border-color:rgba(60,190,125,.65); }
 .roster-status-banner--published > i { color:#54d696; }
 .roster-status-frame {
+  position:relative;
   padding:.65rem 0;
-  border:1px solid;
+  border:0;
   border-radius:12px;
+  --roster-status-frame-width:100%;
 }
-.roster-status-frame--draft {
+.roster-status-frame::before {
+  content:"";
+  position:absolute;
+  inset:0 auto auto 0;
+  width:var(--roster-status-frame-width);
+  height:100%;
+  box-sizing:border-box;
+  border:1px solid;
+  border-radius:inherit;
+  pointer-events:none;
+  z-index:20;
+}
+.roster-status-frame--draft::before {
   border-color:rgba(245,183,66,.65);
 }
-.roster-status-frame--published { border-color:rgba(60,190,125,.65); }
+.roster-status-frame--published::before { border-color:rgba(60,190,125,.65); }
 .roster-state-note {
   display:flex;
   align-items:center;

--- a/templates/base.html
+++ b/templates/base.html
@@ -410,11 +410,6 @@
       }
 
       const host = table.closest('#roster') || table.parentElement;
-      // The publication-status frame follows the rendered table width. Reset
-      // it before measuring the available viewport for a fresh fit-width pass.
-      if (host?.classList.contains('roster-status-frame')) {
-        host.style.removeProperty('width');
-      }
       const hostRect = host ? host.getBoundingClientRect() : null;
       let containerWidth = hostRect && hostRect.width ? hostRect.width : 0;
 

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -448,7 +448,9 @@
     if (!rosterTable || !rosterStatusFrame) return;
     const renderedWidth = rosterTable.getBoundingClientRect().width;
     if (renderedWidth > 0) {
-      rosterStatusFrame.style.width = `${Math.ceil(renderedWidth)}px`;
+      rosterStatusFrame.style.setProperty(
+        '--roster-status-frame-width', `${Math.ceil(renderedWidth)}px`
+      );
     }
   };
   const updateRosterStickyTop = () => {

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -714,8 +714,8 @@ def test_roster_has_persistent_zoom_presets(client):
     assert b"Saving\xe2\x80\xa6" in response.data
     assert b"atcroster:scroll:" in response.data
     assert b"updateRosterStatusFrameWidth" in response.data
-    assert b"rosterStatusFrame.style.width" in response.data
-    assert b"host.style.removeProperty('width')" in response.data
+    assert b"--roster-status-frame-width" in response.data
+    assert b".roster-status-frame::before" in stylesheet.data
     assert b"annotationButton.dataset.version = payload.version" in response.data
 
 


### PR DESCRIPTION
## What changed

- renders the draft/published outline as a non-layout overlay sized to the rendered table
- preserves genuine horizontal scaling at 75%, 90%, 100%, and Fit width
- removes the container-width feedback loop found during production browser verification

## Validation

- `python -m pytest tests/test_routes.py -q` (106 passed)
- `git diff --check`
