### PR TITLE
Land airport users on module selection

### DIFF
--- a/app.py
+++ b/app.py
@@ -474,19 +474,10 @@ def _canonical_login_redirect(
 
 
 def _airport_login_endpoint(user) -> str:
-    """Land multi-module airport users on the module launcher."""
+    """Land airport users on their appropriate application launcher."""
     if getattr(user, "role", "") == "position_monitor":
         return "live_position.kiosk_hmi"
-    if is_admin_user(user):
-        return "module_home"
-    enabled = FeatureFlag.query.filter(
-        FeatureFlag.unit_id == user.unit_id,
-        FeatureFlag.key.in_((
-            "briefing_module", "training_module", "competency_module"
-        )),
-        FeatureFlag.enabled.is_(True),
-    ).first()
-    return "module_home" if enabled else "index"
+    return "module_home"
 
 
 # ----- Lightweight caching -----
@@ -4484,14 +4475,6 @@ def module_home():
     """Select between subscribed airport modules after authentication."""
     if current_user.role == "superadmin":
         return redirect(url_for("platform_admin"))
-    if not (
-        is_admin_user(current_user)
-        or
-        briefing_enabled(current_user.unit_id)
-        or training_enabled(current_user.unit_id)
-        or competency_enabled(current_user.unit_id)
-    ):
-        return redirect(url_for("index"))
     return render_template(
         "module_home.html",
         show_briefing=briefing_enabled(current_user.unit_id),

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1682,6 +1682,19 @@ def test_module_home_restores_original_launcher_and_admin_card(client):
     assert b">Today</a>" not in resp.data
 
 
+def test_standard_user_login_lands_on_module_selection(client):
+    with app.app.app_context():
+        user = Staff.query.filter_by(username="staff_test").one()
+        assert app._airport_login_endpoint(user) == "module_home"
+
+    login_as(client, "staff_test", follow_redirects=False)
+    launcher = client.get("/modules")
+    assert launcher.status_code == 200
+    assert b"Please select a module" in launcher.data
+    assert b"<strong>Roster</strong>" in launcher.data
+    assert b"<strong>Administration</strong>" not in launcher.data
+
+
 def test_fatigue_segments_use_effective_override_and_airport_shift(client):
     login(client)
     with app.app.app_context():


### PR DESCRIPTION
## What changed

- send every ordinary airport user to the module selection page after authentication
- keep dedicated position-monitor accounts routed directly to the kiosk HMI
- keep platform super-administrators routed to platform administration
- allow staff with only the roster module enabled to use the module launcher
- add regression coverage for a standard staff account

## Why

The roster-only fallback bypassed the module selector for ordinary users. The module selector is now the consistent airport landing page and displays only the modules available to the user and unit.

## Validation

- `ruff check app.py tests/test_routes.py`
- `pytest -q tests/test_routes.py` (122 passed)
