### PR TITLE
Add safe automatic roster allocation service

### DIFF
--- a/docs/flexible_roster_design.md
+++ b/docs/flexible_roster_design.md
@@ -104,3 +104,30 @@ the legacy fallback. The server repeats the analysis when migration is submitted
 so a stale browser report cannot force an unsafe match. Migration only inserts
 an effective-dated `StaffPatternAssignment`, retaining the legacy anchor and
 leaving every existing roster assignment unchanged.
+
+## Initial automatic allocation (Stages 11 and 12)
+
+`roster_allocation_service.generate_roster_proposal` is the first safe
+gap-filling boundary. It accepts plain staff, shift, requirement and existing
+assignment snapshots plus callbacks for the application's eligibility,
+qualification, medical, leave and fatigue decisions. It returns an immutable
+`RosterProposal`; it has no database session and cannot alter the live roster.
+
+The initial strategy is deterministic and constraint-first. Existing
+assignments, including soft- and hard-locked assignments, are retained. A
+person can receive no more than one proposed duty per day. Hard constraint
+failures are rejected before scoring and can never be traded for fairness.
+Overtime is prohibited unless explicitly enabled.
+
+Legal candidates are ranked using centralised `AllocationWeights`. Coverage
+has the dominant penalty, followed by overtime, contractual-minute deviation,
+proportional night/weekend balance and soft preferences. The result contains
+proposed and retained duties, structured uncovered reasons and explanations,
+objective cost, fairness minute impact, elapsed time and configuration.
+`FEASIBLE` means this deterministic strategy filled every requested gap;
+`OPTIMAL` is reserved for a future solver that can prove optimality.
+
+This stage deliberately has no apply operation. Stage 13 will persist proposals,
+let authorised planners accept or reject each proposed duty, and audit every
+accepted change. A CP-SAT strategy can later replace this strategy behind the
+same proposal result types without changing that review workflow.

