### PR TITLE
Fix leave year column alignment

### DIFF
--- a/templates/report_leave_year.html
+++ b/templates/report_leave_year.html
@@ -28,7 +28,7 @@
         <th class="leave-year-col leave-year-col--entitlement">Entitlement</th>
         <th class="leave-year-col leave-year-col--public-holidays">Public Hols</th>
         <th class="leave-year-col leave-year-col--carryover">Carryover</th>
-        <th class="leave-year-col leave-year-col--taken">AL taken</th><th></th>
+        <th class="leave-year-col leave-year-col--taken">AL taken</th>
         <th class="leave-year-col leave-year-col--remaining">Remaining</th>
         <th class="leave-year-col leave-year-col--toil-accrued">TOIL accrued</th>
         <th class="leave-year-col leave-year-col--toil-used">TOIL used</th>
@@ -45,14 +45,13 @@
           <td class="ta-right leave-year-col leave-year-col--public-holidays">{{ r.public_holidays }}</td>
           <td class="ta-right leave-year-col leave-year-col--carryover">{{ r.carryover }}</td>
           <td class="ta-right leave-year-col leave-year-col--taken">{{ r.al_taken }}</td>
-          <td></td>
           <td class="ta-right leave-year-col leave-year-col--remaining balance-{{ 'negative' if r.remaining < 0 else ('zero' if r.remaining == 0 else 'positive') }}"><strong>{{ r.remaining }}</strong></td>
           <td class="ta-right leave-year-col leave-year-col--toil-accrued">{{ '%.1f' % r.toil_accrued_days }}</td>
           <td class="ta-right leave-year-col leave-year-col--toil-used">{{ '%.1f' % r.toil_used_days }}</td>
           <td class="ta-right leave-year-col leave-year-col--toil-balance balance-{{ 'negative' if r.toil_balance_days < 0 else ('zero' if r.toil_balance_days == 0 else 'positive') }}"><strong>{{ '%.1f' % r.toil_balance_days }}</strong></td>
         </tr>
       {% else %}
-        <tr><td colspan="12">No users are assigned to this watch.</td></tr>
+        <tr><td colspan="11">No users are assigned to this watch.</td></tr>
       {% endfor %}
     </tbody>
   </table>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -420,6 +420,8 @@ def test_leave_year_report_uses_selected_end_date_and_coloured_balances(client):
     assert f'data-staff-id="{person_id}" data-al-taken="2" data-leave-remaining="25"'.encode() in later.data
     assert b"leave-year-col--remaining balance-positive" in early.data
     assert b"leave-year-col--toil-balance balance-positive" in early.data
+    assert b'leave-year-col--taken">AL taken</th><th></th>' not in early.data
+    assert b'<td class="ta-right leave-year-col leave-year-col--taken">1</td>\n          <td></td>' not in early.data
     assert client.get("/reports/leave-year?end_date=not-a-date").status_code == 400
 
     with app.app.app_context():


### PR DESCRIPTION
## What changed

- removes the unintended blank column between AL taken and Remaining
- realigns Remaining and all TOIL values with their headings
- corrects the empty-state colspan

## Root cause

The leave-year template rendered an extra empty header and body cell in every row.

## Validation

- `python -m pytest tests/test_routes.py -q` (106 passed)
- `git diff --check`
