### PR TITLE
Add roster allocation proposal review workflow

### DIFF
--- a/app.py
+++ b/app.py
@@ -1415,6 +1415,8 @@ WorkPatternDayAllowedShift = SaaS.WorkPatternDayAllowedShift
 StaffPatternAssignment = SaaS.StaffPatternAssignment
 StaffRule = SaaS.StaffRule
 BankHoliday = SaaS.BankHoliday
+RosterProposal = SaaS.RosterProposal
+RosterProposalAssignment = SaaS.RosterProposalAssignment
 RosterRuleVersion = SaaS.RosterRuleVersion
 MfaCredential = SaaS.MfaCredential
 
@@ -2654,6 +2656,50 @@ def would_trigger_fatigue(staff: Staff, day: date, code: str):
         segs, observation_start=datetime.combine(start_lb, time.min)
     )
     return flags.get(day, [])
+
+
+def would_trigger_fatigue_with_plan(
+    staff: Staff,
+    day: date,
+    code: str,
+    proposed_codes: dict[date, str],
+):
+    """Evaluate a candidate together with earlier in-memory proposal duties."""
+    shift = get_shift(code, staff.unit_id)
+    if not _is_working(shift):
+        return []
+    start_day = min([day, *proposed_codes], default=day) - timedelta(days=30)
+    end_day = max([day, *proposed_codes], default=day)
+    segments = _segments_for_staff(staff, start_day, end_day)
+    definitions = _fatigue_rule_config(staff.unit_id)["definitions"]
+    for proposed_day, proposed_code in {**proposed_codes, day: code}.items():
+        proposed_shift = get_shift(proposed_code, staff.unit_id)
+        start_dt, end_dt = _span(proposed_day, proposed_shift)
+        if not start_dt:
+            continue
+        early, pre0600 = _is_early_start(start_dt, definitions)
+        segments.append({
+            "day": proposed_day,
+            "start": start_dt,
+            "end": end_dt,
+            "mins": int((end_dt - start_dt).total_seconds() // 60),
+            "night": _is_night_duty(start_dt, end_dt, definitions),
+            "early": early,
+            "early_pre0600": pre0600,
+            "morning": _is_morning_duty(start_dt),
+        })
+    segments.sort(key=lambda item: item["start"])
+    config = _fatigue_rule_config(staff.unit_id)
+    findings = _analyze_segments(
+        segments,
+        config,
+        observation_start=datetime.combine(start_day, time.min),
+    )
+    for finding_day, messages in _custom_fatigue_flags(
+        segments, config["custom"]
+    ).items():
+        findings.setdefault(finding_day, []).extend(messages)
+    return findings.get(day, [])
 
 
 def _year_month_iter(start_date: date, end_date: date):
@@ -8973,6 +9019,9 @@ from work_pattern_blueprint import (
 from roster_validation_service import (
     RosterValidationDependencies, RosterValidationService,
 )
+from roster_proposal_service import (
+    RosterProposalDependencies, RosterProposalService,
+)
 from work_pattern_migration_service import (
     WorkPatternMigrationDependencies, WorkPatternMigrationService,
 )
@@ -9012,6 +9061,29 @@ roster_validation_service = RosterValidationService(
         StaffPatternAssignment=StaffPatternAssignment,
         StaffRule=StaffRule,
         work_pattern_service=work_pattern_service,
+    )
+)
+roster_proposal_service = RosterProposalService(
+    RosterProposalDependencies(
+        db=db,
+        Staff=Staff,
+        ShiftType=ShiftType,
+        Assignment=Assignment,
+        Sickness=Sickness,
+        Requirement=Requirement,
+        SpecialRequirement=SpecialRequirement,
+        RosterProposal=RosterProposal,
+        RosterProposalAssignment=RosterProposalAssignment,
+        ChangeLog=ChangeLog,
+        work_pattern_service=work_pattern_service,
+        requirements_for_day=requirements_for_day,
+        shift_group_for_day=shift_counter_group_for_day,
+        shift_minutes=shift_duration_minutes,
+        staff_is_countable_on=staff_is_countable_on,
+        staff_has_qualification=_staff_has_shift_qualification,
+        would_trigger_fatigue=would_trigger_fatigue_with_plan,
+        compute_fairness_range=_compute_fairness_range,
+        utcnow=utcnow,
     )
 )
 work_pattern_migration_service = WorkPatternMigrationService(
@@ -9152,6 +9224,9 @@ app.register_blueprint(create_roster_blueprint(RosterDependencies(
     watch_ids_for_staff_on=watch_ids_for_staff_on,
     roster_fatigue_flags=roster_fatigue_flags_for_range,
     roster_validation=roster_validation_service,
+    RosterProposal=RosterProposal,
+    RosterProposalAssignment=RosterProposalAssignment,
+    roster_proposal_service=roster_proposal_service,
     get_annotation_groups=get_annotation_groups,
     lock_roster_month=_lock_roster_month,
 )))

--- a/docs/flexible_roster_design.md
+++ b/docs/flexible_roster_design.md
@@ -131,3 +131,22 @@ This stage deliberately has no apply operation. Stage 13 will persist proposals,
 let authorised planners accept or reject each proposed duty, and audit every
 accepted change. A CP-SAT strategy can later replace this strategy behind the
 same proposal result types without changing that review workflow.
+
+## Proposal review workflow (Stage 13)
+
+Authorised roster editors open **Allocation proposals** from the monthly roster.
+They select an inclusive date range of up to 93 days, a fairness lookback and
+whether overtime may be considered. Generation persists a tenant-scoped draft
+and its proposed duties but does not alter `Assignment` rows.
+
+Each duty retains structured explanations and can be accepted or rejected
+individually. Applying a draft inserts accepted duties in one transaction and
+adds an audit row for each insertion. Every target staff/date cell is locked and
+rechecked first; if another editor has populated a cell since generation, the
+whole apply operation is rolled back and the planner must regenerate. Discarding
+a draft records who discarded it and leaves the roster untouched.
+
+The generator composes active patterns, dated hard and soft staff rules,
+approved leave, sickness, current medical/endorsement and shift qualification,
+existing duties, staffing requirements and fatigue rules. Earlier suggestions
+in the same proposal are included when later fatigue candidates are evaluated.

--- a/migrations/versions/20260803_40_roster_proposals.py
+++ b/migrations/versions/20260803_40_roster_proposals.py
@@ -1,0 +1,82 @@
+"""Add reviewable automatic roster proposals.
+
+Revision ID: 20260803_40
+Revises: 20260803_39
+"""
+import os
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260803_40"
+down_revision = "20260803_39"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
+    tables = set(sa.inspect(op.get_bind()).get_table_names())
+    if "staff" not in tables:
+        return
+    if "roster_proposal" not in tables:
+        op.create_table(
+            "roster_proposal",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("unit_id", sa.Integer(), nullable=False),
+            sa.Column("start_date", sa.Date(), nullable=False),
+            sa.Column("end_date", sa.Date(), nullable=False),
+            sa.Column("status", sa.String(32), nullable=False),
+            sa.Column("workflow_state", sa.String(20), nullable=False, server_default="draft"),
+            sa.Column("objective_score", sa.BigInteger(), nullable=False, server_default="0"),
+            sa.Column("configuration_json", sa.Text(), nullable=False, server_default="{}"),
+            sa.Column("warnings_json", sa.Text(), nullable=False, server_default="[]"),
+            sa.Column("uncovered_json", sa.Text(), nullable=False, server_default="[]"),
+            sa.Column("created_by_user_id", sa.Integer(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+            sa.Column("applied_by_user_id", sa.Integer()),
+            sa.Column("applied_at", sa.DateTime()),
+            sa.Column("discarded_by_user_id", sa.Integer()),
+            sa.Column("discarded_at", sa.DateTime()),
+            sa.CheckConstraint("end_date >= start_date", name="ck_roster_proposal_date_range"),
+            sa.CheckConstraint("workflow_state IN ('draft','applied','discarded')", name="ck_roster_proposal_workflow_state"),
+            sa.UniqueConstraint("unit_id", "id", name="uq_roster_proposal_unit_id"),
+        )
+        op.create_index("ix_roster_proposal_unit_id", "roster_proposal", ["unit_id"])
+        op.create_index("ix_roster_proposal_start_date", "roster_proposal", ["start_date"])
+        op.create_index("ix_roster_proposal_end_date", "roster_proposal", ["end_date"])
+    if "roster_proposal_assignment" not in tables:
+        op.create_table(
+            "roster_proposal_assignment",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("unit_id", sa.Integer(), nullable=False),
+            sa.Column("proposal_id", sa.Integer(), nullable=False),
+            sa.Column("staff_id", sa.Integer(), nullable=False),
+            sa.Column("day", sa.Date(), nullable=False),
+            sa.Column("shift_type_id", sa.Integer(), nullable=False),
+            sa.Column("shift_code", sa.String(10), nullable=False),
+            sa.Column("review_state", sa.String(20), nullable=False, server_default="pending"),
+            sa.Column("score", sa.BigInteger(), nullable=False, server_default="0"),
+            sa.Column("explanations_json", sa.Text(), nullable=False, server_default="[]"),
+            sa.Column("applied_assignment_id", sa.Integer()),
+            sa.Column("reviewed_by_user_id", sa.Integer()),
+            sa.Column("reviewed_at", sa.DateTime()),
+            sa.ForeignKeyConstraint(["unit_id", "proposal_id"], ["roster_proposal.unit_id", "roster_proposal.id"], name="fk_proposal_assignment_proposal_unit", ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["unit_id", "staff_id"], ["staff.unit_id", "staff.id"], name="fk_proposal_assignment_staff_unit"),
+            sa.ForeignKeyConstraint(["unit_id", "shift_type_id"], ["shift_type.unit_id", "shift_type.id"], name="fk_proposal_assignment_shift_unit"),
+            sa.CheckConstraint("review_state IN ('pending','accepted','rejected','applied')", name="ck_proposal_assignment_review_state"),
+            sa.UniqueConstraint("unit_id", "proposal_id", "staff_id", "day", name="uq_proposal_assignment_staff_day"),
+        )
+        for column in ("unit_id", "proposal_id", "staff_id", "day"):
+            op.create_index(f"ix_roster_proposal_assignment_{column}", "roster_proposal_assignment", [column])
+
+
+def downgrade() -> None:
+    if os.environ.get("ATCROSTER_SCHEMA_ROLE") == "control":
+        return
+    tables = set(sa.inspect(op.get_bind()).get_table_names())
+    if "roster_proposal_assignment" in tables:
+        op.drop_table("roster_proposal_assignment")
+    if "roster_proposal" in tables:
+        op.drop_table("roster_proposal")

--- a/roster_allocation_service.py
+++ b/roster_allocation_service.py
@@ -124,6 +124,7 @@ class RosterProposal:
 
 HardConstraint = Callable[[int, date, int], HardConstraintResult]
 SoftConstraint = Callable[[int, date, int], SoftConstraintResult]
+SelectionCallback = Callable[[int, date, int], None]
 
 
 def generate_roster_proposal(
@@ -136,6 +137,7 @@ def generate_roster_proposal(
     existing_assignments: Iterable[ExistingAllocation] = (),
     hard_constraint: HardConstraint,
     soft_constraint: SoftConstraint | None = None,
+    on_assignment_selected: SelectionCallback | None = None,
     staff_ids: Iterable[int] | None = None,
     shift_type_ids: Iterable[int] | None = None,
     preserve_existing: bool = True,
@@ -276,6 +278,8 @@ def generate_roster_proposal(
             actual_minutes[staff_id] += shift.minutes
             night_counts[staff_id] += int(shift.is_night)
             weekend_counts[staff_id] += int(need.day.weekday() >= 5)
+            if on_assignment_selected is not None:
+                on_assignment_selected(staff_id, need.day, shift.shift_type_id)
             objective += score
             missing -= 1
         if missing:

--- a/roster_blueprint.py
+++ b/roster_blueprint.py
@@ -76,6 +76,9 @@ class RosterDependencies:
     roster_validation: Any
     get_annotation_groups: Callable[[], list]
     lock_roster_month: Callable[[int, int, int], Any]
+    RosterProposal: Any = None
+    RosterProposalAssignment: Any = None
+    roster_proposal_service: Any = None
 
 
 def create_roster_blueprint(dependencies: RosterDependencies) -> Blueprint:
@@ -84,6 +87,123 @@ def create_roster_blueprint(dependencies: RosterDependencies) -> Blueprint:
     def annotation_is_soal(value: str | None) -> bool:
         parsed = dependencies.parse_annotation((value or "").strip().upper())
         return bool(parsed and parsed.get("type") == "SOAL")
+
+    def _proposal_or_404(proposal_id: int):
+        return dependencies.RosterProposal.query.filter_by(
+            id=proposal_id, unit_id=dependencies.current_unit_id()
+        ).first_or_404()
+
+    @login_required
+    def roster_proposals():
+        if not dependencies.can_edit_roster(current_user):
+            abort(403)
+        unit_id = dependencies.current_unit_id()
+        if request.method == "POST":
+            dependencies.validate_csrf()
+            try:
+                start_date = date.fromisoformat(request.form.get("start_date") or "")
+                end_date = date.fromisoformat(request.form.get("end_date") or "")
+                lookback = max(1, min(730, int(
+                    request.form.get("fairness_lookback_days") or 180
+                )))
+                proposal = dependencies.roster_proposal_service.generate(
+                    unit_id,
+                    start_date,
+                    end_date,
+                    current_user.id,
+                    allow_overtime=request.form.get("allow_overtime") == "1",
+                    fairness_lookback_days=lookback,
+                )
+            except (TypeError, ValueError) as exc:
+                flash(str(exc) or "Choose valid proposal dates.", "error")
+            else:
+                flash("Automatic allocation proposal generated for review.", "ok")
+                return redirect(url_for("roster_proposal_detail", proposal_id=proposal.id))
+        rows = dependencies.RosterProposal.query.filter_by(
+            unit_id=unit_id
+        ).order_by(dependencies.RosterProposal.created_at.desc()).limit(50).all()
+        return render_template(
+            "roster_proposals.html", proposals=rows, today=date.today()
+        )
+
+    @login_required
+    def roster_proposal_detail(proposal_id: int):
+        if not dependencies.can_edit_roster(current_user):
+            abort(403)
+        proposal = _proposal_or_404(proposal_id)
+        items = dependencies.RosterProposalAssignment.query.filter_by(
+            unit_id=proposal.unit_id, proposal_id=proposal.id
+        ).order_by(
+            dependencies.RosterProposalAssignment.day,
+            dependencies.RosterProposalAssignment.shift_code,
+        ).all()
+        staff = {
+            row.id: row for row in dependencies.Staff.query.filter(
+                dependencies.Staff.unit_id == proposal.unit_id,
+                dependencies.Staff.id.in_([item.staff_id for item in items] or [0]),
+            ).all()
+        }
+        uncovered = json.loads(proposal.uncovered_json or "[]")
+        return render_template(
+            "roster_proposal_detail.html",
+            proposal=proposal,
+            items=items,
+            staff_by_id=staff,
+            uncovered=uncovered,
+            json_loads=json.loads,
+        )
+
+    @login_required
+    def roster_proposal_review(proposal_id: int, item_id: int):
+        if not dependencies.can_edit_roster(current_user):
+            abort(403)
+        dependencies.validate_csrf()
+        proposal = _proposal_or_404(proposal_id)
+        if proposal.workflow_state != "draft":
+            abort(409, "This proposal is no longer open for review.")
+        item = dependencies.RosterProposalAssignment.query.filter_by(
+            id=item_id, proposal_id=proposal.id, unit_id=proposal.unit_id
+        ).first_or_404()
+        state = request.form.get("review_state") or ""
+        if state not in {"accepted", "rejected", "pending"}:
+            abort(400)
+        item.review_state = state
+        item.reviewed_by_user_id = current_user.id
+        item.reviewed_at = dependencies.utcnow()
+        dependencies.db.session.commit()
+        return redirect(url_for("roster_proposal_detail", proposal_id=proposal.id))
+
+    @login_required
+    def roster_proposal_apply(proposal_id: int):
+        if not dependencies.can_edit_roster(current_user):
+            abort(403)
+        dependencies.validate_csrf()
+        proposal = _proposal_or_404(proposal_id)
+        try:
+            applied = dependencies.roster_proposal_service.apply(
+                proposal, current_user.id
+            )
+        except ValueError as exc:
+            dependencies.db.session.rollback()
+            flash(str(exc), "error")
+        else:
+            flash(f"Applied {applied} accepted proposed duties.", "ok")
+        return redirect(url_for("roster_proposal_detail", proposal_id=proposal.id))
+
+    @login_required
+    def roster_proposal_discard(proposal_id: int):
+        if not dependencies.can_edit_roster(current_user):
+            abort(403)
+        dependencies.validate_csrf()
+        proposal = _proposal_or_404(proposal_id)
+        if proposal.workflow_state != "draft":
+            abort(409)
+        proposal.workflow_state = "discarded"
+        proposal.discarded_by_user_id = current_user.id
+        proposal.discarded_at = dependencies.utcnow()
+        dependencies.db.session.commit()
+        flash("Proposal discarded; the live roster was not changed.", "ok")
+        return redirect(url_for("roster_proposal_detail", proposal_id=proposal.id))
 
     @login_required
     def roster_month_publish(ym):
@@ -951,6 +1071,11 @@ def create_roster_blueprint(dependencies: RosterDependencies) -> Blueprint:
             ),
             ("/roster/<ym>/export", "roster_export_csv", roster_export_csv, ["GET"]),
             ("/roster/<ym>/print", "roster_print_view", roster_print_view, ["GET"]),
+            ("/roster/proposals", "roster_proposals", roster_proposals, ["GET", "POST"]),
+            ("/roster/proposals/<int:proposal_id>", "roster_proposal_detail", roster_proposal_detail, ["GET"]),
+            ("/roster/proposals/<int:proposal_id>/items/<int:item_id>", "roster_proposal_review", roster_proposal_review, ["POST"]),
+            ("/roster/proposals/<int:proposal_id>/apply", "roster_proposal_apply", roster_proposal_apply, ["POST"]),
+            ("/roster/proposals/<int:proposal_id>/discard", "roster_proposal_discard", roster_proposal_discard, ["POST"]),
         )
         for rule, endpoint, view_func, methods in routes:
             state.app.add_url_rule(

--- a/roster_proposal_service.py
+++ b/roster_proposal_service.py
@@ -1,0 +1,341 @@
+"""Database adapter and review workflow for automatic roster proposals."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import date, timedelta
+from typing import Any, Callable
+
+from roster_allocation_service import (
+    AllocationShift,
+    AllocationStaff,
+    ExistingAllocation,
+    HardConstraintResult,
+    SoftConstraintResult,
+    StaffingNeed,
+    generate_roster_proposal,
+)
+
+
+@dataclass(frozen=True)
+class RosterProposalDependencies:
+    db: Any
+    Staff: Any
+    ShiftType: Any
+    Assignment: Any
+    Sickness: Any
+    Requirement: Any
+    SpecialRequirement: Any
+    RosterProposal: Any
+    RosterProposalAssignment: Any
+    ChangeLog: Any
+    work_pattern_service: Any
+    requirements_for_day: Callable[..., dict[str, int]]
+    shift_group_for_day: Callable[[str, date, int], str | None]
+    shift_minutes: Callable[[Any], int]
+    staff_is_countable_on: Callable[[Any, date], bool]
+    staff_has_qualification: Callable[[Any, Any, date], bool]
+    would_trigger_fatigue: Callable[[Any, date, str, dict[date, str]], list[str]]
+    compute_fairness_range: Callable[[date, date], list[Any]]
+    utcnow: Callable[[], Any]
+
+
+class RosterProposalService:
+    def __init__(self, dependencies: RosterProposalDependencies) -> None:
+        self.dependencies = dependencies
+
+    def generate(
+        self,
+        unit_id: int,
+        start_date: date,
+        end_date: date,
+        actor_id: int,
+        *,
+        allow_overtime: bool = False,
+        fairness_lookback_days: int = 180,
+        max_solve_seconds: float = 30,
+    ) -> Any:
+        if end_date < start_date or (end_date - start_date).days > 92:
+            raise ValueError("Choose a proposal period between 1 and 93 days.")
+        staff_rows = self.dependencies.Staff.query.filter_by(
+            unit_id=unit_id, is_operational=True, membership_status="active"
+        ).filter(self.dependencies.Staff.role != "position_monitor").order_by(
+            self.dependencies.Staff.id
+        ).all()
+        shift_rows = self.dependencies.ShiftType.query.filter_by(
+            unit_id=unit_id, is_active=True, is_working=True
+        ).order_by(self.dependencies.ShiftType.id).all()
+        shift_by_code = {(row.code or "").upper(): row for row in shift_rows}
+        shift_by_id = {row.id: row for row in shift_rows}
+        days = [
+            start_date + timedelta(days=offset)
+            for offset in range((end_date - start_date).days + 1)
+        ]
+        requirements = {
+            (row.year, row.month): row
+            for row in self.dependencies.Requirement.query.filter(
+                self.dependencies.Requirement.unit_id == unit_id
+            ).all()
+        }
+        specials = {
+            row.day: row for row in self.dependencies.SpecialRequirement.query.filter(
+                self.dependencies.SpecialRequirement.unit_id == unit_id,
+                self.dependencies.SpecialRequirement.day >= start_date,
+                self.dependencies.SpecialRequirement.day <= end_date,
+            ).all()
+        }
+        canonical_shift: dict[tuple[date, str], Any] = {}
+        for day in days:
+            for shift in shift_rows:
+                group = self.dependencies.shift_group_for_day(
+                    shift.code, day, unit_id
+                )
+                if group and (
+                    (day, group) not in canonical_shift
+                    or shift.code.upper() == group
+                ):
+                    canonical_shift[(day, group)] = shift
+        needs = []
+        for day in days:
+            requirement = requirements.get((day.year, day.month))
+            counts = self.dependencies.requirements_for_day(
+                requirement, day, specials.get(day)
+            )
+            for group, required_count in counts.items():
+                shift = canonical_shift.get((day, group))
+                if shift and required_count:
+                    needs.append(StaffingNeed(day, shift.id, required_count))
+
+        assignment_rows = self.dependencies.Assignment.query.filter(
+            self.dependencies.Assignment.unit_id == unit_id,
+            self.dependencies.Assignment.day >= start_date,
+            self.dependencies.Assignment.day <= end_date,
+        ).all()
+        existing = []
+        for row in assignment_rows:
+            shift = shift_by_code.get((row.code or "").upper())
+            group = (
+                self.dependencies.shift_group_for_day(row.code, row.day, unit_id)
+                if shift else None
+            )
+            coverage_shift = canonical_shift.get((row.day, group)) if group else None
+            existing.append(ExistingAllocation(
+                assignment_id=row.id,
+                staff_id=row.staff_id,
+                day=row.day,
+                shift_type_id=coverage_shift.id if coverage_shift else 0,
+                shift_code=row.code,
+                lock_status=row.lock_status or "UNLOCKED",
+            ))
+        lookback_start = start_date - timedelta(days=fairness_lookback_days)
+        fairness = {
+            row.staff_id: row
+            for row in self.dependencies.compute_fairness_range(
+                lookback_start, end_date
+            )
+        }
+        people = [
+            AllocationStaff(
+                staff_id=row.id,
+                name=row.name,
+                target_minutes=max(
+                    int(getattr(fairness.get(row.id), "target_minutes", 0)),
+                    int(getattr(fairness.get(row.id), "actual_minutes", 0)),
+                ),
+                actual_minutes=int(
+                    getattr(fairness.get(row.id), "actual_minutes", 0)
+                ),
+                night_count=int(getattr(fairness.get(row.id), "night_count", 0)),
+                target_night_count=float(
+                    getattr(fairness.get(row.id), "target_night_count", 0)
+                ),
+                weekend_count=int(
+                    getattr(fairness.get(row.id), "weekend_count", 0)
+                ),
+                target_weekend_count=float(
+                    getattr(fairness.get(row.id), "target_weekend_count", 0)
+                ),
+            )
+            for row in staff_rows
+        ]
+        allocation_shifts = [
+            AllocationShift(
+                shift.id,
+                shift.code,
+                self.dependencies.shift_minutes(shift),
+                any(
+                    self.dependencies.shift_group_for_day(
+                        shift.code, day, unit_id
+                    ) == "N"
+                    for day in days
+                ),
+            )
+            for shift in shift_rows
+        ]
+        staff_by_id = {row.id: row for row in staff_rows}
+        sickness = self.dependencies.Sickness.query.filter(
+            self.dependencies.Sickness.unit_id == unit_id,
+            self.dependencies.Sickness.start <= end_date,
+            self.dependencies.Sickness.end >= start_date,
+        ).all()
+        eligibility_context = (
+            self.dependencies.work_pattern_service.build_eligibility_context(
+                unit_id, list(staff_by_id), start_date, end_date
+            )
+        )
+        planned_codes: dict[int, dict[date, str]] = {
+            staff_id: {} for staff_id in staff_by_id
+        }
+
+        def hard_constraint(staff_id: int, day: date, shift_id: int):
+            person = staff_by_id[staff_id]
+            shift = shift_by_id[shift_id]
+            if any(
+                row.staff_id == staff_id and row.start <= day <= row.end
+                for row in sickness
+            ):
+                return HardConstraintResult(
+                    False, "SICKNESS", "Employee is recorded sick on this date."
+                )
+            if not self.dependencies.staff_is_countable_on(person, day):
+                return HardConstraintResult(
+                    False, "MEDICAL_OR_ENDORSEMENT_INVALID",
+                    "Employee does not have the required current medical and endorsement.",
+                )
+            if shift.required_qualification and not (
+                self.dependencies.staff_has_qualification(person, shift, day)
+            ):
+                return HardConstraintResult(
+                    False, "QUALIFICATION_INVALID",
+                    "Employee does not hold the qualification required for this shift.",
+                )
+            eligibility = (
+                self.dependencies.work_pattern_service.is_staff_eligible_for_shift(
+                    staff_id, day, shift_id, context=eligibility_context
+                )
+            )
+            if not eligibility.eligible:
+                return HardConstraintResult(
+                    False, eligibility.reason_code, eligibility.explanation
+                )
+            fatigue = self.dependencies.would_trigger_fatigue(
+                person, day, shift.code, planned_codes[staff_id]
+            )
+            if fatigue:
+                return HardConstraintResult(
+                    False, "FATIGUE_RULE", "; ".join(fatigue)
+                )
+            return HardConstraintResult(True)
+
+        def soft_constraint(staff_id: int, day: date, shift_id: int):
+            result = self.dependencies.work_pattern_service.is_staff_eligible_for_shift(
+                staff_id, day, shift_id, context=eligibility_context
+            )
+            reasons = tuple(
+                reason for reason in result.reasons if reason.code.startswith("SOFT_")
+            )
+            return SoftConstraintResult(
+                penalty=result.soft_penalty,
+                reason_codes=tuple(reason.code for reason in reasons),
+                explanations=tuple(reason.explanation for reason in reasons),
+            )
+
+        result = generate_roster_proposal(
+            start_date,
+            end_date,
+            staff=people,
+            shifts=allocation_shifts,
+            staffing_needs=needs,
+            existing_assignments=existing,
+            hard_constraint=hard_constraint,
+            soft_constraint=soft_constraint,
+            on_assignment_selected=lambda staff_id, day, shift_id: (
+                planned_codes[staff_id].__setitem__(day, shift_by_id[shift_id].code)
+            ),
+            allow_overtime=allow_overtime,
+            fairness_lookback_days=fairness_lookback_days,
+            max_solve_seconds=max_solve_seconds,
+        )
+        proposal = self.dependencies.RosterProposal(
+            unit_id=unit_id,
+            start_date=start_date,
+            end_date=end_date,
+            status=result.status.value,
+            objective_score=result.objective_score,
+            configuration_json=json.dumps(
+                {
+                    key: asdict(value) if hasattr(value, "__dataclass_fields__") else value
+                    for key, value in result.configuration.items()
+                }, default=str,
+            ),
+            warnings_json=json.dumps(result.warnings),
+            uncovered_json=json.dumps(
+                [asdict(row) for row in result.uncovered_shifts], default=str
+            ),
+            created_by_user_id=actor_id,
+        )
+        self.dependencies.db.session.add(proposal)
+        self.dependencies.db.session.flush()
+        for row in result.proposed_assignments:
+            self.dependencies.db.session.add(
+                self.dependencies.RosterProposalAssignment(
+                    unit_id=unit_id,
+                    proposal_id=proposal.id,
+                    staff_id=row.staff_id,
+                    day=row.day,
+                    shift_type_id=row.shift_type_id,
+                    shift_code=row.shift_code,
+                    score=row.score,
+                    explanations_json=json.dumps(row.explanations),
+                )
+            )
+        self.dependencies.db.session.commit()
+        return proposal
+
+    def apply(self, proposal: Any, actor_id: int) -> int:
+        if proposal.workflow_state != "draft":
+            raise ValueError("Only a draft proposal can be applied.")
+        rows = self.dependencies.RosterProposalAssignment.query.filter_by(
+            unit_id=proposal.unit_id,
+            proposal_id=proposal.id,
+            review_state="accepted",
+        ).order_by(self.dependencies.RosterProposalAssignment.id).all()
+        applied = 0
+        for row in rows:
+            existing = self.dependencies.Assignment.query.filter_by(
+                unit_id=proposal.unit_id, staff_id=row.staff_id, day=row.day
+            ).with_for_update().first()
+            if existing:
+                raise ValueError(
+                    "The live roster changed after proposal generation; regenerate it."
+                )
+            assignment = self.dependencies.Assignment(
+                unit_id=proposal.unit_id,
+                staff_id=row.staff_id,
+                day=row.day,
+                code=row.shift_code,
+                source="proposal",
+                note=f"Accepted from proposal {proposal.id}",
+            )
+            self.dependencies.db.session.add(assignment)
+            self.dependencies.db.session.flush()
+            row.applied_assignment_id = assignment.id
+            row.review_state = "applied"
+            self.dependencies.db.session.add(self.dependencies.ChangeLog(
+                when=self.dependencies.utcnow(),
+                who_user_id=actor_id,
+                entity_type="Assignment",
+                entity_id=assignment.id,
+                field="code",
+                old_value="",
+                new_value=row.shift_code,
+                context_month=f"{row.day.year:04d}-{row.day.month:02d}",
+                note=f"Accepted from automatic proposal {proposal.id}",
+            ))
+            applied += 1
+        proposal.workflow_state = "applied"
+        proposal.applied_by_user_id = actor_id
+        proposal.applied_at = self.dependencies.utcnow()
+        self.dependencies.db.session.commit()
+        return applied

--- a/saas_models.py
+++ b/saas_models.py
@@ -845,6 +845,77 @@ def register_saas_models(db, utcnow):
             db.UniqueConstraint("unit_id", "day", name="uq_bank_holiday_unit_day"),
         )
 
+    class RosterProposal(db.Model):
+        __tablename__ = "roster_proposal"
+        id = db.Column(db.Integer, primary_key=True)
+        unit_id = db.Column(db.Integer, nullable=False, index=True)
+        start_date = db.Column(db.Date, nullable=False, index=True)
+        end_date = db.Column(db.Date, nullable=False, index=True)
+        status = db.Column(db.String(32), nullable=False)
+        workflow_state = db.Column(db.String(20), nullable=False, default="draft")
+        objective_score = db.Column(db.BigInteger, nullable=False, default=0)
+        configuration_json = db.Column(db.Text, nullable=False, default="{}")
+        warnings_json = db.Column(db.Text, nullable=False, default="[]")
+        uncovered_json = db.Column(db.Text, nullable=False, default="[]")
+        created_by_user_id = db.Column(db.Integer, nullable=False)
+        created_at = db.Column(db.DateTime, nullable=False, default=utcnow)
+        applied_by_user_id = db.Column(db.Integer)
+        applied_at = db.Column(db.DateTime)
+        discarded_by_user_id = db.Column(db.Integer)
+        discarded_at = db.Column(db.DateTime)
+        __table_args__ = (
+            db.CheckConstraint(
+                "end_date >= start_date", name="ck_roster_proposal_date_range"
+            ),
+            db.CheckConstraint(
+                "workflow_state IN ('draft','applied','discarded')",
+                name="ck_roster_proposal_workflow_state",
+            ),
+            db.UniqueConstraint("unit_id", "id", name="uq_roster_proposal_unit_id"),
+        )
+
+    class RosterProposalAssignment(db.Model):
+        __tablename__ = "roster_proposal_assignment"
+        id = db.Column(db.Integer, primary_key=True)
+        unit_id = db.Column(db.Integer, nullable=False, index=True)
+        proposal_id = db.Column(db.Integer, nullable=False, index=True)
+        staff_id = db.Column(db.Integer, nullable=False, index=True)
+        day = db.Column(db.Date, nullable=False, index=True)
+        shift_type_id = db.Column(db.Integer, nullable=False)
+        shift_code = db.Column(db.String(10), nullable=False)
+        review_state = db.Column(db.String(20), nullable=False, default="pending")
+        score = db.Column(db.BigInteger, nullable=False, default=0)
+        explanations_json = db.Column(db.Text, nullable=False, default="[]")
+        applied_assignment_id = db.Column(db.Integer)
+        reviewed_by_user_id = db.Column(db.Integer)
+        reviewed_at = db.Column(db.DateTime)
+        __table_args__ = (
+            db.ForeignKeyConstraint(
+                ["unit_id", "proposal_id"],
+                ["roster_proposal.unit_id", "roster_proposal.id"],
+                name="fk_proposal_assignment_proposal_unit",
+                ondelete="CASCADE",
+            ),
+            db.ForeignKeyConstraint(
+                ["unit_id", "staff_id"],
+                ["staff.unit_id", "staff.id"],
+                name="fk_proposal_assignment_staff_unit",
+            ),
+            db.ForeignKeyConstraint(
+                ["unit_id", "shift_type_id"],
+                ["shift_type.unit_id", "shift_type.id"],
+                name="fk_proposal_assignment_shift_unit",
+            ),
+            db.CheckConstraint(
+                "review_state IN ('pending','accepted','rejected','applied')",
+                name="ck_proposal_assignment_review_state",
+            ),
+            db.UniqueConstraint(
+                "unit_id", "proposal_id", "staff_id", "day",
+                name="uq_proposal_assignment_staff_day",
+            ),
+        )
+
     class RosterRuleVersion(db.Model):
         __tablename__ = "roster_rule_version"
         id = db.Column(db.Integer, primary_key=True)

--- a/templates/roster_month.html
+++ b/templates/roster_month.html
@@ -157,6 +157,9 @@
 
   <a class="btn roster-export-link" href="{{ url_for('roster_export_csv', ym=ym) }}">Export CSV</a>
   <button class="btn" data-command="print-roster">Print</button>
+  {% if can_edit %}
+    <a class="btn" href="{{ url_for('roster_proposals') }}">Allocation proposals</a>
+  {% endif %}
 
   <div class="roster-zoom-controls" role="group" aria-label="Roster zoom">
     <span class="roster-zoom-label">Zoom</span>

--- a/templates/roster_proposal_detail.html
+++ b/templates/roster_proposal_detail.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% block title %}Allocation proposal {{ proposal.id }}{% endblock %}
+{% block content %}
+<div class="page-header">
+  <div><span class="admin-step">Draft allocation</span><h2>Proposal {{ proposal.id }}</h2><p class="muted">{{ proposal.start_date.strftime('%d %b %Y') }} – {{ proposal.end_date.strftime('%d %b %Y') }}</p></div>
+  <a class="btn ghost" href="{{ url_for('roster_proposals') }}">All proposals</a>
+</div>
+<div class="summary-grid">
+  <div class="card"><span class="muted">Solver result</span><strong>{{ proposal.status|replace('_', ' ')|title }}</strong></div>
+  <div class="card"><span class="muted">Workflow</span><strong>{{ proposal.workflow_state|title }}</strong></div>
+  <div class="card"><span class="muted">Objective cost</span><strong>{{ proposal.objective_score }}</strong></div>
+  <div class="card"><span class="muted">Suggestions</span><strong>{{ items|length }}</strong></div>
+</div>
+{% if uncovered %}<section class="card alert-warning"><h3>Uncovered requirements</h3><ul>{% for row in uncovered %}<li>{{ row.day }} · {{ row.shift_code }} · {{ row.missing_count }} missing — {{ row.explanations|join('; ') }}</li>{% endfor %}</ul></section>{% endif %}
+<section class="card">
+  <h3>Proposed duties</h3>
+  {% if items %}<div class="table-scroll"><table><thead><tr><th>Date</th><th>Staff</th><th>Shift</th><th>Why</th><th>Review</th></tr></thead><tbody>
+  {% for item in items %}<tr>
+    <td>{{ item.day.strftime('%a %d %b %Y') }}</td><td>{{ staff_by_id[item.staff_id].name }}</td><td><strong>{{ item.shift_code }}</strong></td>
+    <td><details><summary>Explanation</summary><ul>{% for reason in json_loads(item.explanations_json) %}<li>{{ reason }}</li>{% endfor %}</ul></details></td>
+    <td>{% if proposal.workflow_state == 'draft' %}<form method="post" action="{{ url_for('roster_proposal_review', proposal_id=proposal.id, item_id=item.id) }}" class="inline-actions"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn btn-sm{% if item.review_state == 'accepted' %} btn-primary{% endif %}" name="review_state" value="accepted">Accept</button><button class="btn btn-sm{% if item.review_state == 'rejected' %} danger{% endif %}" name="review_state" value="rejected">Reject</button></form>{% else %}{{ item.review_state|title }}{% endif %}</td>
+  </tr>{% endfor %}</tbody></table></div>{% else %}<p class="muted">No new assignments were proposed.</p>{% endif %}
+</section>
+{% if proposal.workflow_state == 'draft' %}<section class="card"><div class="inline-actions">
+  <form method="post" action="{{ url_for('roster_proposal_apply', proposal_id=proposal.id) }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn btn-primary" type="submit">Apply accepted duties</button></form>
+  <form method="post" action="{{ url_for('roster_proposal_discard', proposal_id=proposal.id) }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn danger" type="submit">Discard proposal</button></form>
+</div><p class="muted">Applying rechecks that every roster cell is still blank. Any intervening roster change stops the operation.</p></section>{% endif %}
+{% endblock %}

--- a/templates/roster_proposals.html
+++ b/templates/roster_proposals.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block title %}Allocation proposals{% endblock %}
+{% block content %}
+<div class="page-header">
+  <div><span class="admin-step">Roster planning</span><h2>Automatic allocation proposals</h2></div>
+  <a class="btn ghost" href="{{ url_for('roster_month', ym=today.strftime('%Y-%m')) }}">Back to roster</a>
+</div>
+<section class="card">
+  <h3>Generate a gap-filling proposal</h3>
+  <p class="muted">This does not change the live roster. Existing duties are retained and every suggestion must be reviewed.</p>
+  <form method="post" class="form-grid">
+    <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+    <label>Start date<input type="date" name="start_date" required></label>
+    <label>End date<input type="date" name="end_date" required></label>
+    <label>Fairness lookback (days)<input type="number" name="fairness_lookback_days" min="1" max="730" value="180" required></label>
+    <label class="checkbox-row"><input type="checkbox" name="allow_overtime" value="1"> Permit overtime when necessary</label>
+    <div><button class="btn btn-primary" type="submit">Generate proposal</button></div>
+  </form>
+</section>
+<section class="card">
+  <h3>Recent proposals</h3>
+  {% if proposals %}
+    <div class="table-scroll"><table><thead><tr><th>Dates</th><th>Result</th><th>Workflow</th><th>Created</th><th></th></tr></thead><tbody>
+    {% for proposal in proposals %}<tr>
+      <td>{{ proposal.start_date.strftime('%d %b %Y') }} – {{ proposal.end_date.strftime('%d %b %Y') }}</td>
+      <td>{{ proposal.status|replace('_', ' ')|title }}</td><td>{{ proposal.workflow_state|title }}</td>
+      <td>{{ proposal.created_at.strftime('%d %b %Y %H:%M') }}</td>
+      <td><a class="btn btn-sm" href="{{ url_for('roster_proposal_detail', proposal_id=proposal.id) }}">Review</a></td>
+    </tr>{% endfor %}
+    </tbody></table></div>
+  {% else %}<p class="muted">No proposals have been generated.</p>{% endif %}
+</section>
+{% endblock %}

--- a/tests/fixtures/route_map.json
+++ b/tests/fixtures/route_map.json
@@ -747,6 +747,42 @@
     "rule": "/roster/<ym>/unpublish"
   },
   {
+    "endpoint": "roster_proposals",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/roster/proposals"
+  },
+  {
+    "endpoint": "roster_proposal_detail",
+    "methods": [
+      "GET"
+    ],
+    "rule": "/roster/proposals/<int:proposal_id>"
+  },
+  {
+    "endpoint": "roster_proposal_apply",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/roster/proposals/<int:proposal_id>/apply"
+  },
+  {
+    "endpoint": "roster_proposal_discard",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/roster/proposals/<int:proposal_id>/discard"
+  },
+  {
+    "endpoint": "roster_proposal_review",
+    "methods": [
+      "POST"
+    ],
+    "rule": "/roster/proposals/<int:proposal_id>/items/<int:item_id>"
+  },
+  {
     "endpoint": "mfa_setup",
     "methods": [
       "GET",

--- a/tests/test_legacy_migration_fixtures.py
+++ b/tests/test_legacy_migration_fixtures.py
@@ -132,7 +132,7 @@ def test_legacy_fixture_upgrades_to_head_without_data_loss(fixture_name, tmp_pat
             connection.execute(
                 text("SELECT version_num FROM alembic_version")
             ).scalar_one()
-            == "20260803_39"
+            == "20260803_40"
         )
         for table, count in before.items():
             assert (

--- a/tests/test_postgresql_multidatabase.py
+++ b/tests/test_postgresql_multidatabase.py
@@ -97,9 +97,9 @@ def test_postgresql_control_and_two_airport_databases_are_isolated(
     dispose_operational_engines()
     for url in (CONTROL_URL, AIRPORT_A_URL, AIRPORT_B_URL):
         _reset_postgres(url)
-    assert upgrade_database(CONTROL_URL, "control") == "20260803_39"
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_39"
-    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260803_39"
+    assert upgrade_database(CONTROL_URL, "control") == "20260803_40"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_40"
+    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260803_40"
     secret_a = "ATCROSTER_UNIT_1_DATABASE_URL"
     secret_b = "ATCROSTER_UNIT_2_DATABASE_URL"
     monkeypatch.setenv(secret_a, AIRPORT_A_URL)
@@ -281,7 +281,7 @@ def test_postgresql_control_and_two_airport_databases_are_isolated(
 def test_generated_postgresql_backup_restores_and_preserves_key_records(tmp_path):
     _reset_postgres(AIRPORT_A_URL)
     _reset_postgres(RESTORE_URL)
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_39"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_40"
     source = create_engine(AIRPORT_A_URL)
     with source.begin() as connection:
         connection.execute(
@@ -298,7 +298,7 @@ def test_generated_postgresql_backup_restores_and_preserves_key_records(tmp_path
         AIRPORT_A_URL, tmp_path, "airport-test", "operational"
     )
     result = restore_backup(archive, metadata, RESTORE_URL)
-    assert result.alembic_revision == "20260803_39"
+    assert result.alembic_revision == "20260803_40"
     restored = create_engine(RESTORE_URL)
     try:
         with restored.connect() as connection:
@@ -331,7 +331,7 @@ def _insert_staff(connection, unit_id, username):
 
 def test_postgresql_rejects_cross_unit_operational_relationships():
     _reset_postgres(AIRPORT_A_URL)
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_39"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_40"
     engine = create_engine(AIRPORT_A_URL)
     try:
         with engine.begin() as connection:
@@ -381,7 +381,7 @@ def test_tenant_integrity_migration_refuses_inconsistent_legacy_data():
 
 def test_postgresql_concurrent_toil_retry_changes_balance_once(monkeypatch):
     _reset_postgres(AIRPORT_A_URL)
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_39"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_40"
     engine = create_engine(AIRPORT_A_URL)
     with engine.begin() as connection:
         person_id = _insert_staff(connection, 1, "toil-concurrency")
@@ -451,7 +451,7 @@ def test_postgresql_concurrent_toil_retry_changes_balance_once(monkeypatch):
 
 def test_postgresql_runtime_role_cannot_mutate_audit_evidence():
     _reset_postgres(AIRPORT_B_URL)
-    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260803_39"
+    assert upgrade_database(AIRPORT_B_URL, "operational") == "20260803_40"
     role = f"atcroster_runtime_{os.getpid()}"
     password = "runtime-integration-only"
     owner_dsn = str(
@@ -511,7 +511,7 @@ def test_postgresql_runtime_role_cannot_mutate_audit_evidence():
 
 def test_postgresql_two_roster_editors_reject_the_stale_cell_version():
     _reset_postgres(AIRPORT_A_URL)
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_39"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_40"
     engine = create_engine(AIRPORT_A_URL)
     with engine.begin() as connection:
         person_id = _insert_staff(connection, 1, "roster-race")
@@ -562,7 +562,7 @@ def test_postgresql_two_roster_editors_reject_the_stale_cell_version():
 
 def test_postgresql_two_managers_create_one_request_transition_and_side_effects():
     _reset_postgres(AIRPORT_A_URL)
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_39"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_40"
     engine = create_engine(AIRPORT_A_URL)
     with engine.begin() as connection:
         person_id = _insert_staff(connection, 1, "request-race")
@@ -641,7 +641,7 @@ def test_postgresql_two_managers_create_one_request_transition_and_side_effects(
 
 def test_postgresql_publication_and_roster_mutations_share_a_coherent_month_lock():
     _reset_postgres(AIRPORT_A_URL)
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_39"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_40"
     dsn = (
         make_url(AIRPORT_A_URL)
         .set(drivername="postgresql")
@@ -767,7 +767,7 @@ def test_postgresql_live_position_logon_retry_tenant_scope_and_handover_races(
     monkeypatch,
 ):
     _reset_postgres(AIRPORT_A_URL)
-    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_39"
+    assert upgrade_database(AIRPORT_A_URL, "operational") == "20260803_40"
     secret_name = "ATCROSTER_TEST_LIVE_CONCURRENCY_DATABASE_URL"
     monkeypatch.setenv(secret_name, AIRPORT_A_URL)
     dispose_operational_engines()

--- a/tests/test_roster_allocation_service.py
+++ b/tests/test_roster_allocation_service.py
@@ -165,3 +165,32 @@ def test_initial_service_refuses_regeneration_of_existing_assignments():
             existing=[ExistingAllocation(10, 1, DAY, 4, "N")],
             preserve_existing=False,
         )
+
+
+def test_later_candidates_can_validate_earlier_proposed_duties():
+    second_day = date(2026, 9, 2)
+    planned = set()
+
+    def sequence_constraint(staff_id, day, _shift_id):
+        if staff_id == 1 and day == second_day and (1, DAY) in planned:
+            return HardConstraintResult(
+                False, "FATIGUE_RULE", "Proposed sequence breaches fatigue rules."
+            )
+        return HardConstraintResult(True)
+
+    result = generate_roster_proposal(
+        DAY,
+        second_day,
+        staff=[
+            AllocationStaff(1, "Alex", 2400),
+            AllocationStaff(2, "Blair", 2400),
+        ],
+        shifts=[NIGHT],
+        staffing_needs=[StaffingNeed(DAY, 4, 1), StaffingNeed(second_day, 4, 1)],
+        hard_constraint=sequence_constraint,
+        on_assignment_selected=lambda staff_id, day, _shift_id: planned.add(
+            (staff_id, day)
+        ),
+    )
+
+    assert [row.staff_id for row in result.proposed_assignments] == [1, 2]

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -3356,6 +3356,29 @@ def test_flexible_pattern_admin_is_permission_and_tenant_scoped():
     ).status_code == 404
 
 
+def test_allocation_proposals_are_editor_only_and_start_as_drafts():
+    ordinary = app.app.test_client()
+    login_as(ordinary, "staff_test")
+    assert ordinary.get("/roster/proposals").status_code == 403
+
+    editor = app.app.test_client()
+    login_as(editor, "editor_test")
+    page = editor.get("/roster/proposals")
+    assert page.status_code == 200
+    assert b"Generate a gap-filling proposal" in page.data
+    invalid = editor.post(
+        "/roster/proposals",
+        data={
+            "_csrf_token": csrf(editor),
+            "start_date": "2026-10-10",
+            "end_date": "2026-10-01",
+        },
+        follow_redirects=True,
+    )
+    assert invalid.status_code == 200
+    assert b"Choose a proposal period between 1 and 93 days" in invalid.data
+
+
 def test_admin_dry_runs_and_migrates_only_exact_legacy_pattern(client):
     login(client)
     effective_from = date(2025, 1, 1)


### PR DESCRIPTION
## Summary
- persist tenant-scoped automatic allocation proposals and proposed duties
- generate proposals from live requirements, eligibility, medical, qualification, sickness, fatigue and fairness data
- add editor-only review, accept/reject, audited apply and discard workflow
- refuse stale-cell application and never overwrite existing roster duties
- add migration 20260803_40 and roster UI entry point

## Verification
- 24 focused tests passed
- fresh SQLite migration reached 20260803_40 with both proposal tables
- Ruff, Python compilation and route snapshot checks passed