--- a/roster_allocation_service.py
+++ b/roster_allocation_service.py
@@ -1,0 +1,331 @@
+"""Safe, deterministic gap-filling proposals for roster assignments.
+
+The allocator accepts plain records and callbacks.  It never writes to the
+database, which keeps proposal generation separate from proposal acceptance
+and makes the strategy replaceable by a future CP-SAT implementation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from enum import StrEnum
+from time import monotonic
+from typing import Callable, Iterable, Mapping, Sequence
+
+
+class ProposalStatus(StrEnum):
+    OPTIMAL = "OPTIMAL"
+    FEASIBLE = "FEASIBLE"
+    PARTIALLY_COVERED = "PARTIALLY_COVERED"
+    INFEASIBLE = "INFEASIBLE"
+    TIMED_OUT_WITH_SOLUTION = "TIMED_OUT_WITH_SOLUTION"
+    TIMED_OUT_NO_SOLUTION = "TIMED_OUT_NO_SOLUTION"
+
+
+@dataclass(frozen=True)
+class AllocationWeights:
+    """Centralised soft-objective priorities; hard rules are never weighted."""
+
+    uncovered_shift: int = 1_000_000
+    overtime_minute: int = 1_000
+    contracted_minute_deviation: int = 10
+    night_deviation: int = 500
+    weekend_deviation: int = 350
+    pattern_deviation: int = 250
+    preference_breach: int = 200
+    soft_lock_change: int = 100_000
+
+
+@dataclass(frozen=True)
+class AllocationStaff:
+    staff_id: int
+    name: str
+    target_minutes: int
+    actual_minutes: int = 0
+    night_count: int = 0
+    target_night_count: float = 0.0
+    weekend_count: int = 0
+    target_weekend_count: float = 0.0
+
+
+@dataclass(frozen=True)
+class AllocationShift:
+    shift_type_id: int
+    code: str
+    minutes: int
+    is_night: bool = False
+
+
+@dataclass(frozen=True)
+class ExistingAllocation:
+    assignment_id: int
+    staff_id: int
+    day: date
+    shift_type_id: int
+    shift_code: str
+    lock_status: str = "UNLOCKED"
+
+
+@dataclass(frozen=True)
+class StaffingNeed:
+    day: date
+    shift_type_id: int
+    required_count: int
+
+
+@dataclass(frozen=True)
+class HardConstraintResult:
+    allowed: bool
+    reason_code: str = "ELIGIBLE"
+    explanation: str = "Employee is eligible for this shift."
+
+
+@dataclass(frozen=True)
+class SoftConstraintResult:
+    penalty: int = 0
+    reason_codes: tuple[str, ...] = ()
+    explanations: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ProposedAssignment:
+    staff_id: int
+    staff_name: str
+    day: date
+    shift_type_id: int
+    shift_code: str
+    score: int
+    explanations: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class UncoveredShift:
+    day: date
+    shift_type_id: int
+    shift_code: str
+    missing_count: int
+    reason_codes: tuple[str, ...]
+    explanations: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RosterProposal:
+    status: ProposalStatus
+    proposed_assignments: tuple[ProposedAssignment, ...]
+    retained_assignments: tuple[ExistingAllocation, ...]
+    uncovered_shifts: tuple[UncoveredShift, ...]
+    objective_score: int
+    warnings: tuple[str, ...]
+    solve_duration_seconds: float
+    configuration: Mapping[str, object]
+    fairness_impact: Mapping[int, int] = field(default_factory=dict)
+
+
+HardConstraint = Callable[[int, date, int], HardConstraintResult]
+SoftConstraint = Callable[[int, date, int], SoftConstraintResult]
+
+
+def generate_roster_proposal(
+    start_date: date,
+    end_date: date,
+    *,
+    staff: Sequence[AllocationStaff],
+    shifts: Sequence[AllocationShift],
+    staffing_needs: Iterable[StaffingNeed],
+    existing_assignments: Iterable[ExistingAllocation] = (),
+    hard_constraint: HardConstraint,
+    soft_constraint: SoftConstraint | None = None,
+    staff_ids: Iterable[int] | None = None,
+    shift_type_ids: Iterable[int] | None = None,
+    preserve_existing: bool = True,
+    allow_overtime: bool = False,
+    fairness_lookback_days: int = 180,
+    max_solve_seconds: float = 30,
+    weights: AllocationWeights | None = None,
+) -> RosterProposal:
+    """Return a gap-filling proposal without mutating any supplied record.
+
+    Coverage is processed in stable date/shift order.  Each slot selects the
+    lowest-cost legal candidate using current contractual, night, weekend and
+    preference balances.  Hard constraints and one-duty-per-day are absolute.
+    """
+    started = monotonic()
+    if end_date < start_date:
+        raise ValueError("Proposal end date cannot be before its start date.")
+    if max_solve_seconds <= 0:
+        raise ValueError("Maximum solve time must be positive.")
+    policy = weights or AllocationWeights()
+    selected_staff_ids = set(staff_ids) if staff_ids is not None else None
+    selected_shift_ids = (
+        set(shift_type_ids) if shift_type_ids is not None else None
+    )
+    people = {
+        person.staff_id: person for person in staff
+        if selected_staff_ids is None or person.staff_id in selected_staff_ids
+    }
+    shift_by_id = {
+        shift.shift_type_id: shift for shift in shifts
+        if selected_shift_ids is None or shift.shift_type_id in selected_shift_ids
+    }
+    retained = tuple(
+        row for row in existing_assignments
+        if start_date <= row.day <= end_date
+    )
+    if not preserve_existing and retained:
+        raise ValueError(
+            "Initial gap filling requires preserve_existing=True; existing "
+            "assignments cannot yet be regenerated."
+        )
+
+    occupied = {(row.staff_id, row.day) for row in retained}
+    covered: dict[tuple[date, int], int] = {}
+    for row in retained:
+        key = (row.day, row.shift_type_id)
+        covered[key] = covered.get(key, 0) + 1
+
+    actual_minutes = {sid: person.actual_minutes for sid, person in people.items()}
+    night_counts = {sid: person.night_count for sid, person in people.items()}
+    weekend_counts = {sid: person.weekend_count for sid, person in people.items()}
+    proposals: list[ProposedAssignment] = []
+    uncovered: list[UncoveredShift] = []
+    objective = 0
+    timed_out = False
+
+    needs = sorted(
+        (
+            need for need in staffing_needs
+            if start_date <= need.day <= end_date
+            and need.shift_type_id in shift_by_id
+            and need.required_count > 0
+        ),
+        key=lambda need: (need.day, need.shift_type_id),
+    )
+    for need in needs:
+        shift = shift_by_id[need.shift_type_id]
+        missing = max(
+            0, int(need.required_count) - covered.get((need.day, need.shift_type_id), 0)
+        )
+        rejection_codes: set[str] = set()
+        rejection_text: set[str] = set()
+        while missing:
+            if monotonic() - started >= max_solve_seconds:
+                timed_out = True
+                break
+            candidates: list[tuple[int, int, tuple[str, ...]]] = []
+            for staff_id, person in people.items():
+                if (staff_id, need.day) in occupied:
+                    rejection_codes.add("ONE_DUTY_PER_DAY")
+                    rejection_text.add("Employee already has a duty on this date.")
+                    continue
+                hard = hard_constraint(staff_id, need.day, shift.shift_type_id)
+                if not hard.allowed:
+                    rejection_codes.add(hard.reason_code)
+                    rejection_text.add(hard.explanation)
+                    continue
+                projected_minutes = actual_minutes[staff_id] + shift.minutes
+                overtime = max(0, projected_minutes - person.target_minutes)
+                if overtime and not allow_overtime:
+                    rejection_codes.add("OVERTIME_NOT_ALLOWED")
+                    rejection_text.add(
+                        "Assignment would exceed the employee's target minutes."
+                    )
+                    continue
+                soft = (
+                    soft_constraint(staff_id, need.day, shift.shift_type_id)
+                    if soft_constraint else SoftConstraintResult()
+                )
+                score = soft.penalty * policy.preference_breach
+                score += overtime * policy.overtime_minute
+                score += abs(projected_minutes - person.target_minutes) * (
+                    policy.contracted_minute_deviation
+                )
+                if shift.is_night:
+                    score += round(
+                        abs((night_counts[staff_id] + 1) - person.target_night_count)
+                        * policy.night_deviation
+                    )
+                if need.day.weekday() >= 5:
+                    score += round(
+                        abs(
+                            (weekend_counts[staff_id] + 1)
+                            - person.target_weekend_count
+                        ) * policy.weekend_deviation
+                    )
+                explanations = (
+                    hard.explanation,
+                    "Assignment fills an uncovered staffing requirement.",
+                    "Employee has the lowest configured legal allocation cost.",
+                    *soft.explanations,
+                )
+                candidates.append((score, staff_id, tuple(dict.fromkeys(explanations))))
+            if not candidates:
+                break
+            score, staff_id, explanations = min(candidates)
+            person = people[staff_id]
+            proposals.append(ProposedAssignment(
+                staff_id=staff_id,
+                staff_name=person.name,
+                day=need.day,
+                shift_type_id=shift.shift_type_id,
+                shift_code=shift.code,
+                score=score,
+                explanations=explanations,
+            ))
+            occupied.add((staff_id, need.day))
+            actual_minutes[staff_id] += shift.minutes
+            night_counts[staff_id] += int(shift.is_night)
+            weekend_counts[staff_id] += int(need.day.weekday() >= 5)
+            objective += score
+            missing -= 1
+        if missing:
+            objective += missing * policy.uncovered_shift
+            uncovered.append(UncoveredShift(
+                day=need.day,
+                shift_type_id=shift.shift_type_id,
+                shift_code=shift.code,
+                missing_count=missing,
+                reason_codes=tuple(sorted(rejection_codes)) or ("NO_CANDIDATE",),
+                explanations=tuple(sorted(rejection_text)) or (
+                    "No eligible employee was available for this requirement.",
+                ),
+            ))
+        if timed_out:
+            break
+
+    if timed_out:
+        status = (
+            ProposalStatus.TIMED_OUT_WITH_SOLUTION
+            if proposals else ProposalStatus.TIMED_OUT_NO_SOLUTION
+        )
+    elif uncovered and proposals:
+        status = ProposalStatus.PARTIALLY_COVERED
+    elif uncovered:
+        status = ProposalStatus.INFEASIBLE
+    else:
+        status = ProposalStatus.FEASIBLE
+    warnings = (
+        ("Solver time limit reached before every requirement was considered.",)
+        if timed_out else ()
+    )
+    return RosterProposal(
+        status=status,
+        proposed_assignments=tuple(proposals),
+        retained_assignments=retained,
+        uncovered_shifts=tuple(uncovered),
+        objective_score=objective,
+        warnings=warnings,
+        solve_duration_seconds=monotonic() - started,
+        configuration={
+            "preserve_existing": preserve_existing,
+            "allow_overtime": allow_overtime,
+            "fairness_lookback_days": fairness_lookback_days,
+            "max_solve_seconds": max_solve_seconds,
+            "strategy": "deterministic_constraint_first_gap_fill",
+            "weights": policy,
+        },
+        fairness_impact={
+            sid: actual_minutes[sid] - person.actual_minutes
+            for sid, person in people.items()
+        },
+    )

--- a/tests/fixtures/route_map.json
+++ b/tests/fixtures/route_map.json
@@ -103,6 +103,14 @@
     "rule": "/administration"
   },
   {
+    "endpoint": "work_patterns.bank_holidays",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/administration/bank-holidays"
+  },
+  {
     "endpoint": "kiosk_accounts",
     "methods": [
       "GET",
@@ -148,6 +156,13 @@
       "POST"
     ],
     "rule": "/assign/<int:staff_id>/<ym>/<day>"
+  },
+  {
+    "endpoint": "assignment_lock",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/assignment/<int:assignment_id>/lock"
   },
   {
     "endpoint": "briefing.home",
@@ -652,6 +667,13 @@
       "POST"
     ],
     "rule": "/reports"
+  },
+  {
+    "endpoint": "report_fairness",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/reports/fairness"
   },
   {
     "endpoint": "report_leave_year",

--- a/tests/test_postgresql_multidatabase.py
+++ b/tests/test_postgresql_multidatabase.py
@@ -97,9 +97,9 @@ def test_postgresql_control_and_two_airport_databases_are_isolated(
     dispose_operational_engines()
     for url in (CONTROL_URL, AIRPORT_A_URL, AIRPORT_B_URL):
         _reset_postgres(url)
-    assert upgrade_database(CONTROL_URL, "control") == "20260802_38"
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260802_38"
-    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260802_38"
+    assert upgrade_database(CONTROL_URL, "control") == "20260803_39"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_39"
+    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260803_39"
     secret_a = "ATCROSTER_UNIT_1_DATABASE_URL"
     secret_b = "ATCROSTER_UNIT_2_DATABASE_URL"
     monkeypatch.setenv(secret_a, AIRPORT_A_URL)
@@ -281,7 +281,7 @@ def test_postgresql_control_and_two_airport_databases_are_isolated(
 def test_generated_postgresql_backup_restores_and_preserves_key_records(tmp_path):
     _reset_postgres(AIRPORT_A_URL)
     _reset_postgres(RESTORE_URL)
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260802_38"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_39"
     source = create_engine(AIRPORT_A_URL)
     with source.begin() as connection:
         connection.execute(
@@ -298,7 +298,7 @@ def test_generated_postgresql_backup_restores_and_preserves_key_records(tmp_path
         AIRPORT_A_URL, tmp_path, "airport-test", "operational"
     )
     result = restore_backup(archive, metadata, RESTORE_URL)
-    assert result.alembic_revision == "20260802_38"
+    assert result.alembic_revision == "20260803_39"
     restored = create_engine(RESTORE_URL)
     try:
         with restored.connect() as connection:
@@ -331,7 +331,7 @@ def _insert_staff(connection, unit_id, username):
 
 def test_postgresql_rejects_cross_unit_operational_relationships():
     _reset_postgres(AIRPORT_A_URL)
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260802_38"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_39"
     engine = create_engine(AIRPORT_A_URL)
     try:
         with engine.begin() as connection:
@@ -381,7 +381,7 @@ def test_tenant_integrity_migration_refuses_inconsistent_legacy_data():
 
 def test_postgresql_concurrent_toil_retry_changes_balance_once(monkeypatch):
     _reset_postgres(AIRPORT_A_URL)
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260802_38"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_39"
     engine = create_engine(AIRPORT_A_URL)
     with engine.begin() as connection:
         person_id = _insert_staff(connection, 1, "toil-concurrency")
@@ -451,7 +451,7 @@ def test_postgresql_concurrent_toil_retry_changes_balance_once(monkeypatch):
 
 def test_postgresql_runtime_role_cannot_mutate_audit_evidence():
     _reset_postgres(AIRPORT_B_URL)
-    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260802_38"
+    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260803_39"
     role = f"atcroster_runtime_{os.getpid()}"
     password = "runtime-integration-only"
     owner_dsn = str(
@@ -511,7 +511,7 @@ def test_postgresql_runtime_role_cannot_mutate_audit_evidence():
 
 def test_postgresql_two_roster_editors_reject_the_stale_cell_version():
     _reset_postgres(AIRPORT_A_URL)
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260802_38"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_39"
     engine = create_engine(AIRPORT_A_URL)
     with engine.begin() as connection:
         person_id = _insert_staff(connection, 1, "roster-race")
@@ -562,7 +562,7 @@ def test_postgresql_two_roster_editors_reject_the_stale_cell_version():
 
 def test_postgresql_two_managers_create_one_request_transition_and_side_effects():
     _reset_postgres(AIRPORT_A_URL)
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260802_38"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_39"
     engine = create_engine(AIRPORT_A_URL)
     with engine.begin() as connection:
         person_id = _insert_staff(connection, 1, "request-race")
@@ -641,7 +641,7 @@ def test_postgresql_two_managers_create_one_request_transition_and_side_effects(
 
 def test_postgresql_publication_and_roster_mutations_share_a_coherent_month_lock():
     _reset_postgres(AIRPORT_A_URL)
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260802_38"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_39"
     dsn = (
         make_url(AIRPORT_A_URL)
         .set(drivername="postgresql")
@@ -767,7 +767,7 @@ def test_postgresql_live_position_logon_retry_tenant_scope_and_handover_races(
     monkeypatch,
 ):
     _reset_postgres(AIRPORT_A_URL)
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260802_38"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_39"
     secret_name = "ATCROSTER_TEST_LIVE_CONCURRENCY_DATABASE_URL"
     monkeypatch.setenv(secret_name, AIRPORT_A_URL)
     dispose_operational_engines()

--- a/tests/test_roster_allocation_service.py
+++ b/tests/test_roster_allocation_service.py
@@ -1,0 +1,167 @@
+from datetime import date
+
+import pytest
+
+from roster_allocation_service import (
+    AllocationShift,
+    AllocationStaff,
+    ExistingAllocation,
+    HardConstraintResult,
+    ProposalStatus,
+    SoftConstraintResult,
+    StaffingNeed,
+    generate_roster_proposal,
+)
+
+
+DAY = date(2026, 9, 1)
+NIGHT = AllocationShift(4, "N", 600, is_night=True)
+
+
+def allowed(_staff_id, _day, _shift_id):
+    return HardConstraintResult(True)
+
+
+def proposal(staff, *, existing=(), hard=allowed, soft=None, **options):
+    return generate_roster_proposal(
+        DAY,
+        DAY,
+        staff=staff,
+        shifts=[NIGHT],
+        staffing_needs=[StaffingNeed(DAY, NIGHT.shift_type_id, 1)],
+        existing_assignments=existing,
+        hard_constraint=hard,
+        soft_constraint=soft,
+        **options,
+    )
+
+
+def test_fills_uncovered_shift_without_writing_input_records():
+    people = [AllocationStaff(1, "Alex", 1200)]
+
+    result = proposal(people)
+
+    assert result.status == ProposalStatus.FEASIBLE
+    assert result.proposed_assignments[0].staff_id == 1
+    assert result.retained_assignments == ()
+    assert people[0].actual_minutes == 0
+
+
+def test_hard_constraint_can_block_no_night_employee():
+    def no_night(staff_id, _day, _shift_id):
+        if staff_id == 1:
+            return HardConstraintResult(
+                False, "NO_NIGHT_RULE", "Employee cannot work nights."
+            )
+        return HardConstraintResult(True)
+
+    result = proposal(
+        [AllocationStaff(1, "Alex", 1200), AllocationStaff(2, "Blair", 1200)],
+        hard=no_night,
+    )
+
+    assert result.proposed_assignments[0].staff_id == 2
+
+
+def test_leave_constraint_is_never_traded_for_fairness():
+    def on_leave(staff_id, _day, _shift_id):
+        if staff_id == 1:
+            return HardConstraintResult(
+                False, "APPROVED_LEAVE", "Employee is on approved leave."
+            )
+        return HardConstraintResult(True)
+
+    result = proposal(
+        [
+            AllocationStaff(1, "Under target", 2000),
+            AllocationStaff(2, "Available", 1000),
+        ],
+        hard=on_leave,
+    )
+
+    assert result.proposed_assignments[0].staff_id == 2
+
+
+def test_existing_hard_locked_assignment_is_retained_and_covers_need():
+    locked = ExistingAllocation(10, 1, DAY, 4, "N", "HARD_LOCKED")
+
+    result = proposal([AllocationStaff(1, "Alex", 1200)], existing=[locked])
+
+    assert result.status == ProposalStatus.FEASIBLE
+    assert result.proposed_assignments == ()
+    assert result.retained_assignments == (locked,)
+
+
+def test_one_duty_per_day_is_a_hard_constraint():
+    existing = ExistingAllocation(10, 1, DAY, 2, "M")
+
+    result = proposal([AllocationStaff(1, "Alex", 1200)], existing=[existing])
+
+    assert result.status == ProposalStatus.INFEASIBLE
+    assert "ONE_DUTY_PER_DAY" in result.uncovered_shifts[0].reason_codes
+
+
+def test_avoids_overtime_when_another_legal_person_exists():
+    result = proposal([
+        AllocationStaff(1, "At target", 600, actual_minutes=600),
+        AllocationStaff(2, "Below target", 1200, actual_minutes=0),
+    ])
+
+    assert result.proposed_assignments[0].staff_id == 2
+
+
+def test_selects_fairer_night_candidate_when_other_costs_equal():
+    result = proposal([
+        AllocationStaff(1, "More nights", 1200, night_count=3, target_night_count=2),
+        AllocationStaff(2, "Fewer nights", 1200, night_count=0, target_night_count=2),
+    ])
+
+    assert result.proposed_assignments[0].staff_id == 2
+
+
+def test_soft_preference_penalty_selects_non_breaching_candidate():
+    def preferences(staff_id, _day, _shift_id):
+        if staff_id == 1:
+            return SoftConstraintResult(
+                penalty=5,
+                reason_codes=("SOFT_AVOID_NIGHT",),
+                explanations=("Employee prefers to avoid night duties.",),
+            )
+        return SoftConstraintResult()
+
+    result = proposal(
+        [AllocationStaff(1, "Avoids nights", 1200), AllocationStaff(2, "Alex", 1200)],
+        soft=preferences,
+    )
+
+    assert result.proposed_assignments[0].staff_id == 2
+
+
+def test_reports_structured_reasons_when_no_legal_candidate_exists():
+    def blocked(_staff_id, _day, _shift_id):
+        return HardConstraintResult(False, "MEDICAL_EXPIRED", "Medical is expired.")
+
+    result = proposal([AllocationStaff(1, "Alex", 1200)], hard=blocked)
+
+    assert result.status == ProposalStatus.INFEASIBLE
+    assert result.uncovered_shifts[0].reason_codes == ("MEDICAL_EXPIRED",)
+    assert result.uncovered_shifts[0].missing_count == 1
+
+
+def test_deterministic_tie_break_uses_staff_id():
+    people = [AllocationStaff(2, "Blair", 1200), AllocationStaff(1, "Alex", 1200)]
+
+    first = proposal(people)
+    second = proposal(people)
+
+    assert first.proposed_assignments[0].staff_id == 1
+    assert first.proposed_assignments == second.proposed_assignments
+
+
+def test_initial_service_refuses_regeneration_of_existing_assignments():
+    with pytest.raises(ValueError, match="preserve_existing=True"):
+        proposal(
+            [AllocationStaff(1, "Alex", 1200)],
+            existing=[ExistingAllocation(10, 1, DAY, 4, "N")],
+            preserve_existing=False,
+        )


### PR DESCRIPTION
## Summary
- add a deterministic, read-only gap-filling proposal service
- enforce hard constraints before configurable fairness and preference priorities
- retain all existing and locked assignments and report structured uncovered reasons
- document the Stage 11/12 boundary and future CP-SAT replacement path

## Verification
- 23 focused pattern, validation, fairness and allocation tests passed
- 5 roster/report blueprint tests passed
- Ruff and Python compilation passed
- broad route suite reached 39 passing tests before an existing duplicate-local-migration scan stalled; no assertion failed